### PR TITLE
Remove newline characters from ssh key before processing it.

### DIFF
--- a/routers/user/setting.go
+++ b/routers/user/setting.go
@@ -5,6 +5,8 @@
 package user
 
 import (
+	"strings"
+
 	"github.com/Unknwon/com"
 
 	"github.com/gogits/gogs/models"
@@ -172,7 +174,7 @@ func SettingsSSHKeysPost(ctx *middleware.Context, form auth.AddSSHKeyForm) {
 		}
 
 		// Remove newline characters from form.KeyContent
-		cleanContent := string.Replace(form.Content, "\n", "", -1)
+		cleanContent := strings.Replace(form.Content, "\n", "", -1)
 
 		if ok, err := models.CheckPublicKeyString(cleanContent); !ok {
 			ctx.Flash.Error(ctx.Tr("form.invalid_ssh_key", err.Error()))


### PR DESCRIPTION
Fixes issue https://github.com/gogits/gogs/issues/370

In short gogs stores ssh keys with newline characters (\n). When it wants to remove the key from `authorized_keys` it searches for the ssh key without the newline chars and thus fails to find and remove it.

Dev branch is currently broken, it compiles but gogs can't start due to template errors, so I can't directly confirm the patch for dev.
I tried the fix on the master branch and it works as it should.
Also I checked with the command you use to verify the ssh key (`ssh-keygen -l -f tpmPath`) and it let newline characters to pass, so at least I know that the problem exists on dev.
