### PR TITLE
fix typos in users' editing template.

### DIFF
--- a/templates/admin/user/edit.tmpl
+++ b/templates/admin/user/edit.tmpl
@@ -71,7 +71,7 @@
 			                <div class="checkbox">
 			                    <label>
 			                        <input type="checkbox" name="active" {{if .User.IsActive}}checked{{end}}>
-			                        <strong>This account has activated</strong>
+			                        <strong>This account is activated</strong>
 			                    </label>
 			                </div>
 			            </div>
@@ -82,7 +82,7 @@
 			                <div class="checkbox">
 			                    <label>
 			                        <input type="checkbox" name="admin" {{if .User.IsAdmin}}checked{{end}}>
-			                        <strong>This account has administor permisson</strong>
+			                        <strong>This account has administrator permissions</strong>
 			                    </label>
 			                </div>
 			            </div>


### PR DESCRIPTION
Hi, 

while on this i wonder if for groups, aka Organizations, on the same form, wouldn't make sense, for simplicity, to hide both Auth fields and to not make obligatory the definition of an email address (both for the avatar and for the commit log) 

All the best, 
