### PR TITLE
Set milestone content field to TEXT orm type

### DIFF
--- a/models/issue.go
+++ b/models/issue.go
@@ -612,7 +612,7 @@ type Milestone struct {
 	RepoId          int64 `xorm:"INDEX"`
 	Index           int64
 	Name            string
-	Content         string
+	Content         string `xorm:"TEXT"`
 	RenderedContent string `xorm:"-"`
 	IsClosed        bool
 	NumIssues       int


### PR DESCRIPTION
Right now creation of milestone with content size more then 255 symbols generates 500 error.
I think there is two solutions:
1) Check received content size in router and return 400 with clear error reason;
2) Change Content field from varchar(255) to text.

I suppose the second solution is better. I've changed field type, but I don't know how to create an automatic migration. 
Can anyone help me?
