### PR TITLE
Remove 'None yet' message when adding first label to issue.

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -926,11 +926,17 @@ function initIssue() {
                     $(item).addClass("no-checked");
 
                     $("#label-" + id, $labels).remove();
+                    
+                    if ($labels.children(".label-item").length == 0) {
+                        $labels.append("<p>None yet</p>");
+                    }
                 } else {
                     $(item).prepend('<span class="check pull-left"><i class="fa fa-check"></i></span>');
 
                     $(item).removeClass("no-checked");
                     $(item).addClass("checked");
+                    
+                    $("p:not([class])", $labels).remove();
 
                     var $l = $("<p></p>");
                     var c = $("span.color", item).css("background-color");


### PR DESCRIPTION
This fixes a little flaw in the way labels are added/removed from issues :-)
(The 'None yet' message didn't disappear/reappear before)
