### PR TITLE
Save comment/issue drafts in sessionStorage.

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -520,6 +520,50 @@ function initIssue() {
         });
     }());
 
+    // store unsend text in session storage.
+    (function() {
+        var $textArea = $("#issue-content,#issue-reply-content");
+        var current = "";
+
+        if ($textArea == null || !('sessionStorage' in window)) {
+            return;
+        }
+
+        var path = location.pathname.split("/");
+        var key = "issue-" + path[1] + "-" + path[2] + "-";
+
+        if (/\/issues\/\d+$/.test(location.pathname)) {
+            key = key + path[4];
+        } else {
+            key = key + "new";
+        }
+
+        if ($textArea.val() !== undefined && $textArea.val() !== "") {
+            sessionStorage.setItem(key, $textArea.val());
+        } else {
+            $textArea.val(sessionStorage.getItem(key) || "");
+
+            if ($textArea.attr("id") == "issue-reply-content") {
+                var $closeBtn = $('#issue-close-btn');
+                var $openBtn = $('#issue-open-btn');
+    
+                if ($textArea.val().length) {
+                    $closeBtn.val($closeBtn.data("text"));
+                    $openBtn.val($openBtn.data("text"));
+                } else {
+                    $closeBtn.val($closeBtn.data("origin"));
+                    $openBtn.val($openBtn.data("origin"));
+                }
+            }
+        }
+
+        $textArea.on("keyup", function() {
+            if ($textArea.val() !== current) {
+                sessionStorage.setItem(key, current = $textArea.val());
+            }
+        });
+    }());
+
     // Preview for images.
     (function() {
         var $hoverElement = $("<div></div>");
@@ -659,8 +703,22 @@ function initIssue() {
                     $button.text("An error encoured!")
 
                     return;
-                }                   
+                }
 
+                if (!('sessionStorage' in window)) {
+                    return;
+                }
+
+                var path = location.pathname.split("/");
+                var key = "issue-" + path[1] + "-" + path[2] + "-";
+
+                if (/\/issues\/\d+$/.test(location.pathname)) {
+                    key = key + path[4];
+                } else {
+                    key = key + "new";
+                }
+
+                sessionStorage.removeItem(key);
                 window.location.href = response.data;
             });
 


### PR DESCRIPTION
This does exactly what the title says: If you write an issue or comment and reload the page (or even go to another page and come back late), as long as you didn't close your browser in the mean time, your written text will be pre-filled in the textarea if you come back to the same issue (or in case of creating an issue, if you try to create an issue in the same repo)

I got the idea when I accidentally closed my github tab and reopened it. :-)
