### PR TITLE
Fixes in repo-header-download-drop

### DIFF
--- a/templates/repo/header.tmpl
+++ b/templates/repo/header.tmpl
@@ -18,8 +18,8 @@
                     <div id="repo-clone" class="clear">
                         <button class="btn btn-blue left left btn-left-radius" id="repo-clone-ssh" data-link="{{.CloneLink.SSH}}">SSH</button>
                         <button class="btn btn-gray left" id="repo-clone-https" data-link="{{.CloneLink.HTTPS}}">HTTPS</button>
+                        <button id="repo-clone-copy" class="btn btn-black right btn-right-radius" data-copy-val="val" data-copy-from="#repo-clone-url">{{.i18n.Tr "repo.copy_link"}}</button>
                         <input id="repo-clone-url" class="ipt ipt-disabled left" value="{{.CloneLink.SSH}}" readonly />
-                        <button id="repo-clone-copy" class="btn btn-black left btn-right-radius" data-copy-val="val" data-copy-from="#repo-clone-url">{{.i18n.Tr "repo.copy_link"}}</button>
                         <p class="text-center" id="repo-clone-help">{{.i18n.Tr "repo.clone_helper" | Str2html}}</p>
                         <hr/>
                         <div class="text-center" id="repo-clone-zip">


### PR DESCRIPTION
Fixed incorrect ui in repo-header
swapped places button#repo-clone-copy and input#repo-clone-url
also button#repo-clone-copy putted to the right side

**fixes ui in css too to this changes
