### PR TITLE
Only update access usernames where the username is changing

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -297,10 +297,12 @@ func ChangeUserName(user *User, newUserName string) (err error) {
 		}
 
 		for j := range accesses {
-			accesses[j].UserName = newUserName
-			accesses[j].RepoName = newUserName + "/" + repos[i].LowerName
-			if err = UpdateAccessWithSession(sess, &accesses[j]); err != nil {
-				return err
+			// if the access is not the user's access (already updated above)
+			if accesses[j].UserName != user.LowerName {
+				accesses[j].RepoName = newUserName + "/" + repos[i].LowerName
+				if err = UpdateAccessWithSession(sess, &accesses[j]); err != nil {
+					return err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Updated PR to dev branch.
## 

I did some debugging on #282. I think there are two issues here.

The current process (from what I understand) seems to flow like this:
1. The user's name who is changing has all his/her access records updated
2. Then all the access records for the user's repos are updated, including the records updated in the first case. These updates aren't needed.
3. During the second update, the username for ALL the access records is being set to the new user. This triggers the constraint violation because users A's access record is being changed to B2 (and B2's access record already was updated from B to B2).

This change addresses these two problems by only updating the access records not belonging to the user whose name is being changed in the second pass.
