### PR TITLE
Fix #252

### DIFF
--- a/models/publickey.go
+++ b/models/publickey.go
@@ -161,7 +161,7 @@ func rewriteAuthorizedKeys(key *PublicKey, p, tmpP string) error {
 	}
 	defer fr.Close()
 
-	fw, err := os.Create(tmpP)
+	fw, err := os.OpenFile(tmpP, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixed File Mode Error when Create the temporary "authorized_keys" file. (this file will replace the real "authorized_keys" with bad FileMode Value)
