### PR TITLE
Remove APP_LOGO setting

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -1,6 +1,5 @@
 ; App name that shows on every page title
 APP_NAME = Gogs: Go Git Service
-APP_LOGO = img/favicon.png
 ; Change it if you run locally
 RUN_USER = git
 ; Either "dev", "prod" or "test", default is "dev"

--- a/modules/mailer/mail.go
+++ b/modules/mailer/mail.go
@@ -45,7 +45,6 @@ func GetMailTmplData(u *models.User) map[interface{}]interface{} {
 	data["AppName"] = setting.AppName
 	data["AppVer"] = setting.AppVer
 	data["AppUrl"] = setting.AppUrl
-	data["AppLogo"] = setting.AppLogo
 	data["ActiveCodeLives"] = setting.Service.ActiveCodeLives / 60
 	data["ResetPwdCodeLives"] = setting.Service.ResetPwdCodeLives / 60
 	if u != nil {

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -32,7 +32,6 @@ var (
 	// App settings.
 	AppVer  string
 	AppName string
-	AppLogo string
 	AppUrl  string
 
 	// Server settings.
@@ -155,7 +154,6 @@ func NewConfigContext() {
 	}
 
 	AppName = Cfg.MustValue("", "APP_NAME", "Gogs: Go Git Service")
-	AppLogo = Cfg.MustValue("", "APP_LOGO", "img/favicon.png")
 	AppUrl = Cfg.MustValue("server", "ROOT_URL", "http://localhost:3000/")
 	if AppUrl[len(AppUrl)-1] != '/' {
 		AppUrl += "/"

--- a/routers/dev/template.go
+++ b/routers/dev/template.go
@@ -16,7 +16,6 @@ func TemplatePreview(ctx *middleware.Context) {
 	ctx.Data["AppName"] = setting.AppName
 	ctx.Data["AppVer"] = setting.AppVer
 	ctx.Data["AppUrl"] = setting.AppUrl
-	ctx.Data["AppLogo"] = setting.AppLogo
 	ctx.Data["Code"] = "2014031910370000009fff6782aadb2162b4a997acb69d4400888e0b9274657374"
 	ctx.Data["ActiveCodeLives"] = setting.Service.ActiveCodeLives / 60
 	ctx.Data["ResetPwdCodeLives"] = setting.Service.ResetPwdCodeLives / 60

--- a/templates/mail/auth/active.tmpl
+++ b/templates/mail/auth/active.tmpl
@@ -9,7 +9,7 @@
     <div style="width:600px;margin:0 auto; padding:40px 0 20px;">
         <div style="border:1px solid #d9d9d9;border-radius:3px; background:#fff; box-shadow: 0px 2px 5px rgba(0, 0, 0,.05); -webkit-box-shadow: 0px 2px 5px rgba(0, 0, 0,.05);">
             <div style="padding: 20px 15px;">
-                <h1 style="font-size:20px; padding:10px 0 20px; margin:0; border-bottom:1px solid #ddd;"><img src="{{.AppUrl}}/{{.AppLogo}}" style="height: 32px; margin-bottom: -10px;"> <a style="color:#333;text-decoration:none;" target="_blank" href="{{.AppUrl}}">{{.AppName}}</a></h1>
+                <h1 style="font-size:20px; padding:10px 0 20px; margin:0; border-bottom:1px solid #ddd;"><img src="{{.AppUrl}}/img/favicon.png" style="height: 32px; margin-bottom: -10px;"> <a style="color:#333;text-decoration:none;" target="_blank" href="{{.AppUrl}}">{{.AppName}}</a></h1>
                 <div style="padding:40px 15px;">
                     <div style="font-size:16px; padding-bottom:30px; font-weight:bold;">
                         Hi <span style="color: #00BFFF;">{{.User.Name}}</span>,

--- a/templates/mail/auth/register_success.tmpl
+++ b/templates/mail/auth/register_success.tmpl
@@ -9,7 +9,7 @@
     <div style="width:600px;margin:0 auto; padding:40px 0 20px;">
         <div style="border:1px solid #d9d9d9;border-radius:3px; background:#fff; box-shadow: 0px 2px 5px rgba(0, 0, 0,.05); -webkit-box-shadow: 0px 2px 5px rgba(0, 0, 0,.05);">
             <div style="padding: 20px 15px;">
-                <h1 style="font-size:20px; padding:10px 0 20px; margin:0; border-bottom:1px solid #ddd;"><img src="{{.AppUrl}}/{{.AppLogo}}" style="height: 32px; margin-bottom: -10px;"> <a style="color:#333;text-decoration:none;" target="_blank" href="{{.AppUrl}}">{{.AppName}}</a></h1>
+                <h1 style="font-size:20px; padding:10px 0 20px; margin:0; border-bottom:1px solid #ddd;"><img src="{{.AppUrl}}/img/favicon.png" style="height: 32px; margin-bottom: -10px;"> <a style="color:#333;text-decoration:none;" target="_blank" href="{{.AppUrl}}">{{.AppName}}</a></h1>
                 <div style="padding:40px 15px;">
                     <div style="font-size:16px; padding-bottom:30px; font-weight:bold;">
                         Hi <span style="color: #00BFFF;">{{.User.Name}}</span>, this is your registration email for {{.AppName}}!

--- a/templates/mail/auth/reset_passwd.tmpl
+++ b/templates/mail/auth/reset_passwd.tmpl
@@ -9,7 +9,7 @@
     <div style="width:600px;margin:0 auto; padding:40px 0 20px;">
         <div style="border:1px solid #d9d9d9;border-radius:3px; background:#fff; box-shadow: 0px 2px 5px rgba(0, 0, 0,.05); -webkit-box-shadow: 0px 2px 5px rgba(0, 0, 0,.05);">
             <div style="padding: 20px 15px;">
-                <h1 style="font-size:20px; padding:10px 0 20px; margin:0; border-bottom:1px solid #ddd;"><img src="{{.AppUrl}}/{{.AppLogo}}" style="height: 32px; margin-bottom: -10px;"> <a style="color:#333;text-decoration:none;" target="_blank" href="{{.AppUrl}}">{{.AppName}}</a></h1>
+                <h1 style="font-size:20px; padding:10px 0 20px; margin:0; border-bottom:1px solid #ddd;"><img src="{{.AppUrl}}/img/favicon.png" style="height: 32px; margin-bottom: -10px;"> <a style="color:#333;text-decoration:none;" target="_blank" href="{{.AppUrl}}">{{.AppName}}</a></h1>
                 <div style="padding:40px 15px;">
                     <div style="font-size:16px; padding-bottom:30px; font-weight:bold;">
                         Hi <span style="color: #00BFFF;">{{.User.Name}}</span>,


### PR DESCRIPTION
I tried to change the `APP_LOGO` setting, expecting it to change the logo in the nav but in vain.  Looks like this only change the logo in the mail/auth templates.  To avoid confusion I suggest removing the setting completely.  Relying only on files in public/ so it would be like customizing any other image (gogs-lg.png, 404.png, etc)
