### PR TITLE
Fix #313. Repair broken image extension detection regex.

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -536,7 +536,7 @@ function initIssue() {
         var over = function() {
             var $this = $(this);
 
-            if ($this.text().match(/\.(png|jpg|jpeg|gif)$/i) == false) {
+            if ((/\.(png|jpg|jpeg|gif)$/i).test($this.text()) == false) {
                 return;
             }
 


### PR DESCRIPTION
I failed at using the right function for the test.
This fixes the code.
