### PR TITLE
Set headers in js and go files to X-Csrf-Token

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -95,6 +95,7 @@ func newMacaron() *macaron.Macaron {
 	m.Use(csrf.Generate(csrf.Options{
 		Secret:    setting.SecretKey,
 		SetCookie: true,
+		Header:    "X-Csrf-Token",
 	}))
 	m.Use(toolbox.Toolboxer(m, toolbox.Options{
 		HealthCheckFuncs: []*toolbox.HealthCheckFuncDesc{


### PR DESCRIPTION
In app.js and gogs.js `X-Csrf-Token` is used, but in `macaron-contrib/csrf` `X-CSRFToken` is used by default.
So I set up both to `X-Csrf-Token`.
This PR fixes bug with `issue` updating through ajax request.
