### PR TITLE
Tweak image regexp check to fix #313

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -536,7 +536,7 @@ function initIssue() {
         var over = function() {
             var $this = $(this);
 
-            if ($this.text().match(/\.(png|jpg|jpeg|gif)$/i) == false) {
+            if ((/\.(png|jpg|jpeg|gif)$/i).test($this.text()) === false) {
                 return;
             }
 


### PR DESCRIPTION
Comparing the `.match()` against `false` always returns false, even if `match()` finds nothing and returns `null`. Switched comparison to use `RegExp.test` at the same time for performance (and for simple true or false return type)
