### PR TITLE
Install: Set the default host string based on database type

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -468,6 +468,9 @@ function initRepository() {
 function initInstall() {
     // database type change
     (function () {
+        var mysql_default    = '127.0.0.1:3306'
+        var postgres_default = '127.0.0.1:5432'
+
         $('#install-database').on("change", function () {
             var val = $(this).val();
             if (val != "SQLite3") {
@@ -475,6 +478,18 @@ function initInstall() {
                 $('.sqlite-setting').addClass("hide");
                 if (val == "PostgreSQL") {
                     $('.pgsql-setting').removeClass("hide");
+
+                    // Change the host value to the Postgres default, but only
+                    // if the user hasn't already changed it from the MySQL
+                    // default.
+                    if ($('#database-host').val() == mysql_default) {
+                        $('#database-host').val(postgres_default);
+                    }
+                } else if (val == 'MySQL') {
+                    $('.pgsql-setting').addClass("hide");
+                    if ($('#database-host').val() == postgres_default) {
+                        $('#database-host').val(mysql_default);
+                    }
                 } else {
                     $('.pgsql-setting').addClass("hide");
                 }

--- a/templates/install.tmpl
+++ b/templates/install.tmpl
@@ -21,7 +21,7 @@
             <div class="form-group">
                 <label class="col-md-3 control-label">Host: </label>
                 <div class="col-md-8">
-                    <input name="host" class="form-control" placeholder="Type database server host" value="{{.host}}">
+                    <input name="host" id="database-host" class="form-control" placeholder="Type database server host" value="{{.host}}">
                 </div>
             </div>
 


### PR DESCRIPTION
I can never remember the default Postgres port. This change will update the
default `host` field's value depending on the database backend selected. It
will not change the value if the user has changed it from the default.
