### PR TITLE
Remove password from log message upon login failure

### DIFF
--- a/routers/user/user.go
+++ b/routers/user/user.go
@@ -105,7 +105,7 @@ func SignInPost(ctx *middleware.Context, form auth.LogInForm) {
 	user, err = models.LoginUser(form.UserName, form.Password)
 	if err != nil {
 		if err == models.ErrUserNotExist {
-			log.Trace("%s Log in failed: %s/%s", ctx.Req.RequestURI, form.UserName, form.Password)
+			log.Trace("%s Log in failed: %s", ctx.Req.RequestURI, form.UserName)
 			ctx.RenderWithErr("Username or password is not correct", "user/signin", &form)
 			return
 		}


### PR DESCRIPTION
When working on adding LDAPS support I had situations where my correct username/password were logged to the config file simply because the LDAP server was not reachable/there were connection failures.
For security reasons I've removed the password from login failure messages.
