### PR TITLE
Add handling to branch switcher label to make label more consistent with

### DIFF
--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -17,7 +17,7 @@
                 <li id="repo-branch-switch" class="down drop">
                     <a href="#">
                         <button class="btn btn-gray btn-small btn-radius">
-                            <i class="octicon octicon-git-branch"></i> Branch :
+                            <i class="octicon octicon-git-branch"></i> {{if .IsViewBranch}}Branch{{else}}Tree{{end}}:
                             <strong id="repo-branch-current">{{if .IsViewBranch}}{{.BranchName}}{{else}}{{ShortSha .BranchName}}{{end}}</strong>
                         </button>
                     </a>


### PR DESCRIPTION
GitHub behaviour

Addresses #431
