### PR TITLE
update specific hook_task, not all

### DIFF
--- a/models/webhook.go
+++ b/models/webhook.go
@@ -230,7 +230,7 @@ func CreateHookTask(t *HookTask) error {
 
 // UpdateHookTask updates information of hook task.
 func UpdateHookTask(t *HookTask) error {
-	_, err := x.AllCols().Update(t)
+	_, err := x.Id(t.Id).AllCols().Update(t)
 	return err
 }
 


### PR DESCRIPTION
This method should only update the HookTask passed to it, not all tasks in the table to the same information.
