### PR TITLE
Use commit summaries instead of full messages

### DIFF
--- a/routers/repo/commit.go
+++ b/routers/repo/commit.go
@@ -92,7 +92,7 @@ func Diff(ctx *middleware.Context, params martini.Params) {
 	}
 
 	ctx.Data["IsImageFile"] = isImageFile
-	ctx.Data["Title"] = commit.Message() + " · " + base.ShortSha(commitId)
+	ctx.Data["Title"] = commit.Summary() + " · " + base.ShortSha(commitId)
 	ctx.Data["Commit"] = commit
 	ctx.Data["Diff"] = diff
 	ctx.Data["DiffNotAvailable"] = diff.NumFiles() == 0

--- a/templates/repo/commits.tmpl
+++ b/templates/repo/commits.tmpl
@@ -33,7 +33,7 @@
                 <tr>
                     <td class="author"><img class="avatar" src="{{AvatarLink .Author.Email}}" alt=""/><a href="/user/email2user?email={{.Author.Email}}">{{.Author.Name}}</a></td>
                     <td class="sha"><a rel="nofollow" class="label label-success" href="/{{$username}}/{{$reponame}}/commit/{{.Id}} ">{{SubStr .Id.String 0 10}} </a></td>
-                    <td class="message">{{.Message}} </td>
+                    <td class="message">{{.Summary}} </td>
                     <td class="date">{{TimeSince .Author.When}}</td>
                 </tr>
                 {{end}}

--- a/templates/repo/single_list.tmpl
+++ b/templates/repo/single_list.tmpl
@@ -1,6 +1,6 @@
 <div class="panel panel-default info-box">
     <div class="panel-heading info-head">
-        <a href="/{{.Username}}/{{.Reponame}}/commit/{{.LastCommit.Id}}">{{.LastCommit.Message}}</a>
+        <a href="/{{.Username}}/{{.Reponame}}/commit/{{.LastCommit.Id}}">{{.LastCommit.Summary}}</a>
     </div>
     <div class="panel-body info-content">
         <a href="/user/{{.LastCommit.Author.Name}}">{{.LastCommit.Author.Name}}</a> <span class="text-muted">{{TimeSince .LastCommit.Author.When}}</span>
@@ -36,7 +36,7 @@
                         </span>
                     </td>
                     <td class="text">
-                        <span class="wrap"><a rel="nofollow" href="/{{$.Username}}/{{$.Reponame}}/commit/{{$commit.Id}}">{{$commit.Message}}</a></span>
+                        <span class="wrap"><a rel="nofollow" href="/{{$.Username}}/{{$.Reponame}}/commit/{{$commit.Id}}">{{$commit.Summary}}</a></span>
                     </td>
                     <td class="date">
                         <span class="wrap">{{TimeSince $commit.Committer.When}}</span>


### PR DESCRIPTION
Requires https://github.com/gogits/git/pull/1 to provide the commit.Summary() method.
