### PR TITLE
change gravatar image to match URL scheme

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -76,7 +76,7 @@ func (user *User) AvatarLink() string {
 	if base.Service.EnableCacheAvatar {
 		return "/avatar/" + user.Avatar
 	}
-	return "http://1.gravatar.com/avatar/" + user.Avatar
+	return "//1.gravatar.com/avatar/" + user.Avatar
 }
 
 // NewGitSig generates and returns the signature of given user.

--- a/modules/base/tool.go
+++ b/modules/base/tool.go
@@ -143,7 +143,7 @@ func AvatarLink(email string) string {
 	if Service.EnableCacheAvatar {
 		return "/avatar/" + EncodeMd5(email)
 	}
-	return "http://1.gravatar.com/avatar/" + EncodeMd5(email)
+	return "//1.gravatar.com/avatar/" + EncodeMd5(email)
 }
 
 // Seconds-based time units


### PR DESCRIPTION
Hi,
One more from me. This ensures that the gravatar image scheme will match the page's scheme. I was getting warnings on https pages that insecure elements were being loaded.

Thanks,
Chris
