### PR TITLE
Add sqlite build tag

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -12,7 +12,6 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/lib/pq"
 	"github.com/lunny/xorm"
-	// _ "github.com/mattn/go-sqlite3"
 
 	"github.com/gogits/gogs/modules/base"
 )
@@ -56,9 +55,9 @@ func NewTestEngine(x *xorm.Engine) (err error) {
 	case "postgres":
 		x, err = xorm.NewEngine("postgres", fmt.Sprintf("user=%s password=%s dbname=%s sslmode=%s",
 			DbCfg.User, DbCfg.Pwd, DbCfg.Name, DbCfg.SslMode))
-	// case "sqlite3":
-	// 	os.MkdirAll(path.Dir(DbCfg.Path), os.ModePerm)
-	// 	x, err = xorm.NewEngine("sqlite3", DbCfg.Path)
+	case "sqlite3":
+		os.MkdirAll(path.Dir(DbCfg.Path), os.ModePerm)
+		x, err = xorm.NewEngine("sqlite3", DbCfg.Path)
 	default:
 		return fmt.Errorf("Unknown database type: %s", DbCfg.Type)
 	}

--- a/models/models_sqlite.go
+++ b/models/models_sqlite.go
@@ -1,0 +1,11 @@
+// +build sqlite
+
+// Copyright 2014 The Gogs Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package models
+
+import (
+	_ "github.com/mattn/go-sqlite3"
+)


### PR DESCRIPTION
This adds a sqlite build tag so that you don't have to have the sqlite
import commented out in code and users can run:
`go build -tags sqlite`
if they want to have sqlite support enabled.  It is disabled by default
so nothing changes with the default go get or build commands.
