### PR TITLE
Robust User determination

### DIFF
--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/user"
 	"path"
 	"path/filepath"
 	"strings"
@@ -213,13 +214,13 @@ func NewConfigContext() {
 	}
 
 	RunUser = Cfg.MustValue("", "RUN_USER")
-	curUser := os.Getenv("USER")
-	if len(curUser) == 0 {
-		curUser = os.Getenv("USERNAME")
+	curUser, err := user.Current()
+	if err != nil {
+		log.Fatal(4, "Couldn't determine current User", err)
 	}
 	// Does not check run user when the install lock is off.
-	if InstallLock && RunUser != curUser {
-		log.Fatal(4, "Expect user(%s) but current user is: %s", RunUser, curUser)
+	if InstallLock && RunUser != curUser.Username {
+		log.Fatal(4, "Expect user(%s) but current user is: %s", RunUser, curUser.Username)
 	}
 
 	// Determine and create root git reposiroty path.

--- a/routers/install.go
+++ b/routers/install.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"os/user"
 	"path"
 	"strings"
 
@@ -181,14 +182,13 @@ func InstallPost(ctx *middleware.Context, form auth.InstallForm) {
 		return
 	}
 
-	// Check run user.
-	curUser := os.Getenv("USER")
-	if len(curUser) == 0 {
-		curUser = os.Getenv("USERNAME")
+	curUser, err := user.Current()
+	if err != nil {
+		log.Fatal(4, "Couldn't determine current User", err)
 	}
 	// Does not check run user when the install lock is off.
-	if form.RunUser != curUser {
-		ctx.RenderWithErr("Run user isn't the current user: "+form.RunUser+" -> "+curUser, INSTALL, &form)
+	if form.RunUser != curUser.Username {
+		ctx.RenderWithErr("Run user isn't the current user: "+form.RunUser+" -> "+curUser.Username, INSTALL, &form)
 		return
 	}
 


### PR DESCRIPTION
Use go's statndard lib to determine Username.
This prevents hicups in minimal settings where $USER and $USERNAME might not be set.
