### PR TITLE
Use :index instead of :issue in UpdateIssueMilestone

### DIFF
--- a/routers/repo/issue.go
+++ b/routers/repo/issue.go
@@ -565,7 +565,7 @@ func UpdateIssueMilestone(ctx *middleware.Context) {
 		return
 	}
 
-	issueId := com.StrTo(ctx.Params(":issue")).MustInt64()
+	issueId := com.StrTo(ctx.Params(":index")).MustInt64()
 	if issueId == 0 {
 		ctx.Error(404)
 		return


### PR DESCRIPTION
This fixes UpdateIssueMilestone to use the correct param name.
