### PR TITLE
Add 'pprof' tag for enabling debugging

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gogits/gogs/routers"
 	"github.com/gogits/gogs/routers/admin"
 	"github.com/gogits/gogs/routers/api/v1"
+	"github.com/gogits/gogs/routers/debug"
 	"github.com/gogits/gogs/routers/dev"
 	"github.com/gogits/gogs/routers/org"
 	"github.com/gogits/gogs/routers/repo"
@@ -204,6 +205,8 @@ func runWeb(*cli.Context) {
 		r.Post("/:org/settings", bindIgnErr(auth.OrgSettingForm{}), org.SettingsPost)
 		r.Post("/:org/settings/delete", org.DeletePost)
 	}, reqSignIn)
+
+	debug.RegisterRoutes(m)
 
 	m.Group("/:username/:reponame", func(r martini.Router) {
 		r.Get("/settings", repo.Setting)

--- a/models/repo.go
+++ b/models/repo.go
@@ -158,7 +158,7 @@ func IsRepositoryExist(u *User, repoName string) (bool, error) {
 }
 
 var (
-	illegalEquals  = []string{"raw", "install", "api", "avatar", "user", "org", "help", "stars", "issues", "pulls", "commits", "repo", "template", "admin", "new"}
+	illegalEquals  = []string{"debug", "raw", "install", "api", "avatar", "user", "org", "help", "stars", "issues", "pulls", "commits", "repo", "template", "admin", "new"}
 	illegalSuffixs = []string{".git"}
 )
 

--- a/routers/debug/debug.go
+++ b/routers/debug/debug.go
@@ -1,0 +1,16 @@
+// +build pprof
+
+package debug
+
+import (
+	"net/http/pprof"
+
+	"github.com/go-martini/martini"
+)
+
+func RegisterRoutes(r martini.Router) {
+	r.Get("/debug/pprof/cmdline", pprof.Cmdline)
+	r.Get("/debug/pprof/profile", pprof.Profile)
+	r.Get("/debug/pprof/symbol", pprof.Symbol)
+	r.Get("/debug/pprof/**", pprof.Index)
+}

--- a/routers/debug/ignored.go
+++ b/routers/debug/ignored.go
@@ -1,0 +1,11 @@
+// +build !pprof
+
+package debug
+
+import (
+	"github.com/go-martini/martini"
+)
+
+func RegisterRoutes(r martini.Router) {
+	// do nothing
+}


### PR DESCRIPTION
Hi,

having looked at gogs the last few days I often profiled parts of it, but because writing the code to add profiling to gogs is (at the moment) something everybody has to do himself/herself each time he/she wants to profile something I want to share this little bit of code with you.

It adds a new build tag 'pprof' which enables pprof profiling under the default /debug/pprof path of the [golang.org/pkg/net/http/pprof/](net/http/pprof) package and disallows the name "debug" for users.

To enable it one just has to build gogs like this `go build -tags pprof`.

If something is wrong or must be changed, I'm happy to update my code.
