### PR TITLE
swap \n for \000, update len check, when reading receive-pack input

### DIFF
--- a/routers/repo/http.go
+++ b/routers/repo/http.go
@@ -119,10 +119,10 @@ func Http(ctx *middleware.Context, params martini.Params) {
 
 	config := Config{base.RepoRootPath, "git", true, true, func(rpc string, input []byte) {
 		if rpc == "receive-pack" {
-			firstLine := bytes.IndexRune(input, '\n')
+			firstLine := bytes.IndexRune(input, '\000')
 			if firstLine > -1 {
 				fields := strings.Fields(string(input[:firstLine]))
-				if len(fields) > 3 {
+				if len(fields) == 3 {
 					oldCommitId := fields[0][4:]
 					newCommitId := fields[1]
 					refName := fields[2]


### PR DESCRIPTION
Hi,
I ran into an issue when trying to push commits with postgresql backend:

``` go
2014/04/15 12:35:53 [FATAL][github.com/gogits/gogs/models] update.go:82: runUpdate.models.CommitRepoAction: repo.NotifyWatchers(create action): pq: invalid byte sequence for encoding "UTF8": 0x00
```

I tracked this down to the following piece of code which took in `refs/heads/master\u0000` into `refname` and ultimately tried to insert into db.

Instead of looking for newline, I changed this to look for the first null character. Another thing I noticed was that not all commits had a `\n` in the receive-pack input, so the `models.Update` func wasn't executing sometimes when it should.

Also since fields will now look something like this:

``` js
["00a505583985eeae8a0803063d2a384383043957b24d",
 "aee1aca7ebc8d31677150e9cee4dc1e541e79d39",
 "refs/heads/master"
]
```

I changed the length check to == 3 instead of > 3.

I'm no expert on git internals, but this seemed to work for me. Let me know if you need more info.

Thanks!
Chris
