### PR TITLE
Description list instead of div's in admin Dashboard & Configuration.

### DIFF
--- a/public/css/gogs.css
+++ b/public/css/gogs.css
@@ -1234,10 +1234,10 @@ html, body {
 
 /* admin dashboard/configuration */
 
-.dl-horizontal > dt {
+.admin-dl-horizontal > dt {
     width: 320px;
 }
 
-.dl-horizontal > dd {
+.admin-dl-horizontal > dd {
     margin-left: 340px;
 }

--- a/templates/admin/config.tmpl
+++ b/templates/admin/config.tmpl
@@ -9,7 +9,7 @@
             </div>
 
             <div class="panel-body">
-                <dl class="dl-horizontal">
+                <dl class="dl-horizontal admin-dl-horizontal">
                     <dt>Application Name</dt>
                     <dd>{{AppName}}</dd>
                     <dt>Application Version</dt>
@@ -36,7 +36,7 @@
             </div>
 
             <div class="panel-body">
-                <dl class="dl-horizontal">
+                <dl class="dl-horizontal admin-dl-horizontal">
                     <dt>Type</dt>
                     <dd>{{.DbCfg.Type}}</dd>
                     <dt>Host</dt>
@@ -59,7 +59,7 @@
             </div>
 
             <div class="panel-body">
-                <dl class="dl-horizontal">
+                <dl class="dl-horizontal admin-dl-horizontal">
                     <dt>Register Email Confirmation</dt>
                     <dd><i class="fa fa{{if .Service.RegisterEmailConfirm}}-check{{end}}-square-o"></i></dd>
                     <dt>Disenable Registeration</dt>
@@ -85,7 +85,7 @@
             </div>
 
             <div class="panel-body">
-                <dl class="dl-horizontal">
+                <dl class="dl-horizontal admin-dl-horizontal">
                     <dt>Enabled</dt>
                     <dd><i class="fa fa{{if .MailerEnabled}}-check{{end}}-square-o"></i></dd>
                     <dt>Name</dt>
@@ -104,7 +104,7 @@
             </div>
 
             <div class="panel-body">
-                <dl class="dl-horizontal">
+                <dl class="dl-horizontal admin-dl-horizontal">
                     <dt>Cache Adapter</dt>
                     <dd>{{.CacheAdapter}}</dd>
                     <dt>Cache Config</dt>
@@ -119,7 +119,7 @@
             </div>
 
             <div class="panel-body">
-                <dl class="dl-horizontal">
+                <dl class="dl-horizontal admin-dl-horizontal">
                     <dt>Session Provider</dt>
                     <dd>{{.SessionProvider}}</dd>
                     <dt>Cookie Name</dt>
@@ -150,7 +150,7 @@
             </div>
 
             <div class="panel-body">
-                <dl class="dl-horizontal">
+                <dl class="dl-horizontal admin-dl-horizontal">
                     <dt>Picture Service</dt>
                     <dd>{{.PictureService}}</dd>
                 </dl>
@@ -163,7 +163,7 @@
             </div>
 
             <div class="panel-body">
-                <dl class="dl-horizontal">
+                <dl class="dl-horizontal admin-dl-horizontal">
                     <dt>Log Mode</dt>
                     <dd>{{.LogMode}}</dd>
                     <dt>Log Config</dt>

--- a/templates/admin/dashboard.tmpl
+++ b/templates/admin/dashboard.tmpl
@@ -19,7 +19,7 @@
             </div>
 
             <div class="panel-body">
-                <dl class="dl-horizontal">
+                <dl class="dl-horizontal admin-dl-horizontal">
                     <dt>Server Uptime</dt>
                     <dd>{{.SysStatus.Uptime}}</dd>
 

--- a/templates/repo/single_file.tmpl
+++ b/templates/repo/single_file.tmpl
@@ -13,11 +13,11 @@
         {{end}}
         {{if not .ReadmeInSingle}}
         <div class="btn-group pull-right">
-            <a class="btn btn-default hidden" href="#">Edit</a>
+            <a class="btn btn-default" href="#">Edit</a>
             <a class="btn btn-default" href="{{.FileLink}}">Raw</a>
-            <a class="btn btn-default hidden" href="#">Blame</a>
-            <a class="btn btn-default hidden" href="#">History</a>
-            <a class="btn btn-danger hidden" href="#">Delete</a>
+            <a class="btn btn-default" href="#">Blame</a>
+            <a class="btn btn-default" href="#">History</a>
+            <a class="btn btn-danger" href="#">Delete</a>
         </div>
         {{end}}
     </div>


### PR DESCRIPTION
Just a detail but I think it looks prettier. 
![Dashboard](http://i.gyazo.com/b8f4ae707a7140d0b6e26ed4bb73e011.png)
![Configuration](http://i.gyazo.com/fb30a51224bec42edf909ade8a9fce8c.png)

You might want to manage `.dl-horizontal` style differently.
