### PR TITLE
Ensure correct permissions on .ssh and authorized_keys file

### DIFF
--- a/models/publickey.go
+++ b/models/publickey.go
@@ -155,16 +155,18 @@ func saveAuthorizedKeyFile(key *PublicKey) error {
 	if err != nil {
 		return err
 	}
+	defer f.Close()
 	finfo, err := f.Stat()
 	if err != nil {
 		return err
 	}
 	if finfo.Mode().Perm() > 0600 {
 		log.Error(3, "authorized_keys file has unusual permission flags: %s - setting to -rw-------", finfo.Mode().Perm().String())
-		f.Chmod(0600)
+		err = f.Chmod(0600)
+		if err != nil {
+			return err
+		}
 	}
-
-	defer f.Close()
 
 	_, err = f.WriteString(key.GetAuthorizedString())
 	return err


### PR DESCRIPTION
One of our admins noted that the .ssh directory created by gogs for our git user, as well as the authorized_keys file inside were accessible by anyone. This patch makes sure that if gogs has to create .ssh, it does so with 0700 permissions (rwx to owner only) and keep the authorized_keys file on 0600 (logging if it is found to have greater perms).

This probably needs some beautification in order to be acceptable but I hope I've identified all the causes.
