### PR TITLE
Preserve display of capitalization in filename

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -593,7 +593,7 @@ function initIssue() {
                 $span.addClass("label");
                 $span.addClass("label-default");
 
-                $span.append(file.name.toLowerCase());
+                $span.append(file.name);
                 $attachedList.append($span);
             }
         });


### PR DESCRIPTION
This is super trivial, but I noticed that filenames are displayed in all lowercase when in `#attached-list`, which is kinda weird, because filenames are then shown with original capitalization when they are uploaded and displayed in a comment. Ok with you @nuss-justin?
