### PR TITLE
Avoid using fixed width in CSS for layouts

### DIFF
--- a/public/css/gogs.css
+++ b/public/css/gogs.css
@@ -203,7 +203,7 @@ body {
     border-bottom: 1px solid #ccc;
 }
 #login-card {
-    width: 600px;
+    max-width: 600px;
 }
 #login-card .form-control {
     padding: 6px 12px;
@@ -214,7 +214,7 @@ body {
     line-height: 30px;
 }
 #install-card {
-    width: 800px;
+    max-width: 800px;
 }
 #install-card .form-group {
     margin-left: 0;
@@ -324,7 +324,7 @@ body {
 #org-create,
 #org-teams-create,
 #org-teams-edit {
-    width: 800px;
+    max-width: 800px;
 }
 #repo-create textarea[name=desc] {
     height: 8em;


### PR DESCRIPTION
Some pages, like Sign in, Sign out, and create a new repository use a fixed width form in CSS, which requires the user to scroll horizontally on mobile devices. By using the max-width property instead, the form will look the same at large screen sizes and prevent horizontal scrolling on small screen sizes.
