### PR TITLE
Fix wrong method for profiling routes.

### DIFF
--- a/routers/debug/debug.go
+++ b/routers/debug/debug.go
@@ -9,8 +9,8 @@ import (
 )
 
 func RegisterRoutes(r martini.Router) {
-	r.Get("/debug/pprof/cmdline", pprof.Cmdline)
-	r.Get("/debug/pprof/profile", pprof.Profile)
-	r.Get("/debug/pprof/symbol", pprof.Symbol)
-	r.Get("/debug/pprof/**", pprof.Index)
+	r.Any("/debug/pprof/cmdline", pprof.Cmdline)
+	r.Any("/debug/pprof/profile", pprof.Profile)
+	r.Any("/debug/pprof/symbol", pprof.Symbol)
+	r.Any("/debug/pprof/**", pprof.Index)
 }


### PR DESCRIPTION
It's me again.

I just found out that I incorrectly used GET as method for all routes, while profiling methods (which uses /debug/pprof/symbol) also needs POST.

This commit makes the routes listen for requests with all routes, as it is done for the net/http router.
