### PR TITLE
Remove apt-get cleanup from Dockerfile

### DIFF
--- a/dockerfiles/images/gogits/Dockerfile
+++ b/dockerfiles/images/gogits/Dockerfile
@@ -19,9 +19,6 @@ RUN cd /usr/local/go/src && ./make.bash --no-clean 2>&1
 RUN go get -u -d github.com/gogits/gogs 
 RUN cd $GOPATH/src/github.com/gogits/gogs && git checkout dev && git pull origin dev && go install && go build -tags redis
 
-# Clean all the unused packages
-RUN apt-get autoremove -y
-RUN apt-get clean all
 
 # Add the deploy script to the docker image and assign execution permission to it.
 ADD ./deploy.sh /


### PR DESCRIPTION
Purging/cleaning packages using apt doesn't actually reduce image size, and only creates additional layers, which doesn't add any benefit to the overall image.
