### PR TITLE
Allow Gogs to run from a suburl behind a reverse proxy.

### DIFF
--- a/conf/locale/locale_de-DE.ini
+++ b/conf/locale/locale_de-DE.ini
@@ -490,10 +490,10 @@ monitor.start = Startzeit
 monitor.execute_time = Ausführungszeit
 
 [action]
-create_repo = Repository erstellen <a href="/%s">%s</a>
-commit_repo = pushed to <a href="/%s/src/%s">%s</a> at <a href="/%s">%s</a>
-create_issue = opened issue <a href="/%s/issues/%s">%s#%s</a>
-comment_issue = commented on issue <a href="/%s/issues/%s">%s#%s</a>
+create_repo = Repository erstellen <a href="%s/%s">%s</a>
+commit_repo = pushed to <a href="%s/%s/src/%s">%s</a> at <a href="%s/%s">%s</a>
+create_issue = opened issue <a href="%s/%s/issues/%s">%s#%s</a>
+comment_issue = commented on issue <a href="%s/%s/issues/%s">%s#%s</a>
 
 [tool]
 ago = vor

--- a/conf/locale/locale_en-US.ini
+++ b/conf/locale/locale_en-US.ini
@@ -541,10 +541,10 @@ monitor.start = Start Time
 monitor.execute_time = Execution Time
 
 [action]
-create_repo = created repository <a href="/%s">%s</a>
-commit_repo = pushed to <a href="/%s/src/%s">%s</a> at <a href="/%s">%s</a>
-create_issue = opened issue <a href="/%s/issues/%s">%s#%s</a>
-comment_issue = commented on issue <a href="/%s/issues/%s">%s#%s</a>
+create_repo = created repository <a href="%s/%s">%s</a>
+commit_repo = pushed to <a href="%s/%s/src/%s">%s</a> at <a href="%s/%s">%s</a>
+create_issue = opened issue <a href="%s/%s/issues/%s">%s#%s</a>
+comment_issue = commented on issue <a href="%s/%s/issues/%s">%s#%s</a>
 
 [tool]
 ago = ago

--- a/conf/locale/locale_zh-CN.ini
+++ b/conf/locale/locale_zh-CN.ini
@@ -539,10 +539,10 @@ monitor.start = 开始时间
 monitor.execute_time = 已执行时间
 
 [action]
-create_repo = 创建了仓库 <a href="/%s">%s</a>
-commit_repo = 推送了 <a href="/%s/src/%s">%s</a> 分支的代码到 <a href="/%s">%s</a>
-create_issue = 创建了工单 <a href="/%s/issues/%s">%s#%s</a>
-comment_issue = 评论了工单 <a href="/%s/issues/%s">%s#%s</a>
+create_repo = 创建了仓库 <a href="%s/%s">%s</a>
+commit_repo = 推送了 <a href="%s/%s/src/%s">%s</a> 分支的代码到 <a href="%s/%s">%s</a>
+create_issue = 创建了工单 <a href="%s/%s/issues/%s">%s#%s</a>
+comment_issue = 评论了工单 <a href="%s/%s/issues/%s">%s#%s</a>
 
 [tool]
 ago = 之前

--- a/models/action.go
+++ b/models/action.go
@@ -137,7 +137,7 @@ func updateIssuesCommit(userId, repoId int64, repoUserName, repoName string, com
 				return err
 			}
 
-			url := fmt.Sprintf("/%s/%s/commit/%s", repoUserName, repoName, c.Sha1)
+			url := fmt.Sprintf("%s/%s/%s/commit/%s", setting.AppRootSubUrl, repoUserName, repoName, c.Sha1)
 			message := fmt.Sprintf(`<a href="%s">%s</a>`, url, c.Message)
 
 			if _, err = CreateComment(userId, issue.RepoId, issue.Id, 0, 0, COMMIT, message, nil); err != nil {

--- a/models/user.go
+++ b/models/user.go
@@ -82,14 +82,14 @@ type User struct {
 // DashboardLink returns the user dashboard page link.
 func (u *User) DashboardLink() string {
 	if u.IsOrganization() {
-		return "/org/" + u.Name + "/dashboard/"
+		return setting.AppRootSubUrl + "/org/" + u.Name + "/dashboard/"
 	}
-	return "/"
+	return setting.AppRootSubUrl + "/"
 }
 
 // HomeLink returns the user home page link.
 func (u *User) HomeLink() string {
-	return "/user/" + u.Name
+	return setting.AppRootSubUrl + "/user/" + u.Name
 }
 
 // AvatarLink returns user gravatar link.

--- a/modules/base/markdown.go
+++ b/modules/base/markdown.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/gogits/gfm"
+	"github.com/gogits/gogs/modules/setting"
 )
 
 func isletter(c byte) bool {
@@ -112,7 +113,7 @@ func RenderSpecialLink(rawBytes []byte, urlPrefix string) []byte {
 			ms := MentionPattern.FindAll(line, -1)
 			for _, m := range ms {
 				line = bytes.Replace(line, m,
-					[]byte(fmt.Sprintf(`<a href="/user/%s">%s</a>`, m[1:], m)), -1)
+					[]byte(fmt.Sprintf(`<a href="%s/user/%s">%s</a>`, setting.AppRootSubUrl, m[1:], m)), -1)
 			}
 		}
 

--- a/modules/base/template.go
+++ b/modules/base/template.go
@@ -82,6 +82,9 @@ var TemplateFuncs template.FuncMap = map[string]interface{}{
 	"AppName": func() string {
 		return setting.AppName
 	},
+	"AppRootSubUrl": func() string {
+		return setting.AppRootSubUrl
+	},
 	"AppVer": func() string {
 		return setting.AppVer
 	},
@@ -163,14 +166,14 @@ func ActionIcon(opType int) string {
 
 // TODO: Legacy
 const (
-	TPL_CREATE_REPO    = `<a href="/user/%s">%s</a> created repository <a href="/%s">%s</a>`
-	TPL_COMMIT_REPO    = `<a href="/user/%s">%s</a> pushed to <a href="/%s/src/%s">%s</a> at <a href="/%s">%s</a>%s`
-	TPL_COMMIT_REPO_LI = `<div><img src="%s?s=16" alt="user-avatar"/> <a href="/%s/commit/%s" rel="nofollow">%s</a> %s</div>`
-	TPL_CREATE_ISSUE   = `<a href="/user/%s">%s</a> opened issue <a href="/%s/issues/%s">%s#%s</a>
+	TPL_CREATE_REPO    = `<a href="%s/user/%s">%s</a> created repository <a href="%s">%s</a>`
+	TPL_COMMIT_REPO    = `<a href="%s/user/%s">%s</a> pushed to <a href="%s/src/%s">%s</a> at <a href="%s">%s</a>%s`
+	TPL_COMMIT_REPO_LI = `<div><img src="%s?s=16" alt="user-avatar"/> <a href="%s/commit/%s" rel="nofollow">%s</a> %s</div>`
+	TPL_CREATE_ISSUE   = `<a href="%s/user/%s">%s</a> opened issue <a href="%s/issues/%s">%s#%s</a>
 <div><img src="%s?s=16" alt="user-avatar"/> %s</div>`
-	TPL_TRANSFER_REPO = `<a href="/user/%s">%s</a> transfered repository <code>%s</code> to <a href="/%s">%s</a>`
-	TPL_PUSH_TAG      = `<a href="/user/%s">%s</a> pushed tag <a href="/%s/src/%s" rel="nofollow">%s</a> at <a href="/%s">%s</a>`
-	TPL_COMMENT_ISSUE = `<a href="/user/%s">%s</a> commented on issue <a href="/%s/issues/%s">%s#%s</a>
+	TPL_TRANSFER_REPO = `<a href="%s/user/%s">%s</a> transfered repository <code>%s</code> to <a href="%s">%s</a>`
+	TPL_PUSH_TAG      = `<a href="%s/user/%s">%s</a> pushed tag <a href="%s/src/%s" rel="nofollow">%s</a> at <a href="%s">%s</a>`
+	TPL_COMMENT_ISSUE = `<a href="%s/user/%s">%s</a> commented on issue <a href="%s/issues/%s">%s#%s</a>
 <div><img src="%s?s=16" alt="user-avatar"/> %s</div>`
 )
 
@@ -207,7 +210,7 @@ func ActionDesc(act Actioner) string {
 	content := act.GetContent()
 	switch act.GetOpType() {
 	case 1: // Create repository.
-		return fmt.Sprintf(TPL_CREATE_REPO, actUserName, actUserName, repoLink, repoName)
+		return fmt.Sprintf(TPL_CREATE_REPO, setting.AppRootSubUrl, actUserName, actUserName, repoLink, repoName)
 	case 5: // Commit repository.
 		var push *PushCommits
 		if err := json.Unmarshal([]byte(content), &push); err != nil {
@@ -218,22 +221,22 @@ func ActionDesc(act Actioner) string {
 			buf.WriteString(fmt.Sprintf(TPL_COMMIT_REPO_LI, AvatarLink(commit.AuthorEmail), repoLink, commit.Sha1, commit.Sha1[:7], commit.Message) + "\n")
 		}
 		if push.Len > 3 {
-			buf.WriteString(fmt.Sprintf(`<div><a href="/%s/%s/commits/%s" rel="nofollow">%d other commits >></a></div>`, actUserName, repoName, branch, push.Len))
+			buf.WriteString(fmt.Sprintf(`<div><a href="{{AppRootSubUrl}}/%s/%s/commits/%s" rel="nofollow">%d other commits >></a></div>`, actUserName, repoName, branch, push.Len))
 		}
-		return fmt.Sprintf(TPL_COMMIT_REPO, actUserName, actUserName, repoLink, branch, branch, repoLink, repoLink,
+		return fmt.Sprintf(TPL_COMMIT_REPO, setting.AppRootSubUrl, actUserName, actUserName, repoLink, branch, branch, repoLink, repoLink,
 			buf.String())
 	case 6: // Create issue.
 		infos := strings.SplitN(content, "|", 2)
-		return fmt.Sprintf(TPL_CREATE_ISSUE, actUserName, actUserName, repoLink, infos[0], repoLink, infos[0],
+		return fmt.Sprintf(TPL_CREATE_ISSUE, setting.AppRootSubUrl, actUserName, actUserName, repoLink, infos[0], repoLink, infos[0],
 			AvatarLink(email), infos[1])
 	case 8: // Transfer repository.
 		newRepoLink := content + "/" + repoName
-		return fmt.Sprintf(TPL_TRANSFER_REPO, actUserName, actUserName, repoLink, newRepoLink, newRepoLink)
+		return fmt.Sprintf(TPL_TRANSFER_REPO, setting.AppRootSubUrl, actUserName, actUserName, repoLink, newRepoLink, newRepoLink)
 	case 9: // Push tag.
-		return fmt.Sprintf(TPL_PUSH_TAG, actUserName, actUserName, repoLink, branch, branch, repoLink, repoLink)
+		return fmt.Sprintf(TPL_PUSH_TAG, setting.AppRootSubUrl, actUserName, actUserName, repoLink, branch, branch, repoLink, repoLink)
 	case 10: // Comment issue.
 		infos := strings.SplitN(content, "|", 2)
-		return fmt.Sprintf(TPL_COMMENT_ISSUE, actUserName, actUserName, repoLink, infos[0], repoLink, infos[0],
+		return fmt.Sprintf(TPL_COMMENT_ISSUE, setting.AppRootSubUrl, actUserName, actUserName, repoLink, infos[0], repoLink, infos[0],
 			AvatarLink(email), infos[1])
 	default:
 		return "invalid type"

--- a/modules/middleware/auth.go
+++ b/modules/middleware/auth.go
@@ -25,13 +25,13 @@ func Toggle(options *ToggleOptions) macaron.Handler {
 	return func(ctx *Context) {
 		// Cannot view any page before installation.
 		if !setting.InstallLock {
-			ctx.Redirect("/install")
+			ctx.Redirect(setting.AppRootSubUrl + "/install")
 			return
 		}
 
 		// Redirect to dashboard if user tries to visit any non-login page.
 		if options.SignOutRequire && ctx.IsSigned && ctx.Req.RequestURI != "/" {
-			ctx.Redirect("/")
+			ctx.Redirect(setting.AppRootSubUrl + "/")
 			return
 		}
 
@@ -48,8 +48,8 @@ func Toggle(options *ToggleOptions) macaron.Handler {
 				if strings.HasSuffix(ctx.Req.RequestURI, "watch") {
 					return
 				}
-				ctx.SetCookie("redirect_to", "/"+url.QueryEscape(ctx.Req.RequestURI))
-				ctx.Redirect("/user/login")
+				ctx.SetCookie("redirect_to", "/"+url.QueryEscape(setting.AppRootSubUrl + ctx.Req.RequestURI))
+				ctx.Redirect(setting.AppRootSubUrl + "/user/login")
 				return
 			} else if !ctx.User.IsActive && setting.Service.RegisterEmailConfirm {
 				ctx.Data["Title"] = ctx.Tr("auth.active_your_account")

--- a/modules/middleware/context.go
+++ b/modules/middleware/context.go
@@ -187,7 +187,7 @@ func Contexter() macaron.Handler {
 			Session: sess,
 		}
 		// Compute current URL for real-time change language.
-		link := ctx.Req.RequestURI
+		link := setting.AppRootSubUrl + ctx.Req.RequestURI
 		i := strings.Index(link, "?")
 		if i > -1 {
 			link = link[:i]

--- a/modules/middleware/org.go
+++ b/modules/middleware/org.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gogits/gogs/models"
 	"github.com/gogits/gogs/modules/log"
+	"github.com/gogits/gogs/modules/setting"
 )
 
 func OrgAssignment(redirect bool, args ...bool) macaron.Handler {
@@ -37,7 +38,7 @@ func OrgAssignment(redirect bool, args ...bool) macaron.Handler {
 				ctx.Handle(404, "GetUserByName", err)
 			} else if redirect {
 				log.Error(4, "GetUserByName", err)
-				ctx.Redirect("/")
+				ctx.Redirect(setting.AppRootSubUrl + "/")
 			} else {
 				ctx.Handle(500, "GetUserByName", err)
 			}
@@ -67,7 +68,7 @@ func OrgAssignment(redirect bool, args ...bool) macaron.Handler {
 		}
 		ctx.Data["IsOrganizationOwner"] = ctx.Org.IsOwner
 
-		ctx.Org.OrgLink = "/org/" + org.Name
+		ctx.Org.OrgLink = setting.AppRootSubUrl + "/org/" + org.Name
 		ctx.Data["OrgLink"] = ctx.Org.OrgLink
 
 		// Team.
@@ -79,7 +80,7 @@ func OrgAssignment(redirect bool, args ...bool) macaron.Handler {
 					ctx.Handle(404, "GetTeam", err)
 				} else if redirect {
 					log.Error(4, "GetTeam", err)
-					ctx.Redirect("/")
+					ctx.Redirect(setting.AppRootSubUrl + "/")
 				} else {
 					ctx.Handle(500, "GetTeam", err)
 				}

--- a/modules/middleware/repo.go
+++ b/modules/middleware/repo.go
@@ -60,7 +60,7 @@ func RepoAssignment(redirect bool, args ...bool) macaron.Handler {
 					ctx.Handle(404, "GetUserByName", err)
 				} else if redirect {
 					log.Error(4, "GetUserByName", err)
-					ctx.Redirect("/")
+					ctx.Redirect(setting.AppRootSubUrl + "/")
 				} else {
 					ctx.Handle(500, "GetUserByName", err)
 				}
@@ -72,7 +72,7 @@ func RepoAssignment(redirect bool, args ...bool) macaron.Handler {
 
 		if u == nil {
 			if redirect {
-				ctx.Redirect("/")
+				ctx.Redirect(setting.AppRootSubUrl + "/")
 				return
 			}
 			ctx.Handle(404, "RepoAssignment", errors.New("invliad user account for single repository"))
@@ -92,7 +92,7 @@ func RepoAssignment(redirect bool, args ...bool) macaron.Handler {
 				ctx.Handle(404, "GetRepositoryByName", err)
 				return
 			} else if redirect {
-				ctx.Redirect("/")
+				ctx.Redirect(setting.AppRootSubUrl + "/")
 				return
 			}
 			ctx.Handle(500, "GetRepositoryByName", err)
@@ -160,7 +160,7 @@ func RepoAssignment(redirect bool, args ...bool) macaron.Handler {
 			return
 		}
 		ctx.Repo.GitRepo = gitRepo
-		ctx.Repo.RepoLink = "/" + u.Name + "/" + repo.Name
+		ctx.Repo.RepoLink = setting.AppRootSubUrl + "/" + u.Name + "/" + repo.Name
 		ctx.Data["RepoLink"] = ctx.Repo.RepoLink
 
 		tags, err := ctx.Repo.GitRepo.GetTags()
@@ -298,8 +298,8 @@ func RequireTrueOwner() macaron.Handler {
 	return func(ctx *Context) {
 		if !ctx.Repo.IsTrueOwner && !ctx.Repo.IsAdmin {
 			if !ctx.IsSigned {
-				ctx.SetCookie("redirect_to", "/"+url.QueryEscape(ctx.Req.RequestURI))
-				ctx.Redirect("/user/login")
+				ctx.SetCookie("redirect_to", "/"+url.QueryEscape(setting.AppRootSubUrl + ctx.Req.RequestURI))
+				ctx.Redirect(setting.AppRootSubUrl + "/user/login")
 				return
 			}
 			ctx.Handle(404, ctx.Req.RequestURI, nil)

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -6,6 +6,7 @@ package setting
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"path"
@@ -31,9 +32,10 @@ const (
 
 var (
 	// App settings.
-	AppVer  string
-	AppName string
-	AppUrl  string
+	AppVer        string
+	AppName       string
+	AppUrl        string
+	AppRootSubUrl string
 
 	// Server settings.
 	Protocol           Scheme
@@ -164,6 +166,12 @@ func NewConfigContext() {
 	if AppUrl[len(AppUrl)-1] != '/' {
 		AppUrl += "/"
 	}
+
+	url, err := url.Parse(AppUrl)
+	if err != nil {
+		log.Fatal(4, "Invalid ROOT_URL %s: %s", AppUrl, err)
+	}
+	AppRootSubUrl = strings.TrimSuffix(url.Path, "/")
 
 	Protocol = HTTP
 	if Cfg.MustValue("server", "PROTOCOL") == "https" {

--- a/public/ng/js/gogs.js
+++ b/public/ng/js/gogs.js
@@ -202,7 +202,7 @@ var Gogs = {};
     // Search users by keyword.
     Gogs.searchUsers = function (val, $target) {
         $.ajax({
-            url: '/api/v1/users/search?q=' + val,
+            url: Gogs.AppRootSubUrl + '/api/v1/users/search?q=' + val,
             dataType: "json",
             success: function (json) {
                 if (json.ok && json.data.length) {
@@ -222,7 +222,7 @@ var Gogs = {};
     // Search repositories by keyword.
     Gogs.searchRepos = function (val, $target, $param) {
         $.ajax({
-            url: '/api/v1/repos/search?q=' + val + '&' + $param,
+            url: Gogs.AppRootSubUrl + '/api/v1/repos/search?q=' + val + '&' + $param,
             dataType: "json",
             success: function (json) {
                 if (json.ok && json.data.length) {
@@ -245,7 +245,7 @@ var Gogs = {};
             return;
         }
         $(selector).zclip({
-            path: "/js/ZeroClipboard.swf",
+            path: Gogs.AppRootSubUrl + "/js/ZeroClipboard.swf",
             copy: function () {
                 var t = $(this).data("copy-val");
                 var to = $($(this).data("copy-from"));
@@ -592,6 +592,7 @@ function initInstall() {
 }
 
 $(document).ready(function () {
+	Gogs.AppRootSubUrl = $('head').data('suburl');
     initCore();
     if ($('#user-profile-setting').length) {
         initUserSetting();
@@ -644,7 +645,7 @@ function homepage() {
     $('#promo-form').submit(function (e) {
         if ($('#username').val() === "") {
             e.preventDefault();
-            window.location.href = '/user/login';
+            window.location.href = Gogs.AppRootSubUrl + '/user/login';
             return true
         }
     });
@@ -652,9 +653,9 @@ function homepage() {
     $('#register-button').click(function (e) {
         if ($('#username').val() === "") {
             e.preventDefault();
-            window.location.href = '/user/sign_up';
+            window.location.href = Gogs.AppRootSubUrl + '/user/sign_up';
             return true
         }
-        $('#promo-form').attr('action', '/user/sign_up');
+        $('#promo-form').attr('action', Gogs.AppRootSubUrl + '/user/sign_up');
     });
 }

--- a/routers/admin/admin.go
+++ b/routers/admin/admin.go
@@ -143,7 +143,7 @@ func Dashboard(ctx *middleware.Context) {
 		} else {
 			ctx.Flash.Success(success)
 		}
-		ctx.Redirect("/admin")
+		ctx.Redirect(setting.AppRootSubUrl + "/admin")
 		return
 	}
 

--- a/routers/admin/auths.go
+++ b/routers/admin/auths.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gogits/gogs/modules/base"
 	"github.com/gogits/gogs/modules/log"
 	"github.com/gogits/gogs/modules/middleware"
+	"github.com/gogits/gogs/modules/setting"
 )
 
 const (
@@ -99,7 +100,7 @@ func NewAuthSourcePost(ctx *middleware.Context, form auth.AuthenticationForm) {
 	}
 
 	log.Trace("Authentication created by admin(%s): %s", ctx.User.Name, form.AuthName)
-	ctx.Redirect("/admin/auths")
+	ctx.Redirect(setting.AppRootSubUrl + "/admin/auths")
 }
 
 func EditAuthSource(ctx *middleware.Context) {
@@ -180,7 +181,7 @@ func EditAuthSourcePost(ctx *middleware.Context, form auth.AuthenticationForm) {
 
 	log.Trace("Authentication changed by admin(%s): %s", ctx.User.Name, form.AuthName)
 	ctx.Flash.Success(ctx.Tr("admin.auths.update_success"))
-	ctx.Redirect("/admin/auths/" + ctx.Params(":authid"))
+	ctx.Redirect(setting.AppRootSubUrl + "/admin/auths/" + ctx.Params(":authid"))
 }
 
 func DeleteAuthSource(ctx *middleware.Context) {
@@ -200,12 +201,12 @@ func DeleteAuthSource(ctx *middleware.Context) {
 		switch err {
 		case models.ErrAuthenticationUserUsed:
 			ctx.Flash.Error("form.still_own_user")
-			ctx.Redirect("/admin/auths/" + ctx.Params(":authid"))
+			ctx.Redirect(setting.AppRootSubUrl + "/admin/auths/" + ctx.Params(":authid"))
 		default:
 			ctx.Handle(500, "DelLoginSource", err)
 		}
 		return
 	}
 	log.Trace("Authentication deleted by admin(%s): %s", ctx.User.Name, a.Name)
-	ctx.Redirect("/admin/auths")
+	ctx.Redirect(setting.AppRootSubUrl + "/admin/auths")
 }

--- a/routers/admin/users.go
+++ b/routers/admin/users.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gogits/gogs/modules/base"
 	"github.com/gogits/gogs/modules/log"
 	"github.com/gogits/gogs/modules/middleware"
+	"github.com/gogits/gogs/modules/setting"
 )
 
 const (
@@ -120,7 +121,7 @@ func NewUserPost(ctx *middleware.Context, form auth.RegisterForm) {
 		return
 	}
 	log.Trace("Account created by admin(%s): %s", ctx.User.Name, u.Name)
-	ctx.Redirect("/admin/users")
+	ctx.Redirect(setting.AppRootSubUrl + "/admin/users")
 }
 
 func EditUser(ctx *middleware.Context) {
@@ -197,7 +198,7 @@ func EditUserPost(ctx *middleware.Context, form auth.AdminEditUserForm) {
 
 	ctx.Data["User"] = u
 	ctx.Flash.Success(ctx.Tr("admin.users.update_profile_success"))
-	ctx.Redirect("/admin/users/" + ctx.Params(":userid"))
+	ctx.Redirect(setting.AppRootSubUrl + "/admin/users/" + ctx.Params(":userid"))
 }
 
 func DeleteUser(ctx *middleware.Context) {
@@ -217,12 +218,12 @@ func DeleteUser(ctx *middleware.Context) {
 		switch err {
 		case models.ErrUserOwnRepos:
 			ctx.Flash.Error(ctx.Tr("admin.users.still_own_repo"))
-			ctx.Redirect("/admin/users/" + ctx.Params(":userid"))
+			ctx.Redirect(setting.AppRootSubUrl + "/admin/users/" + ctx.Params(":userid"))
 		default:
 			ctx.Handle(500, "DeleteUser", err)
 		}
 		return
 	}
 	log.Trace("Account deleted by admin(%s): %s", ctx.User.Name, u.Name)
-	ctx.Redirect("/admin/users")
+	ctx.Redirect(setting.AppRootSubUrl + "/admin/users")
 }

--- a/routers/home.go
+++ b/routers/home.go
@@ -33,7 +33,7 @@ func Home(ctx *middleware.Context) {
 	// Check auto-login.
 	uname := ctx.GetCookie(setting.CookieUserName)
 	if len(uname) != 0 {
-		ctx.Redirect("/user/login")
+		ctx.Redirect(setting.AppRootSubUrl + "/user/login")
 		return
 	}
 

--- a/routers/install.go
+++ b/routers/install.go
@@ -253,5 +253,5 @@ func InstallPost(ctx *middleware.Context, form auth.InstallForm) {
 
 	log.Info("First-time run install finished!")
 	ctx.Flash.Success(ctx.Tr("install.install_success"))
-	ctx.Redirect("/user/login")
+	ctx.Redirect(setting.AppRootSubUrl + "/user/login")
 }

--- a/routers/org/members.go
+++ b/routers/org/members.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gogits/gogs/modules/base"
 	"github.com/gogits/gogs/modules/log"
 	"github.com/gogits/gogs/modules/middleware"
+	"github.com/gogits/gogs/modules/setting"
 )
 
 const (
@@ -86,7 +87,7 @@ func MembersAction(ctx *middleware.Context) {
 	if ctx.Params(":action") != "leave" {
 		ctx.Redirect(ctx.Org.OrgLink + "/members")
 	} else {
-		ctx.Redirect("/")
+		ctx.Redirect(setting.AppRootSubUrl + "/")
 	}
 }
 

--- a/routers/org/org.go
+++ b/routers/org/org.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gogits/gogs/modules/base"
 	"github.com/gogits/gogs/modules/log"
 	"github.com/gogits/gogs/modules/middleware"
+	"github.com/gogits/gogs/modules/setting"
 )
 
 const (
@@ -82,5 +83,5 @@ func CreatePost(ctx *middleware.Context, form auth.CreateOrgForm) {
 	}
 	log.Trace("Organization created: %s", org.Name)
 
-	ctx.Redirect("/org/" + form.OrgName + "/dashboard")
+	ctx.Redirect(setting.AppRootSubUrl + "/org/" + form.OrgName + "/dashboard")
 }

--- a/routers/org/setting.go
+++ b/routers/org/setting.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gogits/gogs/modules/base"
 	"github.com/gogits/gogs/modules/log"
 	"github.com/gogits/gogs/modules/middleware"
+	"github.com/gogits/gogs/modules/setting"
 )
 
 const (
@@ -48,7 +49,7 @@ func SettingsPost(ctx *middleware.Context, form auth.UpdateOrgSettingForm) {
 		} else if err = models.ChangeUserName(org, form.OrgUserName); err != nil {
 			if err == models.ErrUserNameIllegal {
 				ctx.Flash.Error(ctx.Tr("form.illegal_username"))
-				ctx.Redirect("/org/" + org.LowerName + "/settings")
+				ctx.Redirect(setting.AppRootSubUrl + "/org/" + org.LowerName + "/settings")
 				return
 			} else {
 				ctx.Handle(500, "ChangeUserName", err)
@@ -72,7 +73,7 @@ func SettingsPost(ctx *middleware.Context, form auth.UpdateOrgSettingForm) {
 	}
 	log.Trace("Organization setting updated: %s", org.Name)
 	ctx.Flash.Success(ctx.Tr("org.settings.update_setting_success"))
-	ctx.Redirect("/org/" + org.Name + "/settings")
+	ctx.Redirect(setting.AppRootSubUrl + "/org/" + org.Name + "/settings")
 }
 
 func SettingsDelete(ctx *middleware.Context) {
@@ -86,13 +87,13 @@ func SettingsDelete(ctx *middleware.Context) {
 			switch err {
 			case models.ErrUserOwnRepos:
 				ctx.Flash.Error(ctx.Tr("form.org_still_own_repo"))
-				ctx.Redirect("/org/" + org.LowerName + "/settings/delete")
+				ctx.Redirect(setting.AppRootSubUrl + "/org/" + org.LowerName + "/settings/delete")
 			default:
 				ctx.Handle(500, "DeleteOrganization", err)
 			}
 		} else {
 			log.Trace("Organization deleted: %s", ctx.User.Name)
-			ctx.Redirect("/")
+			ctx.Redirect(setting.AppRootSubUrl + "/")
 		}
 		return
 	}

--- a/routers/repo/commit.go
+++ b/routers/repo/commit.go
@@ -159,8 +159,8 @@ func Diff(ctx *middleware.Context) {
 	ctx.Data["Diff"] = diff
 	ctx.Data["Parents"] = parents
 	ctx.Data["DiffNotAvailable"] = diff.NumFiles() == 0
-	ctx.Data["SourcePath"] = "/" + path.Join(userName, repoName, "src", commitId)
-	ctx.Data["RawPath"] = "/" + path.Join(userName, repoName, "raw", commitId)
+	ctx.Data["SourcePath"] = setting.AppRootSubUrl + "/" + path.Join(userName, repoName, "src", commitId)
+	ctx.Data["RawPath"] = setting.AppRootSubUrl + "/" + path.Join(userName, repoName, "raw", commitId)
 	ctx.HTML(200, DIFF)
 }
 

--- a/routers/repo/issue.go
+++ b/routers/repo/issue.go
@@ -54,8 +54,8 @@ func Issues(ctx *middleware.Context) {
 	isShowClosed := ctx.Query("state") == "closed"
 
 	if viewType != "all" && !ctx.IsSigned {
-		ctx.SetCookie("redirect_to", "/"+url.QueryEscape(ctx.Req.RequestURI))
-		ctx.Redirect("/user/login")
+		ctx.SetCookie("redirect_to", "/"+url.QueryEscape(setting.AppRootSubUrl + ctx.Req.RequestURI))
+		ctx.Redirect(setting.AppRootSubUrl + "/user/login")
 		return
 	}
 
@@ -312,7 +312,7 @@ func CreateIssuePost(ctx *middleware.Context, form auth.CreateIssueForm) {
 	}
 	log.Trace("%d Issue created: %d", ctx.Repo.Repository.Id, issue.Id)
 
-	send(200, fmt.Sprintf("/%s/%s/issues/%d", ctx.Params(":username"), ctx.Params(":reponame"), issue.Index), nil)
+	send(200, fmt.Sprintf("%s/%s/%s/issues/%d", setting.AppRootSubUrl, ctx.Params(":username"), ctx.Params(":reponame"), issue.Index), nil)
 }
 
 func checkLabels(labels, allLabels []*models.Label) {

--- a/routers/repo/repo.go
+++ b/routers/repo/repo.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gogits/gogs/modules/git"
 	"github.com/gogits/gogs/modules/log"
 	"github.com/gogits/gogs/modules/middleware"
+	"github.com/gogits/gogs/modules/setting"
 )
 
 const (
@@ -95,7 +96,7 @@ func CreatePost(ctx *middleware.Context, form auth.CreateRepoForm) {
 		form.Gitignore, form.License, form.Private, false, form.InitReadme)
 	if err == nil {
 		log.Trace("Repository created: %s/%s", ctxUser.Name, form.RepoName)
-		ctx.Redirect("/" + ctxUser.Name + "/" + form.RepoName)
+		ctx.Redirect(setting.AppRootSubUrl + "/" + ctxUser.Name + "/" + form.RepoName)
 		return
 	} else if err == models.ErrRepoAlreadyExist {
 		ctx.Data["Err_RepoName"] = true
@@ -179,7 +180,7 @@ func MigratePost(ctx *middleware.Context, form auth.MigrateRepoForm) {
 		form.Mirror, url)
 	if err == nil {
 		log.Trace("Repository migrated: %s/%s", ctxUser.Name, form.RepoName)
-		ctx.Redirect("/" + ctxUser.Name + "/" + form.RepoName)
+		ctx.Redirect(setting.AppRootSubUrl + "/" + ctxUser.Name + "/" + form.RepoName)
 		return
 	} else if err == models.ErrRepoAlreadyExist {
 		ctx.Data["Err_RepoName"] = true

--- a/routers/repo/setting.go
+++ b/routers/repo/setting.go
@@ -97,7 +97,7 @@ func SettingsPost(ctx *middleware.Context, form auth.RepoSettingForm) {
 		}
 
 		ctx.Flash.Success(ctx.Tr("repo.settings.update_settings_success"))
-		ctx.Redirect(fmt.Sprintf("/%s/%s/settings", ctx.Repo.Owner.Name, ctx.Repo.Repository.Name))
+		ctx.Redirect(fmt.Sprintf("%s/%s/%s/settings", setting.AppRootSubUrl, ctx.Repo.Owner.Name, ctx.Repo.Repository.Name))
 	case "transfer":
 		if ctx.Repo.Repository.Name != form.RepoName {
 			ctx.RenderWithErr(ctx.Tr("form.enterred_invalid_repo_name"), SETTINGS_OPTIONS, nil)
@@ -122,7 +122,7 @@ func SettingsPost(ctx *middleware.Context, form auth.RepoSettingForm) {
 		}
 		log.Trace("Repository transfered: %s/%s -> %s", ctx.Repo.Owner.Name, ctx.Repo.Repository.Name, newOwner)
 		ctx.Flash.Success(ctx.Tr("repo.settings.transfer_succeed"))
-		ctx.Redirect("/")
+		ctx.Redirect(setting.AppRootSubUrl + "/")
 	case "delete":
 		if ctx.Repo.Repository.Name != form.RepoName {
 			ctx.RenderWithErr(ctx.Tr("form.enterred_invalid_repo_name"), SETTINGS_OPTIONS, nil)
@@ -151,9 +151,9 @@ func SettingsPost(ctx *middleware.Context, form auth.RepoSettingForm) {
 		}
 		log.Trace("Repository deleted: %s/%s", ctx.Repo.Owner.Name, ctx.Repo.Repository.Name)
 		if ctx.Repo.Owner.IsOrganization() {
-			ctx.Redirect("/org/" + ctx.Repo.Owner.Name + "/dashboard")
+			ctx.Redirect(setting.AppRootSubUrl + "/org/" + ctx.Repo.Owner.Name + "/dashboard")
 		} else {
-			ctx.Redirect("/")
+			ctx.Redirect(setting.AppRootSubUrl + "/")
 		}
 	}
 }
@@ -167,7 +167,7 @@ func SettingsCollaboration(ctx *middleware.Context) {
 	if ctx.Req.Method == "POST" {
 		name := strings.ToLower(ctx.Query("collaborator"))
 		if len(name) == 0 || ctx.Repo.Owner.LowerName == name {
-			ctx.Redirect(ctx.Req.URL.Path)
+			ctx.Redirect(setting.AppRootSubUrl + ctx.Req.URL.Path)
 			return
 		}
 		has, err := models.HasAccess(name, repoLink, models.WRITABLE)
@@ -175,7 +175,7 @@ func SettingsCollaboration(ctx *middleware.Context) {
 			ctx.Handle(500, "HasAccess", err)
 			return
 		} else if has {
-			ctx.Redirect(ctx.Req.URL.Path)
+			ctx.Redirect(setting.AppRootSubUrl + ctx.Req.URL.Path)
 			return
 		}
 
@@ -183,7 +183,7 @@ func SettingsCollaboration(ctx *middleware.Context) {
 		if err != nil {
 			if err == models.ErrUserNotExist {
 				ctx.Flash.Error(ctx.Tr("form.user_not_exist"))
-				ctx.Redirect(ctx.Req.URL.Path)
+				ctx.Redirect(setting.AppRootSubUrl + ctx.Req.URL.Path)
 			} else {
 				ctx.Handle(500, "GetUserByName", err)
 			}
@@ -204,7 +204,7 @@ func SettingsCollaboration(ctx *middleware.Context) {
 		}
 
 		ctx.Flash.Success(ctx.Tr("repo.settings.add_collaborator_success"))
-		ctx.Redirect(ctx.Req.URL.Path)
+		ctx.Redirect(setting.AppRootSubUrl + ctx.Req.URL.Path)
 		return
 	}
 

--- a/routers/user/auth.go
+++ b/routers/user/auth.go
@@ -82,7 +82,7 @@ func SignIn(ctx *middleware.Context) {
 		return
 	}
 
-	ctx.Redirect("/")
+	ctx.Redirect(setting.AppRootSubUrl + "/")
 }
 
 func SignInPost(ctx *middleware.Context, form auth.SignInForm) {
@@ -140,7 +140,7 @@ func SignInPost(ctx *middleware.Context, form auth.SignInForm) {
 		return
 	}
 
-	ctx.Redirect("/")
+	ctx.Redirect(setting.AppRootSubUrl + "/")
 }
 
 func SignOut(ctx *middleware.Context) {
@@ -151,7 +151,7 @@ func SignOut(ctx *middleware.Context) {
 	ctx.Session.Delete("socialEmail")
 	ctx.SetCookie(setting.CookieUserName, "", -1)
 	ctx.SetCookie(setting.CookieRememberName, "", -1)
-	ctx.Redirect("/")
+	ctx.Redirect(setting.AppRootSubUrl + "/")
 }
 
 func oauthSignUp(ctx *middleware.Context, sid int64) {
@@ -288,7 +288,7 @@ func SignUpPost(ctx *middleware.Context, cpt *captcha.Captcha, form auth.Registe
 		return
 	}
 
-	ctx.Redirect("/user/login")
+	ctx.Redirect(setting.AppRootSubUrl + "/user/login")
 }
 
 func Activate(ctx *middleware.Context) {
@@ -335,7 +335,7 @@ func Activate(ctx *middleware.Context) {
 
 		ctx.Session.Set("uid", user.Id)
 		ctx.Session.Set("uname", user.Name)
-		ctx.Redirect("/")
+		ctx.Redirect(setting.AppRootSubUrl + "/")
 		return
 	}
 
@@ -437,7 +437,7 @@ func ResetPasswdPost(ctx *middleware.Context) {
 		}
 
 		log.Trace("User password reset: %s", u.Name)
-		ctx.Redirect("/user/login")
+		ctx.Redirect(setting.AppRootSubUrl + "/user/login")
 		return
 	}
 

--- a/routers/user/home.go
+++ b/routers/user/home.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gogits/gogs/modules/base"
 	"github.com/gogits/gogs/modules/log"
 	"github.com/gogits/gogs/modules/middleware"
+	"github.com/gogits/gogs/modules/setting"
 )
 
 const (
@@ -126,7 +127,7 @@ func Profile(ctx *middleware.Context) {
 	uname := ctx.Params(":username")
 	// Special handle for FireFox requests favicon.ico.
 	if uname == "favicon.ico" {
-		ctx.Redirect("/img/favicon.png")
+		ctx.Redirect(setting.AppRootSubUrl + "/img/favicon.png")
 		return
 	}
 
@@ -141,7 +142,7 @@ func Profile(ctx *middleware.Context) {
 	}
 
 	if u.IsOrganization() {
-		ctx.Redirect("/org/" + u.Name)
+		ctx.Redirect(setting.AppRootSubUrl + "/org/" + u.Name)
 		return
 	}
 
@@ -181,7 +182,7 @@ func Email2User(ctx *middleware.Context) {
 		}
 		return
 	}
-	ctx.Redirect("/user/" + u.Name)
+	ctx.Redirect(setting.AppRootSubUrl + "/user/" + u.Name)
 }
 
 const (

--- a/routers/user/setting.go
+++ b/routers/user/setting.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gogits/gogs/modules/base"
 	"github.com/gogits/gogs/modules/log"
 	"github.com/gogits/gogs/modules/middleware"
+	"github.com/gogits/gogs/modules/setting"
 )
 
 const (
@@ -55,7 +56,7 @@ func SettingsPost(ctx *middleware.Context, form auth.UpdateProfileForm) {
 		} else if err = models.ChangeUserName(ctx.User, form.UserName); err != nil {
 			if err == models.ErrUserNameIllegal {
 				ctx.Flash.Error(ctx.Tr("form.illegal_username"))
-				ctx.Redirect("/user/settings")
+				ctx.Redirect(setting.AppRootSubUrl + "/user/settings")
 				return
 			} else {
 				ctx.Handle(500, "ChangeUserName", err)
@@ -78,7 +79,7 @@ func SettingsPost(ctx *middleware.Context, form auth.UpdateProfileForm) {
 	}
 	log.Trace("User setting updated: %s", ctx.User.Name)
 	ctx.Flash.Success(ctx.Tr("settings.update_profile_success"))
-	ctx.Redirect("/user/settings")
+	ctx.Redirect(setting.AppRootSubUrl + "/user/settings")
 }
 
 func SettingsPassword(ctx *middleware.Context) {
@@ -119,7 +120,7 @@ func SettingsPasswordPost(ctx *middleware.Context, form auth.ChangePasswordForm)
 		ctx.Flash.Success(ctx.Tr("settings.change_password_success"))
 	}
 
-	ctx.Redirect("/user/settings/password")
+	ctx.Redirect(setting.AppRootSubUrl + "/user/settings/password")
 }
 
 func SettingsSSHKeys(ctx *middleware.Context) {
@@ -160,7 +161,7 @@ func SettingsSSHKeysPost(ctx *middleware.Context, form auth.AddSSHKeyForm) {
 			ctx.Handle(500, "DeletePublicKey", err)
 		} else {
 			log.Trace("SSH key deleted: %s", ctx.User.Name)
-			ctx.Redirect("/user/settings/ssh")
+			ctx.Redirect(setting.AppRootSubUrl + "/user/settings/ssh")
 		}
 		return
 	}
@@ -177,7 +178,7 @@ func SettingsSSHKeysPost(ctx *middleware.Context, form auth.AddSSHKeyForm) {
 
 		if ok, err := models.CheckPublicKeyString(cleanContent); !ok {
 			ctx.Flash.Error(ctx.Tr("form.invalid_ssh_key", err.Error()))
-			ctx.Redirect("/user/settings/ssh")
+			ctx.Redirect(setting.AppRootSubUrl + "/user/settings/ssh")
 			return
 		}
 
@@ -196,7 +197,7 @@ func SettingsSSHKeysPost(ctx *middleware.Context, form auth.AddSSHKeyForm) {
 		} else {
 			log.Trace("SSH key added: %s", ctx.User.Name)
 			ctx.Flash.Success(ctx.Tr("settings.add_key_success"))
-			ctx.Redirect("/user/settings/ssh")
+			ctx.Redirect(setting.AppRootSubUrl + "/user/settings/ssh")
 			return
 		}
 	}
@@ -217,7 +218,7 @@ func SettingsSocial(ctx *middleware.Context) {
 			return
 		}
 		ctx.Flash.Success(ctx.Tr("settings.unbind_success"))
-		ctx.Redirect("/user/settings/social")
+		ctx.Redirect(setting.AppRootSubUrl + "/user/settings/social")
 		return
 	}
 
@@ -248,13 +249,13 @@ func SettingsDelete(ctx *middleware.Context) {
 			switch err {
 			case models.ErrUserOwnRepos:
 				ctx.Flash.Error(ctx.Tr("form.still_own_repo"))
-				ctx.Redirect("/user/settings/delete")
+				ctx.Redirect(setting.AppRootSubUrl + "/user/settings/delete")
 			default:
 				ctx.Handle(500, "DeleteUser", err)
 			}
 		} else {
 			log.Trace("Account deleted: %s", ctx.User.Name)
-			ctx.Redirect("/")
+			ctx.Redirect(setting.AppRootSubUrl + "/")
 		}
 		return
 	}

--- a/routers/user/social.go
+++ b/routers/user/social.go
@@ -22,7 +22,7 @@ import (
 func extractPath(next string) string {
 	n, err := url.Parse(next)
 	if err != nil {
-		return "/"
+		return setting.AppRootSubUrl + "/"
 	}
 	return n.Path
 }
@@ -88,7 +88,7 @@ func SocialSignIn(ctx *middleware.Context) {
 			return
 		}
 	case models.ErrOauth2NotAssociated:
-		next = "/user/sign_up"
+		next = setting.AppRootSubUrl + "/user/sign_up"
 	default:
 		ctx.Handle(500, "social.SocialSignIn(GetOauth2)", err)
 		return

--- a/templates/admin/auth/edit.tmpl
+++ b/templates/admin/auth/edit.tmpl
@@ -12,7 +12,7 @@
                             <div class="panel-header">
                                 <strong>{{.i18n.Tr "admin.auths.edit"}}</strong>
                             </div>
-                            <form class="form form-align panel-body" id="auth-setting-form" action="/admin/auths/{{.Source.Id}}" data-delete-url="/admin/auths/{{.Source.Id}}/delete" method="post">
+                            <form class="form form-align panel-body" id="auth-setting-form" action="{{AppRootSubUrl}}/admin/auths/{{.Source.Id}}" data-delete-url="/admin/auths/{{.Source.Id}}/delete" method="post">
                                 {{.CsrfTokenHtml}}
                                 <input type="hidden" value="{{.Source.Id}}" name="id"/>
                                 {{$type := .Source.Type}}

--- a/templates/admin/auth/list.tmpl
+++ b/templates/admin/auth/list.tmpl
@@ -13,7 +13,7 @@
                                 <strong>{{.i18n.Tr "admin.auths.auth_manage_panel"}}</strong>
                             </div>
                             <div class="panel-body admin-panel">
-								<a class="btn-blue btn-medium btn-link btn-radius" href="/admin/auths/new">{{.i18n.Tr "admin.auths.new"}}</a>
+								<a class="btn-blue btn-medium btn-link btn-radius" href="{{AppRootSubUrl}}/admin/auths/new">{{.i18n.Tr "admin.auths.new"}}</a>
                                 <div class="admin-table">
 					                <table class="table table-striped">
 					                    <thead>
@@ -31,20 +31,20 @@
 					                        {{range .Sources}}
 					                        <tr>
 					                            <td>{{.Id}}</td>
-					                            <td><a href="/admin/auths/{{.Id}}">{{.Name}}</a></td>
+					                            <td><a href="{{AppRootSubUrl}}/admin/auths/{{.Id}}">{{.Name}}</a></td>
 					                            <td>{{.TypeString}}</td>
 					                            <td><i class="fa fa{{if .IsActived}}-check{{end}}-square-o"></i></td>
 					                            <td>{{DateFormat .Updated "M d, Y"}}</td>
 					                            <td>{{DateFormat .Created "M d, Y"}}</td>
-					                            <td><a href="/admin/auths/{{.Id}}"><i class="fa fa-pencil-square-o"></i></a></td>
+					                            <td><a href="{{AppRootSubUrl}}/admin/auths/{{.Id}}"><i class="fa fa-pencil-square-o"></i></a></td>
 					                        </tr>
 					                        {{end}}
 					                    </tbody>
 					                </table>
 					                {{if or .LastPageNum .NextPageNum}}
 					                <ul class="pagination">
-					                    {{if .LastPageNum}}<li><a class="btn btn-medium btn-gray btn-radius" href="/admin/auths?p={{.LastPageNum}}">&laquo; Prev.</a></li>{{end}}
-					                    {{if .NextPageNum}}<li><a class="btn btn-medium btn-gray btn-radius" href="/admin/auths?p={{.NextPageNum}}">&raquo; Next</a></li>{{end}}
+					                    {{if .LastPageNum}}<li><a class="btn btn-medium btn-gray btn-radius" href="{{AppRootSubUrl}}/admin/auths?p={{.LastPageNum}}">&laquo; Prev.</a></li>{{end}}
+					                    {{if .NextPageNum}}<li><a class="btn btn-medium btn-gray btn-radius" href="{{AppRootSubUrl}}/admin/auths?p={{.NextPageNum}}">&raquo; Next</a></li>{{end}}
 					                </ul>
 					                {{end}}
 				                </div>

--- a/templates/admin/auth/new.tmpl
+++ b/templates/admin/auth/new.tmpl
@@ -12,7 +12,7 @@
                             <div class="panel-header">
                                 <strong>{{.i18n.Tr "admin.auths.new"}}</strong>
                             </div>
-                            <form class="form form-align panel-body" id="repo-setting-form" action="/admin/auths/new" method="post">
+                            <form class="form form-align panel-body" id="repo-setting-form" action="{{AppRootSubUrl}}/admin/auths/new" method="post">
                                 {{.CsrfTokenHtml}}
                                 <div class="field">
                                     <label class="req">{{.i18n.Tr "admin.auths.auth_type"}}</label>

--- a/templates/admin/dashboard.tmpl
+++ b/templates/admin/dashboard.tmpl
@@ -34,11 +34,11 @@
                                         <tbody>
                                             <tr>
                                                 <td>{{.i18n.Tr "admin.dashboard.clean_unbind_oauth"}}</td>
-                                                <td><i class="fa fa-caret-square-o-right"></i> <a href="/admin?op=1">{{.i18n.Tr "admin.dashboard.operation_run"}}</a></td>
+                                                <td><i class="fa fa-caret-square-o-right"></i> <a href="{{AppRootSubUrl}}/admin?op=1">{{.i18n.Tr "admin.dashboard.operation_run"}}</a></td>
                                             </tr>
                                             <tr>
                                                 <td>{{.i18n.Tr "admin.dashboard.delete_inactivate_accounts"}}</td>
-                                                <td><i class="fa fa-caret-square-o-right"></i> <a href="/admin?op=2">{{.i18n.Tr "admin.dashboard.operation_run"}}</a></td>
+                                                <td><i class="fa fa-caret-square-o-right"></i> <a href="{{AppRootSubUrl}}/admin?op=2">{{.i18n.Tr "admin.dashboard.operation_run"}}</a></td>
                                             </tr>
                                         </tbody>
                                     </table>

--- a/templates/admin/nav.tmpl
+++ b/templates/admin/nav.tmpl
@@ -2,13 +2,13 @@
     <p class="panel-header"><strong>{{.i18n.Tr "admin_panel"}}</strong></p>
     <div class="panel-body">
         <ul class="menu menu-vertical switching-list grid-1-5 left">
-            <li {{if .PageIsAdminDashboard}}class="current"{{end}}><a href="/admin">{{.i18n.Tr "admin.dashboard"}}</a></li>
-            <li {{if .PageIsAdminUsers}}class="current"{{end}}><a href="/admin/users">{{.i18n.Tr "admin.users"}}</a></li>
-            <li {{if .PageIsAdminOrganizations}}class="current"{{end}}><a href="/admin/orgs">{{.i18n.Tr "admin.organizations"}}</a></li>
-            <li {{if .PageIsAdminRepositories}}class="current"{{end}}><a href="/admin/repos">{{.i18n.Tr "admin.repositories"}}</a></li>
-            <li {{if .PageIsAdminAuthentications}}class="current"{{end}}><a href="/admin/auths">{{.i18n.Tr "admin.authentication"}}</a></li>
-            <li {{if .PageIsAdminConfig}}class="current"{{end}}><a href="/admin/config">{{.i18n.Tr "admin.config"}}</a></li>
-            <li {{if .PageIsAdminMonitor}}class="current"{{end}}><a href="/admin/monitor">{{.i18n.Tr "admin.monitor"}}</a></li>
+            <li {{if .PageIsAdminDashboard}}class="current"{{end}}><a href="{{AppRootSubUrl}}/admin">{{.i18n.Tr "admin.dashboard"}}</a></li>
+            <li {{if .PageIsAdminUsers}}class="current"{{end}}><a href="{{AppRootSubUrl}}/admin/users">{{.i18n.Tr "admin.users"}}</a></li>
+            <li {{if .PageIsAdminOrganizations}}class="current"{{end}}><a href="{{AppRootSubUrl}}/admin/orgs">{{.i18n.Tr "admin.organizations"}}</a></li>
+            <li {{if .PageIsAdminRepositories}}class="current"{{end}}><a href="{{AppRootSubUrl}}/admin/repos">{{.i18n.Tr "admin.repositories"}}</a></li>
+            <li {{if .PageIsAdminAuthentications}}class="current"{{end}}><a href="{{AppRootSubUrl}}/admin/auths">{{.i18n.Tr "admin.authentication"}}</a></li>
+            <li {{if .PageIsAdminConfig}}class="current"{{end}}><a href="{{AppRootSubUrl}}/admin/config">{{.i18n.Tr "admin.config"}}</a></li>
+            <li {{if .PageIsAdminMonitor}}class="current"{{end}}><a href="{{AppRootSubUrl}}/admin/monitor">{{.i18n.Tr "admin.monitor"}}</a></li>
         </ul>
     </div>
 </div>

--- a/templates/admin/org/list.tmpl
+++ b/templates/admin/org/list.tmpl
@@ -30,7 +30,7 @@
 					                        {{range .Orgs}}
 					                        <tr>
 					                            <td>{{.Id}}</td>
-					                            <td><a href="/org/{{.Name}}">{{.Name}}</a></td>
+					                            <td><a href="{{AppRootSubUrl}}/org/{{.Name}}">{{.Name}}</a></td>
 					                            <td>{{.Email}}</td>
 					                            <td>{{.NumTeams}}</td>
 					                            <td>{{.NumMembers}}</td>
@@ -42,8 +42,8 @@
 					                </table>
 					                {{if or .LastPageNum .NextPageNum}}
 					                <ul class="pagination">
-					                    {{if .LastPageNum}}<li><a class="btn btn-medium btn-gray btn-radius" href="/admin/orgs?p={{.LastPageNum}}">&laquo; {{.i18n.Tr "admin.prev"}}</a></li>{{end}}
-					                    {{if .NextPageNum}}<li><a class="btn btn-medium btn-gray btn-radius" href="/admin/orgs?p={{.NextPageNum}}">&raquo; {{.i18n.Tr "admin.next"}}</a></li>{{end}}
+					                    {{if .LastPageNum}}<li><a class="btn btn-medium btn-gray btn-radius" href="{{AppRootSubUrl}}/admin/orgs?p={{.LastPageNum}}">&laquo; {{.i18n.Tr "admin.prev"}}</a></li>{{end}}
+					                    {{if .NextPageNum}}<li><a class="btn btn-medium btn-gray btn-radius" href="{{AppRootSubUrl}}/admin/orgs?p={{.NextPageNum}}">&raquo; {{.i18n.Tr "admin.next"}}</a></li>{{end}}
 					                </ul>
 					                {{end}}
 				                </div>

--- a/templates/admin/repo/list.tmpl
+++ b/templates/admin/repo/list.tmpl
@@ -31,8 +31,8 @@
 					                        {{range .Repos}}
 					                        <tr>
 					                            <td>{{.Id}}</td>
-					                            <td><a href="/user/{{.Owner.Name}}">{{.Owner.Name}}</a></td>
-                            					<td><a href="/{{.Owner.Name}}/{{.Name}}">{{.Name}}</a></td>
+					                            <td><a href="{{AppRootSubUrl}}/user/{{.Owner.Name}}">{{.Owner.Name}}</a></td>
+                            					<td><a href="{{AppRootSubUrl}}/{{.Owner.Name}}/{{.Name}}">{{.Name}}</a></td>
 					                            <td><i class="fa fa{{if .IsPrivate}}-check{{end}}-square-o"></i></td>
 					                            <td>{{.NumWatches}}</td>
 					                            <td>{{.NumIssues}}</td>
@@ -44,8 +44,8 @@
 					                </table>
 					                {{if or .LastPageNum .NextPageNum}}
 					                <ul class="pagination">
-					                    {{if .LastPageNum}}<li><a class="btn btn-medium btn-gray btn-radius" href="/admin/repos?p={{.LastPageNum}}">&laquo; Prev.</a></li>{{end}}
-					                    {{if .NextPageNum}}<li><a class="btn btn-medium btn-gray btn-radius" href="/admin/repos?p={{.NextPageNum}}">&raquo; Next</a></li>{{end}}
+					                    {{if .LastPageNum}}<li><a class="btn btn-medium btn-gray btn-radius" href="{{AppRootSubUrl}}/admin/repos?p={{.LastPageNum}}">&laquo; Prev.</a></li>{{end}}
+					                    {{if .NextPageNum}}<li><a class="btn btn-medium btn-gray btn-radius" href="{{AppRootSubUrl}}/admin/repos?p={{.NextPageNum}}">&raquo; Next</a></li>{{end}}
 					                </ul>
 					                {{end}}
 				                </div>

--- a/templates/admin/user/edit.tmpl
+++ b/templates/admin/user/edit.tmpl
@@ -12,7 +12,7 @@
                             <div class="panel-header">
                                 <strong>{{.i18n.Tr "admin.users.edit_account"}}</strong>
                             </div>
-                            <form class="form form-align panel-body" id="user-profile-form" action="/admin/users/{{.User.Id}}" method="post" data-delete-url="/admin/users/{{.User.Id}}/delete">
+                            <form class="form form-align panel-body" id="user-profile-form" action="{{AppRootSubUrl}}/admin/users/{{.User.Id}}" method="post" data-delete-url="/admin/users/{{.User.Id}}/delete">
 					            {{.CsrfTokenHtml}}
                                 <div class="field">
                                     <label class="req">{{.i18n.Tr "admin.users.auth_source"}}</label>

--- a/templates/admin/user/list.tmpl
+++ b/templates/admin/user/list.tmpl
@@ -13,7 +13,7 @@
                                 <strong>{{.i18n.Tr "admin.users.user_manage_panel"}}</strong>
                             </div>
                             <div class="panel-body admin-panel">
-								<a class="btn-blue btn-medium btn-link btn-radius" href="/admin/users/new">{{.i18n.Tr "admin.users.new_account"}}</a>
+								<a class="btn-blue btn-medium btn-link btn-radius" href="{{AppRootSubUrl}}/admin/users/new">{{.i18n.Tr "admin.users.new_account"}}</a>
                                 <div class="admin-table">
 					                <table class="table table-striped">
 					                    <thead>
@@ -32,21 +32,21 @@
 					                        {{range .Users}}
 					                        <tr>
 					                            <td>{{.Id}}</td>
-					                            <td><a href="/user/{{.Name}}">{{.Name}}</a></td>
+					                            <td><a href="{{AppRootSubUrl}}/user/{{.Name}}">{{.Name}}</a></td>
 					                            <td>{{.Email}}</td>
 					                            <td><i class="fa fa{{if .IsActive}}-check{{end}}-square-o"></i></td>
 					                            <td><i class="fa fa{{if .IsAdmin}}-check{{end}}-square-o"></i></td>
 					                            <td>{{.NumRepos}}</td>
 					                            <td>{{DateFormat .Created "M d, Y"}}</td>
-					                            <td><a href="/admin/users/{{.Id}}"><i class="fa fa-pencil-square-o"></i></a></td>
+					                            <td><a href="{{AppRootSubUrl}}/admin/users/{{.Id}}"><i class="fa fa-pencil-square-o"></i></a></td>
 					                        </tr>
 					                        {{end}}
 					                    </tbody>
 					                </table>
 					                {{if or .LastPageNum .NextPageNum}}
 					                <ul class="pagination">
-					                    {{if .LastPageNum}}<li><a class="btn btn-medium btn-gray btn-radius" href="/admin/users?p={{.LastPageNum}}">&laquo; Prev.</a></li>{{end}}
-					                    {{if .NextPageNum}}<li><a class="btn btn-medium btn-gray btn-radius" href="/admin/users?p={{.NextPageNum}}">&raquo; Next</a></li>{{end}}
+					                    {{if .LastPageNum}}<li><a class="btn btn-medium btn-gray btn-radius" href="{{AppRootSubUrl}}/admin/users?p={{.LastPageNum}}">&laquo; Prev.</a></li>{{end}}
+					                    {{if .NextPageNum}}<li><a class="btn btn-medium btn-gray btn-radius" href="{{AppRootSubUrl}}/admin/users?p={{.NextPageNum}}">&raquo; Next</a></li>{{end}}
 					                </ul>
 					                {{end}}
 				                </div>

--- a/templates/admin/user/new.tmpl
+++ b/templates/admin/user/new.tmpl
@@ -12,7 +12,7 @@
                             <div class="panel-header">
                                 <strong>{{.i18n.Tr "admin.users.new_account"}}</strong>
                             </div>
-                            <form class="form form-align panel-body" id="repo-setting-form" action="/admin/users/new" method="post">
+                            <form class="form form-align panel-body" id="repo-setting-form" action="{{AppRootSubUrl}}/admin/users/new" method="post">
 					            {{.CsrfTokenHtml}}
                                 <div class="field">
                                     <label class="req">{{.i18n.Tr "admin.users.auth_source"}}</label>

--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
-	<head>
+	<head{{if AppRootSubUrl}} data-suburl="{{AppRootSubUrl}}"{{end}}>
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-		<link rel="shortcut icon" href="/img/favicon.png" />
+		<link rel="shortcut icon" href="{{AppRootSubUrl}}/img/favicon.png" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
         <meta name="author" content="Gogs - Go Git Service" />
@@ -19,21 +19,21 @@
 		<script src="//code.jquery.com/jquery-1.11.0.min.js"></script>
 		<script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 		{{else}}
-		<link href="/css/bootstrap.min.css" rel="stylesheet" />
-		<link href="/css/font-awesome.min.css" rel="stylesheet" />
+		<link href="{{AppRootSubUrl}}/css/bootstrap.min.css" rel="stylesheet" />
+		<link href="{{AppRootSubUrl}}/css/font-awesome.min.css" rel="stylesheet" />
 
-		<script src="/js/jquery-1.10.1.min.js"></script>
-		<script src="/js/bootstrap.min.js"></script>
+		<script src="{{AppRootSubUrl}}/js/jquery-1.10.1.min.js"></script>
+		<script src="{{AppRootSubUrl}}/js/bootstrap.min.js"></script>
 		{{end}}
 
-		<link href="/css/todc-bootstrap.min.css" rel="stylesheet" />
-        <link href="/css/datepicker3.css" rel="stylesheet" />
-        <link href="/css/bootstrap-colorpicker.min.css" rel="stylesheet" />
-		<link href="/css/markdown.css" rel="stylesheet" />
-		<link href="/css/gogs.css" rel="stylesheet" />
+		<link href="{{AppRootSubUrl}}/css/todc-bootstrap.min.css" rel="stylesheet" />
+        <link href="{{AppRootSubUrl}}/css/datepicker3.css" rel="stylesheet" />
+        <link href="{{AppRootSubUrl}}/css/bootstrap-colorpicker.min.css" rel="stylesheet" />
+		<link href="{{AppRootSubUrl}}/css/markdown.css" rel="stylesheet" />
+		<link href="{{AppRootSubUrl}}/css/gogs.css" rel="stylesheet" />
 
-        <script src="/js/lib.js"></script>
-        <script src="/js/app.js"></script>
+        <script src="{{AppRootSubUrl}}/js/lib.js"></script>
+        <script src="{{AppRootSubUrl}}/js/app.js"></script>
 		<title>{{if .Title}}{{.Title}} - {{end}}{{AppName}}</title>
 	</head>
 	<body>

--- a/templates/base/navbar.tmpl
+++ b/templates/base/navbar.tmpl
@@ -1,8 +1,8 @@
 <div class="masthead navbar" id="masthead">
     <div class="container">
         <nav class="nav">
-            <a id="nav-logo" class="nav-item pull-left{{if .PageIsHome}} active{{end}}" href="/"><img src="/img/favicon.png" alt="Gogs Logo" id="logo"></a>
-            <a class="nav-item pull-left{{if .PageIsUserDashboard}} active{{end}}" href="/">Dashboard</a>
+            <a id="nav-logo" class="nav-item pull-left{{if .PageIsHome}} active{{end}}" href="{{AppRootSubUrl}}/"><img src="{{AppRootSubUrl}}/img/favicon.png" alt="Gogs Logo" id="logo"></a>
+            <a class="nav-item pull-left{{if .PageIsUserDashboard}} active{{end}}" href="{{AppRootSubUrl}}/">Dashboard</a>
             <a class="nav-item pull-left{{if .PageIsHelp}} active{{end}}" target="_blank" href="http://gogs.io/docs">Help</a>
             {{if .IsSigned}}
             {{if .HasAccess}}
@@ -22,27 +22,27 @@
                 </div>
             </form> -->
             {{end}}
-            <a id="nav-out" class="nav-item navbar-right navbar-btn btn btn-danger" href="/user/logout/"><i class="fa fa-power-off fa-lg"></i></a>
+            <a id="nav-out" class="nav-item navbar-right navbar-btn btn btn-danger" href="{{AppRootSubUrl}}/user/logout/"><i class="fa fa-power-off fa-lg"></i></a>
             <a id="nav-avatar" class="nav-item navbar-right{{if .PageIsUserProfile}} active{{end}}" href="{{.SignedUser.HomeLink}}" data-toggle="tooltip" data-placement="bottom" title="{{.SignedUserName}}">
                 <img src="{{.SignedUser.AvatarLink}}?s=28" alt="user-avatar" title="username"/>
             </a>
-            <a class="navbar-right nav-item{{if .PageIsUserSetting}} active{{end}}" href="/user/settings"  data-toggle="tooltip" data-placement="bottom" title="Settings"><i class="fa fa-cogs fa-lg"></i></a>
+            <a class="navbar-right nav-item{{if .PageIsUserSetting}} active{{end}}" href="{{AppRootSubUrl}}/user/settings"  data-toggle="tooltip" data-placement="bottom" title="Settings"><i class="fa fa-cogs fa-lg"></i></a>
             {{if .IsAdmin}}
-            <a class="navbar-right nav-item{{if .PageIsAdmin}} active{{end}}" href="/admin"  data-toggle="tooltip" data-placement="bottom" title="Admin"><i class="fa fa-gear fa-lg"></i></a>
+            <a class="navbar-right nav-item{{if .PageIsAdmin}} active{{end}}" href="{{AppRootSubUrl}}/admin"  data-toggle="tooltip" data-placement="bottom" title="Admin"><i class="fa fa-gear fa-lg"></i></a>
             {{end}}
             <div class="navbar-right nav-item pull-right{{if .PageIsNewRepo}} active{{end}}" id="nav-repo-new" data-toggle="tooltip" data-placement="bottom" title="New Repo">
                 <button type="button" class="dropdown-toggle" data-toggle="dropdown"><i class="fa fa-plus-square fa-lg"></i></button>
                 <div class="dropdown-menu">
                     <ul class="list-unstyled">
-                        <li><a href="/repo/create"><i class="fa fa-book"></i>Repository</a></li>
-                        <li><a href="/repo/migrate"><i class="fa fa-clipboard"></i>Migration</a></li>
+                        <li><a href="{{AppRootSubUrl}}/repo/create"><i class="fa fa-book"></i>Repository</a></li>
+                        <li><a href="{{AppRootSubUrl}}/repo/migrate"><i class="fa fa-clipboard"></i>Migration</a></li>
                         <!-- <li><a href="#"><i class="fa fa-users"></i>Organization</a></li> -->
                     </ul>
                 </div>
             </div>
             {{else}}
-            <a id="nav-signin" class="nav-item navbar-right navbar-btn btn btn-danger" href="/user/login/" rel="nofollow">Sign In</a>
-            <a id="nav-signup" class="nav-item navbar-right" href="/user/sign_up/" rel="nofollow">Sign Up</a>
+            <a id="nav-signin" class="nav-item navbar-right navbar-btn btn btn-danger" href="{{AppRootSubUrl}}/user/login/" rel="nofollow">Sign In</a>
+            <a id="nav-signup" class="nav-item navbar-right" href="{{AppRootSubUrl}}/user/sign_up/" rel="nofollow">Sign Up</a>
             {{end}}
         </nav>
     </div>

--- a/templates/explore/nav.tmpl
+++ b/templates/explore/nav.tmpl
@@ -2,7 +2,7 @@
     <p class="panel-header"><strong>{{.i18n.Tr "explore"}}</strong></p>
     <div class="panel-body">
         <ul class="menu menu-vertical switching-list grid-1-5 left">
-            <li {{if .PageIsExploreRepositories}}class="current"{{end}}><a href="/explore">{{.i18n.Tr "explore.repos"}}</a></li>
+            <li {{if .PageIsExploreRepositories}}class="current"{{end}}><a href="{{AppRootSubUrl}}/explore">{{.i18n.Tr "explore.repos"}}</a></li>
         </ul>
     </div>
 </div>

--- a/templates/explore/repos.tmpl
+++ b/templates/explore/repos.tmpl
@@ -12,7 +12,7 @@
 			                <li><i class="octicon octicon-star"></i> {{.NumStars}}</li>
 			                <li><i class="octicon octicon-git-branch"></i> {{.NumForks}}</li>
 			            </ul>
-						<h2><a href="/{{.Owner.Name}}/{{.Name}}">{{.Name}}</a></h2>
+						<h2><a href="{{AppRootSubUrl}}/{{.Owner.Name}}/{{.Name}}">{{.Name}}</a></h2>
 						<p class="org-repo-description">{{.Description}}</p>
 						<p class="org-repo-updated">{{$.i18n.Tr "org.repo_updated"}} {{TimeSince .Updated $.i18n.Lang}}</p>
 					</div>

--- a/templates/home.tmpl
+++ b/templates/home.tmpl
@@ -3,12 +3,12 @@
 <div id="promo-wrapper">
     <div class="container clear">
         <div id="promo-logo" class="left">
-            <img src="/img/gogs-lg.png" alt="logo" />
+            <img src="{{AppRootSubUrl}}/img/gogs-lg.png" alt="logo" />
         </div>
         <div id="promo-content">
             <h1>Gogs</h1>
             <h2>{{.i18n.Tr "app_desc"}}</h2>
-            <form id="promo-form" action="/user/login" method="post">
+            <form id="promo-form" action="{{AppRootSubUrl}}/user/login" method="post">
                 {{.CsrfTokenHtml}}
                 <input class="ipt ipt-large" id="username" name="uname" type="text" placeholder="{{.i18n.Tr "home.uname_holder"}}"/>
                 <input class="ipt ipt-large" name="password" type="password" placeholder="{{.i18n.Tr "home.password_holder"}}"/>

--- a/templates/install.tmpl
+++ b/templates/install.tmpl
@@ -8,7 +8,7 @@
                     <div class="panel-header">
                         <strong>{{.i18n.Tr "install.title"}}</strong>
                     </div>
-                    <form class="form form-align panel-body" id="install-form" action="/install" method="post">
+                    <form class="form form-align panel-body" id="install-form" action="{{AppRootSubUrl}}/install" method="post">
                         {{.CsrfTokenHtml}}
                         <div class="text-center panel-desc">{{.i18n.Tr "install.requite_db_desc"}}</div>
                         <div class="field">

--- a/templates/ng/base/head.tmpl
+++ b/templates/ng/base/head.tmpl
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-	<head>
+	<head{{if AppRootSubUrl}} data-suburl="{{AppRootSubUrl}}"{{end}}>
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
         <meta name="author" content="Gogs - Go Git Service" />
@@ -9,27 +9,27 @@
 		<meta name="_csrf" content="{{.CsrfToken}}" />
 		{{if .Repository.IsGoget}}<meta name="go-import" content="{{.GoGetImport}} git {{.CloneLink.HTTPS}}">{{end}}
 
-		<link rel="shortcut icon" href="/img/favicon.png" />
+		<link rel="shortcut icon" href="{{AppRootSubUrl}}/img/favicon.png" />
 
 		{{if CdnMode}}
 		<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css">
 
 		<script src="//code.jquery.com/jquery-1.11.1.min.js"></script>
 		{{else}}
-		<link rel="stylesheet" href="/css/font-awesome.min.css">
+		<link rel="stylesheet" href="{{AppRootSubUrl}}/css/font-awesome.min.css">
 		
-		<script src="/ng/js/lib/jquery-1.11.1.min.js"></script>
+		<script src="{{AppRootSubUrl}}/ng/js/lib/jquery-1.11.1.min.js"></script>
 		{{end}}
 		<!-- Stylesheet -->
-		<link rel="stylesheet" href="/ng/css/ui.css">
-		<link rel="stylesheet" href="/ng/css/gogs.css">
-		<link rel="stylesheet" href="/ng/fonts/octicons.css">
-		<link rel="stylesheet" href="/css/github.min.css">
+		<link rel="stylesheet" href="{{AppRootSubUrl}}/ng/css/ui.css">
+		<link rel="stylesheet" href="{{AppRootSubUrl}}/ng/css/gogs.css">
+		<link rel="stylesheet" href="{{AppRootSubUrl}}/ng/fonts/octicons.css">
+		<link rel="stylesheet" href="{{AppRootSubUrl}}/css/github.min.css">
 
 		<!-- JavaScript -->
-		<script src="/ng/js/lib/tabs.js"></script>
-    	<script src="/ng/js/lib/lib.js"></script>
-		<script src="/ng/js/gogs.js"></script>
+		<script src="{{AppRootSubUrl}}/ng/js/lib/tabs.js"></script>
+    	<script src="{{AppRootSubUrl}}/ng/js/lib/lib.js"></script>
+		<script src="{{AppRootSubUrl}}/ng/js/gogs.js"></script>
 
 		<title>{{if .Title}}{{.Title}} - {{end}}{{AppName}}</title>
 	</head>

--- a/templates/ng/base/header.tmpl
+++ b/templates/ng/base/header.tmpl
@@ -2,37 +2,37 @@
     <ul class="menu menu-line container" id="header-nav">
         {{if not .PageIsHome}}
         <li class="head" id="header-nav-logo">
-            <img src="/img/favicon.png" alt="avatar" class="avatar-30"/>
+            <img src="{{AppRootSubUrl}}/img/favicon.png" alt="avatar" class="avatar-30"/>
         </li>
         <li {{if .PageIsDashboard}}class="current"{{end}}>
-            <a href="/">{{if .IsSigned}}{{.i18n.Tr "dashboard"}}{{else}}{{.i18n.Tr "home"}}{{end}}</a>
+            <a href="{{AppRootSubUrl}}/">{{if .IsSigned}}{{.i18n.Tr "dashboard"}}{{else}}{{.i18n.Tr "home"}}{{end}}</a>
         </li>
-        <li><a href="/explore">{{.i18n.Tr "explore"}}</a></li>
+        <li><a href="{{AppRootSubUrl}}/explore">{{.i18n.Tr "explore"}}</a></li>
         <li><a target="_blank" href="http://gogs.io/docs">{{.i18n.Tr "help"}}</a></li>
         {{end}}
 
         {{if .IsSigned}}
         <li class="right" id="header-nav-sign-out">
-            <a href="/user/logout" title="{{.i18n.Tr "sign_out"}}"><i class="octicon octicon-sign-out"></i></a>
+            <a href="{{AppRootSubUrl}}/user/logout" title="{{.i18n.Tr "sign_out"}}"><i class="octicon octicon-sign-out"></i></a>
         </li>
         <li class="right {{if .PageIsUserSettings}}current{{end}}">
-            <a href="/user/settings" title="{{.i18n.Tr "account_settings"}}"><i class="octicon octicon-settings"></i></a>
+            <a href="{{AppRootSubUrl}}/user/settings" title="{{.i18n.Tr "account_settings"}}"><i class="octicon octicon-settings"></i></a>
         </li>
             {{if .IsAdmin}}
             <li class="right {{if .PageIsAdmin}}current{{end}}">
-                <a href="/admin" title="{{.i18n.Tr "admin_panel"}}"><i class="octicon octicon-circuit-board"></i></a>
+                <a href="{{AppRootSubUrl}}/admin" title="{{.i18n.Tr "admin_panel"}}"><i class="octicon octicon-circuit-board"></i></a>
             </li>
             {{end}}
         <li class="right down">
             <a href="#"><i class="octicon octicon-plus"></i></a>
             <ul class="menu menu-down" id="header-new-repo-menu">
-                <li><a href="/repo/create"><i class="octicon octicon-repo-create"></i>{{.i18n.Tr "new_repo"}}</a></li>
-                <li><a href="/repo/migrate"><i class="octicon octicon-repo-clone"></i>{{.i18n.Tr "new_migrate"}}</a></li>
-                <li><a href="/org/create"><i class="octicon octicon-organization"></i>{{.i18n.Tr "new_org"}}</a></li>
+                <li><a href="{{AppRootSubUrl}}/repo/create"><i class="octicon octicon-repo-create"></i>{{.i18n.Tr "new_repo"}}</a></li>
+                <li><a href="{{AppRootSubUrl}}/repo/migrate"><i class="octicon octicon-repo-clone"></i>{{.i18n.Tr "new_migrate"}}</a></li>
+                <li><a href="{{AppRootSubUrl}}/org/create"><i class="octicon octicon-organization"></i>{{.i18n.Tr "new_org"}}</a></li>
             </ul>
         </li>
         <li class="right" id="header-nav-user">
-            <a href="/{{.SignedUser.Name}}" class="text-bold">
+            <a href="{{AppRootSubUrl}}/{{.SignedUser.Name}}" class="text-bold">
                 <img src="{{.SignedUser.AvatarLink}}" alt="user-avatar" class="avatar-30"/>
                 {{.SignedUser.Name}}
             </a>
@@ -43,14 +43,14 @@
                 <a target="_blank" href="http://gogs.io/docs"><i class="octicon octicon-info"></i>&nbsp;&nbsp;{{.i18n.Tr "help"}}</a>
             </li>
             <li class="right" id="header-nav-explore">
-                <a href="/explore"><i class="octicon octicon-globe"></i>&nbsp;&nbsp;{{.i18n.Tr "explore"}}</a>
+                <a href="{{AppRootSubUrl}}/explore"><i class="octicon octicon-globe"></i>&nbsp;&nbsp;{{.i18n.Tr "explore"}}</a>
             </li>
             {{else}}
             <li class="right" id="header-nav-sign-in">
-                <a href="/user/login" title="Sign In"><i class="octicon octicon-sign-in"></i> {{.i18n.Tr "sign_in"}}</a>
+                <a href="{{AppRootSubUrl}}/user/login" title="Sign In"><i class="octicon octicon-sign-in"></i> {{.i18n.Tr "sign_in"}}</a>
             </li>
             <li class="right">
-                <a href="/user/sign_up" title="Account Settings"><i class="octicon octicon-person-add"></i> {{.i18n.Tr "register"}}</a>
+                <a href="{{AppRootSubUrl}}/user/sign_up" title="Account Settings"><i class="octicon octicon-person-add"></i> {{.i18n.Tr "register"}}</a>
             </li>
             {{end}}
         {{end}}

--- a/templates/ng/base/social.tmpl
+++ b/templates/ng/base/social.tmpl
@@ -1,4 +1,4 @@
-{{if .OauthService.GitHub}}<a class="btn github" href="/user/login/github?next=/user/sign_up"><i class="fa fa-github"></i>GitHub</a>{{end}}
-{{if .OauthService.Google}}<a class="btn google" href="/user/login/google?next=/user/sign_up"><i class="fa fa-google"></i>Google +</a>{{end}}
-{{if .OauthService.Weibo}}<a class="btn weibo" href="/user/login/weibo?next=/user/sign_up"><i class="fa fa-weibo"></i>新浪微博</a>{{end}}
-{{if .OauthService.Tencent}}<a class="btn qq" href="/user/login/qq?next=/user/sign_up"><i class="fa fa-qq"></i>腾讯 QQ&nbsp;</a>{{end}}
+{{if .OauthService.GitHub}}<a class="btn github" href="{{AppRootSubUrl}}/user/login/github?next=/user/sign_up"><i class="fa fa-github"></i>GitHub</a>{{end}}
+{{if .OauthService.Google}}<a class="btn google" href="{{AppRootSubUrl}}/user/login/google?next=/user/sign_up"><i class="fa fa-google"></i>Google +</a>{{end}}
+{{if .OauthService.Weibo}}<a class="btn weibo" href="{{AppRootSubUrl}}/user/login/weibo?next=/user/sign_up"><i class="fa fa-weibo"></i>新浪微博</a>{{end}}
+{{if .OauthService.Tencent}}<a class="btn qq" href="{{AppRootSubUrl}}/user/login/qq?next=/user/sign_up"><i class="fa fa-qq"></i>腾讯 QQ&nbsp;</a>{{end}}

--- a/templates/org/base/header.tmpl
+++ b/templates/org/base/header.tmpl
@@ -1,6 +1,6 @@
 <div class="org-header" id="org-header">
 	<div class="container">
-		<a class="text-black left" href="/org/{{.Org.LowerName}}">
+		<a class="text-black left" href="{{AppRootSubUrl}}/org/{{.Org.LowerName}}">
 			<img class="avatar-48 left" src="{{.Org.AvatarLink}}?s=100">
 			<span class="org-name">{{.Org.FullName}}</span>
 		</a>

--- a/templates/org/create.tmpl
+++ b/templates/org/create.tmpl
@@ -1,7 +1,7 @@
 {{template "ng/base/head" .}}
 {{template "ng/base/header" .}}
 <div id="sign-wrapper">
-    <form class="form-align form panel sign-panel sign-form container panel-radius" id="sign-up-form" action="/org/create" method="post">
+    <form class="form-align form panel sign-panel sign-form container panel-radius" id="sign-up-form" action="{{AppRootSubUrl}}/org/create" method="post">
         {{.CsrfTokenHtml}}
         <div class="panel-header">
             <h2>{{.i18n.Tr "new_org"}}</h2>
@@ -23,7 +23,7 @@
             <div class="field">
                 <span class="form-label"></span>
                 <button class="btn btn-large btn-blue btn-radius">{{.i18n.Tr "org.create_org"}}</button>
-                <a class="btn btn-small btn-gray btn-radius" id="repo-create-cancel" href="/"><strong>{{.i18n.Tr "cancel"}}</strong></a>
+                <a class="btn btn-small btn-gray btn-radius" id="repo-create-cancel" href="{{AppRootSubUrl}}/"><strong>{{.i18n.Tr "cancel"}}</strong></a>
             </div>
         </div>
     </form>

--- a/templates/org/home.tmpl
+++ b/templates/org/home.tmpl
@@ -22,7 +22,7 @@
     <div id="org-home-repo-list" class="left grid-2-3">
         <div class="clear">
         	{{if .IsOrganizationOwner}}
-            <a class="btn btn-green btn-large btn-link btn-radius right" href="/repo/create?org={{.Org.Id}}"><i class="octicon octicon-repo-create"></i> {{.i18n.Tr "new_repo"}}</a>
+            <a class="btn btn-green btn-large btn-link btn-radius right" href="{{AppRootSubUrl}}/repo/create?org={{.Org.Id}}"><i class="octicon octicon-repo-create"></i> {{.i18n.Tr "new_repo"}}</a>
         	{{end}}
         </div>
         <div id="org-repo-list">
@@ -33,7 +33,7 @@
                         <li><i class="octicon octicon-star"></i> {{.NumStars}}</li>
                         <li><i class="octicon octicon-git-branch"></i> {{.NumForks}}</li>
                     </ul>
-					<h2><a href="/{{$.Org.Name}}/{{.Name}}">{{.Name}}</a></h2>
+					<h2><a href="{{AppRootSubUrl}}/{{$.Org.Name}}/{{.Name}}">{{.Name}}</a></h2>
 					<p class="org-repo-description">{{.Description}}</p>
 					<p class="org-repo-updated">{{$.i18n.Tr "org.repo_updated"}} {{TimeSince .Updated $.i18n.Lang}}</p>
 				</div>
@@ -46,20 +46,20 @@
 	    	<div class="panel panel-radius">
 	    		<div class="panel-header">
 	    			{{if $isMember}}
-	    			<a class="text-grey right" href="/org/{{.Org.LowerName}}/members"><strong>{{.Org.NumMembers}}</strong><span class="octicon octicon-chevron-right"></span></a>
+	    			<a class="text-grey right" href="{{AppRootSubUrl}}/org/{{.Org.LowerName}}/members"><strong>{{.Org.NumMembers}}</strong><span class="octicon octicon-chevron-right"></span></a>
 	    			{{end}}
 	    			<strong>{{.i18n.Tr "org.people"}}</strong>
 	    		</div>
 	    		<div class="panel-body member-avatar-group">
 	    			{{range .Members}}
 						{{if or $isMember (.IsPublicMember $.Org.Id)}}
-	    				<a href="/{{.Name}}" title="{{.Name}}"><img src="{{.AvatarLink}}"></a>
+	    				<a href="{{AppRootSubUrl}}/{{.Name}}" title="{{.Name}}"><img src="{{.AvatarLink}}"></a>
 	    				{{end}}
 	    			{{end}}
 	    		</div>
 	    		{{if .IsOrganizationOwner}}
 	    		<div class="panel-footer">
-	    			<a class="btn btn-medium btn-blue btn-link btn-radius" href="/org/{{.Org.LowerName}}/invitations/new">{{.i18n.Tr "org.invite_someone"}}</a>
+	    			<a class="btn btn-medium btn-blue btn-link btn-radius" href="{{AppRootSubUrl}}/org/{{.Org.LowerName}}/invitations/new">{{.i18n.Tr "org.invite_someone"}}</a>
 	    		</div>
 	    		{{end}}
 	    	</div>
@@ -67,14 +67,14 @@
 	    	<br>
 	    	<div class="panel panel-radius">
 	    		<div class="panel-header">
-	    			<a class="text-grey right" href="/org/{{.Org.LowerName}}/teams"><strong>{{.Org.NumTeams}}</strong><span class="octicon octicon-chevron-right"></span></a>
+	    			<a class="text-grey right" href="{{AppRootSubUrl}}/org/{{.Org.LowerName}}/teams"><strong>{{.Org.NumTeams}}</strong><span class="octicon octicon-chevron-right"></span></a>
 	    			<strong>{{.i18n.Tr "org.teams"}}</strong>
 	    		</div>
 	    		<div class="panel-body" id="org-home-team-list">
 	    			<ul>
 		    			{{range .Teams}}
 	    				<li>
-	    					<a class="text-black" href="/org/{{$.Org.LowerName}}/teams/{{.LowerName}}"><strong class="team-name">{{.Name}}</strong></a>
+	    					<a class="text-black" href="{{AppRootSubUrl}}/org/{{$.Org.LowerName}}/teams/{{.LowerName}}"><strong class="team-name">{{.Name}}</strong></a>
 	    					<p class="team-meta">{{.NumMembers}} {{$.i18n.Tr "org.lower_members"}} · {{.NumRepos}} {{$.i18n.Tr "org.lower_repositories"}}</p>
 	    				</li>
 		    			{{end}}
@@ -82,7 +82,7 @@
 	    		</div>
 	    		{{if .IsOrganizationOwner}}
 	    		<div class="panel-footer">
-	    			<a class="btn btn-medium btn-blue btn-link btn-radius" href="/org/{{$.Org.LowerName}}/teams/new">{{.i18n.Tr "org.create_new_team"}}</a>
+	    			<a class="btn btn-medium btn-blue btn-link btn-radius" href="{{AppRootSubUrl}}/org/{{$.Org.LowerName}}/teams/new">{{.i18n.Tr "org.create_new_team"}}</a>
 	    		</div>
 	    		{{end}}
 	    	</div>

--- a/templates/org/member/members.tmpl
+++ b/templates/org/member/members.tmpl
@@ -14,7 +14,7 @@
 		{{range .Members}}
 		<div class="org-member-item">
 			<img class="avatar-48 left" src="{{.AvatarLink}}?s=100">
-			<a class="text-black" href="/{{.Name}}"><span class="member-name"><strong>{{.FullName}}</strong>({{.Name}})</span></a>
+			<a class="text-black" href="{{AppRootSubUrl}}/{{.Name}}"><span class="member-name"><strong>{{.FullName}}</strong>({{.Name}})</span></a>
 			<ul class="grid-6-12 right">
 				<li class="grid-1-3">
 				{{ $isPublic := .IsPublicMember $.Org.Id}}

--- a/templates/org/new.tmpl
+++ b/templates/org/new.tmpl
@@ -1,7 +1,7 @@
 {{template "base/head" .}}
 {{template "base/navbar" .}}
 <div class="container" id="body">
-    <form action="/org/create" method="post" class="form-horizontal card" id="org-create">
+    <form action="{{AppRootSubUrl}}/org/create" method="post" class="form-horizontal card" id="org-create">
         {{.CsrfTokenHtml}}
         <h3>Create New Organization</h3>
         {{template "base/alert" .}}
@@ -24,7 +24,7 @@
         <div class="form-group">
             <div class="col-md-offset-2 col-md-8">
                 <button type="submit" class="btn btn-lg btn-primary">Create An Organization</button>
-                <a href="/" class="text-danger">Cancel</a>
+                <a href="{{AppRootSubUrl}}/" class="text-danger">Cancel</a>
             </div>
         </div>
     </form>

--- a/templates/org/settings/delete.tmpl
+++ b/templates/org/settings/delete.tmpl
@@ -12,7 +12,7 @@
                         <p class="panel-header"><strong>{{.i18n.Tr "org.settings.delete_account"}}</strong></p>
                         <div class="panel-body panel-content">
                             <span class="alert alert-red alert-radius block"><i class="octicon octicon-alert"></i>{{.i18n.Tr "org.settings.delete_prompt" | Str2html}}</span>
-                            <form  action="/org/{{.Org.LowerName}}/settings/delete" method="post">
+                            <form  action="{{AppRootSubUrl}}/org/{{.Org.LowerName}}/settings/delete" method="post">
                                 {{.CsrfTokenHtml}}
                                 <p class="field">
                                     <span class="form-label"></span>

--- a/templates/org/settings/nav.tmpl
+++ b/templates/org/settings/nav.tmpl
@@ -4,9 +4,9 @@
     </div>
     <div class="panel-body">
         <ul class="menu menu-vertical switching-list grid-1-5 left">
-            <li {{if .PageIsSettingsOptions}}class="current"{{end}}><a href="/org/{{.Org.LowerName}}/settings">{{.i18n.Tr "org.settings.options"}}</a></li>
-            <li {{if .PageIsSettingsHooks}}class="current"{{end}}><a href="/org/{{.Org.LowerName}}/settings/hooks">{{.i18n.Tr "repo.settings.hooks"}}</a></li>
-            <li {{if .PageIsSettingsDelete}}class="current"{{end}}><a href="/org/{{.Org.LowerName}}/settings/delete">{{.i18n.Tr "org.settings.delete"}}</a></li>
+            <li {{if .PageIsSettingsOptions}}class="current"{{end}}><a href="{{AppRootSubUrl}}/org/{{.Org.LowerName}}/settings">{{.i18n.Tr "org.settings.options"}}</a></li>
+            <li {{if .PageIsSettingsHooks}}class="current"{{end}}><a href="{{AppRootSubUrl}}/org/{{.Org.LowerName}}/settings/hooks">{{.i18n.Tr "repo.settings.hooks"}}</a></li>
+            <li {{if .PageIsSettingsDelete}}class="current"{{end}}><a href="{{AppRootSubUrl}}/org/{{.Org.LowerName}}/settings/delete">{{.i18n.Tr "org.settings.delete"}}</a></li>
         </ul>
     </div>
 </div>

--- a/templates/org/settings/options.tmpl
+++ b/templates/org/settings/options.tmpl
@@ -12,7 +12,7 @@
                         <div class="panel-header">
                         	<strong>{{.i18n.Tr "org.settings.options"}}</strong>
                         </div>
-                        <form class="form form-align panel-body" id="org-setting-form" action="/org/{{.Org.LowerName}}/settings" method="post">
+                        <form class="form form-align panel-body" id="org-setting-form" action="{{AppRootSubUrl}}/org/{{.Org.LowerName}}/settings" method="post">
                             {{.CsrfTokenHtml}}
                 			<input type="hidden" name="action" value="update">
                             <div class="field">

--- a/templates/org/team/members.tmpl
+++ b/templates/org/team/members.tmpl
@@ -30,7 +30,7 @@
                 			{{if $.IsOrganizationOwner}}
 							<a class="btn btn-small btn-red btn-radius right" href="{{$.OrgLink}}/teams/{{$.Team.LowerName}}/action/remove?uid={{.Id}}">{{$.i18n.Tr "org.members.remove"}}</a>
 							{{end}}
-							<a class="member" href="/{{.Name}}">
+							<a class="member" href="{{AppRootSubUrl}}/{{.Name}}">
 							    <img alt="{{.Name}}" class="pull-left avatar" src="{{.AvatarLink}}">
 							    <strong>{{.FullName}}</strong> ({{.Name}})
 							</a>

--- a/templates/org/team/repositories.tmpl
+++ b/templates/org/team/repositories.tmpl
@@ -30,7 +30,7 @@
                 			{{if $canAddRemove}}
 							<a class="btn btn-small btn-red btn-radius right" href="{{$.OrgLink}}/teams/{{$.Team.LowerName}}/action/repo/remove?repoid={{.Id}}">{{$.i18n.Tr "org.teams.remove_repo"}}</a>
 							{{end}}
-							<a class="member" href="/{{$.Org.Name}}/{{.Name}}">
+							<a class="member" href="{{AppRootSubUrl}}/{{$.Org.Name}}/{{.Name}}">
                                 <i class="octicon octicon-{{if .IsPrivate}}lock{{else if .IsFork}}repo-forked{{else if .IsMirror}}repo-clone{{else}}repo{{end}}"></i>
 							    <strong>{{$.Org.Name}}/{{.Name}}</strong>
 							</a>

--- a/templates/org/team/teams.tmpl
+++ b/templates/org/team/teams.tmpl
@@ -25,7 +25,7 @@
 				{{if .NumMembers}}
 				<div class="panel-body member-avatar-group">
 					{{range .Members}}
-					<a href="/{{.Name}}" title="{{.Name}}">
+					<a href="{{AppRootSubUrl}}/{{.Name}}" title="{{.Name}}">
 						<img src="{{.AvatarLink}}">
 					</a>
 					{{end}}

--- a/templates/repo/bare.tmpl
+++ b/templates/repo/bare.tmpl
@@ -5,7 +5,7 @@
         <div class="container clear">
             <h1 id="repo-header-name" class="left public">
                 <i class="mega-octicon octicon-{{if .Repository.IsPrivate}}lock{{else}}repo{{end}}"></i>
-                <a class="author" href="/{{.Repository.Owner.Name}}">{{.Repository.Owner.Name}}</a>
+                <a class="author" href="{{AppRootSubUrl}}/{{.Repository.Owner.Name}}">{{.Repository.Owner.Name}}</a>
                 <span class="divider">/</span>
                 <a class="repo text-bold" href="{{.RepoLink}}">{{.Repository.Name}}</a>
             </h1>

--- a/templates/repo/commits_table.tmpl
+++ b/templates/repo/commits_table.tmpl
@@ -26,8 +26,8 @@
             {{$r := List .Commits}}
             {{range $r}}
             <tr>
-                <td class="author"><img class="avatar" src="{{AvatarLink .Author.Email}}" alt=""/><a href="/user/email2user?email={{.Author.Email}}">{{.Author.Name}}</a></td>
-                <td class="sha"><a rel="nofollow" class="label label-success" href="/{{$username}}/{{$reponame}}/commit/{{.Id}} ">{{SubStr .Id.String 0 10}} </a></td>
+                <td class="author"><img class="avatar" src="{{AvatarLink .Author.Email}}" alt=""/><a href="{{AppRootSubUrl}}/user/email2user?email={{.Author.Email}}">{{.Author.Name}}</a></td>
+                <td class="sha"><a rel="nofollow" class="label label-success" href="{{AppRootSubUrl}}/{{$username}}/{{$reponame}}/commit/{{.Id}} ">{{SubStr .Id.String 0 10}} </a></td>
                 <td class="message">{{.Summary}} </td>
                 <td class="date">{{TimeSince .Author.When $.Lang}}</td>
             </tr>

--- a/templates/repo/create.tmpl
+++ b/templates/repo/create.tmpl
@@ -1,7 +1,7 @@
 {{template "ng/base/head" .}}
 {{template "ng/base/header" .}}
 <div id="repo-wrapper">
-    <form id="repo-create-form" class="form form-align panel panel-radius" action="/repo/create" method="post">
+    <form id="repo-create-form" class="form form-align panel panel-radius" action="{{AppRootSubUrl}}/repo/create" method="post">
         {{.CsrfTokenHtml}}
         <div class="panel-header">
             <h2>{{.i18n.Tr "new_repo"}}</h2>
@@ -75,7 +75,7 @@
             <div class="field">
                 <label></label>
                 <button class="btn btn-large btn-blue btn-radius">{{.i18n.Tr "repo.create_repo"}}</button>
-                <a class="btn btn-small btn-gray btn-radius" id="repo-create-cancel" href="/"><strong>{{.i18n.Tr "cancel"}}</strong></a>
+                <a class="btn btn-small btn-gray btn-radius" id="repo-create-cancel" href="{{AppRootSubUrl}}/"><strong>{{.i18n.Tr "cancel"}}</strong></a>
             </div>
         </div>
     </form>

--- a/templates/repo/diff.tmpl
+++ b/templates/repo/diff.tmpl
@@ -30,7 +30,7 @@
                 </span>
                 <p class="author">
                     <img class="avatar" src="{{AvatarLink .Commit.Author.Email}}" alt=""/>
-                    <a class="name" href="/user/email2user?email={{.Commit.Author.Email}}"><strong>{{.Commit.Author.Name}}</strong></a>
+                    <a class="name" href="{{AppRootSubUrl}}/user/email2user?email={{.Commit.Author.Email}}"><strong>{{.Commit.Author.Name}}</strong></a>
                     <span class="time">{{TimeSince .Commit.Author.When $.Lang}}</span>
                 </p>
           </div>

--- a/templates/repo/header.tmpl
+++ b/templates/repo/header.tmpl
@@ -2,7 +2,7 @@
     <div class="container clear">
         <h1 id="repo-header-name" class="left public">
             <i class="mega-octicon octicon-{{if .Repository.IsPrivate}}lock{{else if .Repository.IsMirror}}repo-clone{{else}}repo{{end}}"></i>
-            <a class="author" href="/{{.Owner.Name}}">{{.Owner.Name}}</a>
+            <a class="author" href="{{AppRootSubUrl}}/{{.Owner.Name}}">{{.Owner.Name}}</a>
             <span class="divider">/</span>
             <a class="repo text-bold" href="{{.RepoLink}}">{{.Repository.Name}}</a>
             {{if .Repository.IsMirror}}<span class="label label-gray">{{.i18n.Tr "mirror"}}</span>{{end}}

--- a/templates/repo/issue/list.tmpl
+++ b/templates/repo/issue/list.tmpl
@@ -85,7 +85,7 @@
                     </h5>
                     <p class="info">
                         <span class="author"><img class="avatar" src="{{.Poster.AvatarLink}}" alt="" width="20"/>
-                        <a href="/user/{{.Poster.Name}}">{{.Poster.Name}}</a></span>
+                        <a href="{{AppRootSubUrl}}/user/{{.Poster.Name}}">{{.Poster.Name}}</a></span>
                         <span class="time">{{TimeSince .Created $.Lang}}</span>
                         <span class="comment"><i class="fa fa-comments"></i> {{.NumComments}}</span>
                     </p>

--- a/templates/repo/issue/view.tmpl
+++ b/templates/repo/issue/view.tmpl
@@ -8,7 +8,7 @@
             <div class="issue-wrap col-md-10">
                 <div class="issue-head clearfix">
                     <div class="number pull-right">#{{.Issue.Index}}</div>
-                    <a class="author pull-left" href="/user/{{.Issue.Poster.Name}}"><img class="avatar" src="{{.Issue.Poster.AvatarLink}}" alt="" width="30"/></a>
+                    <a class="author pull-left" href="{{AppRootSubUrl}}/user/{{.Issue.Poster.Name}}"><img class="avatar" src="{{.Issue.Poster.AvatarLink}}" alt="" width="30"/></a>
                     <h1 class="title pull-left">{{.Issue.Name}}</h1>
                     <input id="issue-edit-title" class="form-control input-lg pull-left hidden" type="text" value="{{.Issue.Name}}" data-ajax-rel="issue-edit-save" data-ajax-val="val" data-ajax-field="title"/>
                     <input type="hidden" value="{{.Issue.Id}}" data-ajax-rel="issue-edit-save" data-ajax-val="val" data-ajax-field="issue_id"/>
@@ -17,7 +17,7 @@
                         <a class="btn btn-danger pull-right issue-edit-cancel hidden" href="#">Cancel</a>
                         <a class="btn btn-primary pull-right issue-edit-save hidden" href="#" data-ajax="{{.RepoLink}}/issues/{{.Issue.Index}}" data-ajax-name="issue-edit-save" data-ajax-method="post">Save</a>{{end}}
                         <span class="status label label-{{if .Issue.IsClosed}}danger{{else}}success{{end}}">{{if .Issue.IsClosed}}Closed{{else}}Open{{end}}</span>
-                        <a href="/user/{{.Issue.Poster.Name}}" class="author"><strong>{{.Issue.Poster.Name}}</strong></a> opened this issue
+                        <a href="{{AppRootSubUrl}}/user/{{.Issue.Poster.Name}}" class="author"><strong>{{.Issue.Poster.Name}}</strong></a> opened this issue
                         <span class="time">{{TimeSince .Issue.Created $.Lang}}</span> · {{.Issue.NumComments}} comments
                     </p>
                 </div>
@@ -63,10 +63,10 @@
                     {{/* 0 = COMMENT, 1 = REOPEN, 2 = CLOSE, 3 = ISSUE, 4 = COMMIT, 5 = PULL */}}
                     {{if eq .Type 0}}
                     <div class="issue-child" id="issue-comment-{{.Id}}">
-                        <a class="user pull-left" href="/user/{{.Poster.Name}}"><img class="avatar" src="{{.Poster.AvatarLink}}" alt=""/></a>
+                        <a class="user pull-left" href="{{AppRootSubUrl}}/user/{{.Poster.Name}}"><img class="avatar" src="{{.Poster.AvatarLink}}" alt=""/></a>
                         <div class="issue-content panel panel-default">
                             <div class="panel-heading">
-                                <a href="/user/{{.Poster.Name}}" class="user">{{.Poster.Name}}</a> commented <span class="time">{{TimeSince .Created $.Lang}}</span>
+                                <a href="{{AppRootSubUrl}}/user/{{.Poster.Name}}" class="user">{{.Poster.Name}}</a> commented <span class="time">{{TimeSince .Created $.Lang}}</span>
                                 <!-- <a class="issue-comment-del pull-right issue-action" href="#" title="Edit Comment"><i class="fa fa-times-circle"></i></a>
                                 <a class="issue-comment-edit pull-right issue-action" href="#" title="Remove Comment" data-url="{remove-link}"><i class="fa fa-edit"></i></a> -->
                                 <span class="role label label-default pull-right">Owner</span>
@@ -93,25 +93,25 @@
                     </div>
                     {{else if eq .Type 1}}
                     <div class="issue-child issue-opened">
-                        <a class="user pull-left" href="/user/{{.Poster.Name}}"><img class="avatar" src="{{.Poster.AvatarLink}}" alt="" /></a>
+                        <a class="user pull-left" href="{{AppRootSubUrl}}/user/{{.Poster.Name}}"><img class="avatar" src="{{.Poster.AvatarLink}}" alt="" /></a>
                         <div class="issue-content">
-                            <a class="user pull-left" href="/user/{{.Poster.Name}}">{{.Poster.Name}}</a> <span class="label label-success">Reopened</span> this issue <span class="time">{{TimeSince .Created $.Lang}}</span>
+                            <a class="user pull-left" href="{{AppRootSubUrl}}/user/{{.Poster.Name}}">{{.Poster.Name}}</a> <span class="label label-success">Reopened</span> this issue <span class="time">{{TimeSince .Created $.Lang}}</span>
                         </div>
                     </div>
                     {{else if eq .Type 2}}
                     <div class="issue-child issue-closed">
-                        <a class="user pull-left" href="/user/{{.Poster.Name}}"><img class="avatar" src="{{.Poster.AvatarLink}}" alt=""/></a>
+                        <a class="user pull-left" href="{{AppRootSubUrl}}/user/{{.Poster.Name}}"><img class="avatar" src="{{.Poster.AvatarLink}}" alt=""/></a>
                         <div class="issue-content">
-                            <a class="user pull-left" href="/user/{{.Poster.Name}}">{{.Poster.Name}}</a> <span class="label label-danger">Closed</span> this issue <span class="time">{{TimeSince .Created $.Lang}}</span>
+                            <a class="user pull-left" href="{{AppRootSubUrl}}/user/{{.Poster.Name}}">{{.Poster.Name}}</a> <span class="label label-danger">Closed</span> this issue <span class="time">{{TimeSince .Created $.Lang}}</span>
                         </div>
                     </div>
                     {{else if eq .Type 4}}
                     <div class="issue-child issue-reference issue-reference-commit">
-                        <a class="user pull-left" href="/user/{{.Poster.Name}}"><img class="avatar" src="{{.Poster.AvatarLink}}" alt=""/></a>
+                        <a class="user pull-left" href="{{AppRootSubUrl}}/user/{{.Poster.Name}}"><img class="avatar" src="{{.Poster.AvatarLink}}" alt=""/></a>
                         <div class="issue-content">
-                            <a class="user pull-left" href="/user/{{.Poster.Name}}">{{.Poster.Name}}</a> <span class="label label-primary">Referenced</span> this issue <span class="time">{{TimeSince .Created $.Lang}}</span>
+                            <a class="user pull-left" href="{{AppRootSubUrl}}/user/{{.Poster.Name}}">{{.Poster.Name}}</a> <span class="label label-primary">Referenced</span> this issue <span class="time">{{TimeSince .Created $.Lang}}</span>
                             <p>
-                                <a class="user pull-left" href="/user/{{.Poster.Name}}"><img class="avatar" src="{{.Poster.AvatarLink}}" alt=""/></a>
+                                <a class="user pull-left" href="{{AppRootSubUrl}}/user/{{.Poster.Name}}"><img class="avatar" src="{{.Poster.AvatarLink}}" alt=""/></a>
                                 {{.ContentHtml}}
                             </p>
                         </div>
@@ -120,7 +120,7 @@
                     {{end}}
                     <hr class="issue-line"/>
                     {{if .SignedUser}}<div class="issue-child issue-reply">
-                    <a class="user pull-left" href="/user/{{.SignedUser.Name}}"><img class="avatar" src="{{.SignedUser.AvatarLink}}" alt=""/></a>
+                    <a class="user pull-left" href="{{AppRootSubUrl}}/user/{{.SignedUser.Name}}"><img class="avatar" src="{{.SignedUser.AvatarLink}}" alt=""/></a>
                     <form class="panel panel-default issue-content" action="{{.RepoLink}}/comment/new" method="post" enctype="multipart/form-data">
                         {{.CsrfTokenHtml}}
                         <div class="panel-body">
@@ -163,7 +163,7 @@
                             </div>
                         </div>
                     </form>
-                </div>{{else}}<div class="alert alert-warning"><a class="btn btn-success btn-lg" href="/user/sign_up">Sign up for free</a> to join this conversation. Already have an account? <a href="/user/login">Sign in to comment</a></div>{{end}}
+                </div>{{else}}<div class="alert alert-warning"><a class="btn btn-success btn-lg" href="{{AppRootSubUrl}}/user/sign_up">Sign up for free</a> to join this conversation. Already have an account? <a href="{{AppRootSubUrl}}/user/login">Sign in to comment</a></div>{{end}}
                 </div>
             </div>
 

--- a/templates/repo/migrate.tmpl
+++ b/templates/repo/migrate.tmpl
@@ -1,7 +1,7 @@
 {{template "ng/base/head" .}}
 {{template "ng/base/header" .}}
 <div id="repo-wrapper">
-    <form id="repo-migrate-form" class="form form-align panel panel-radius" action="/repo/migrate" method="post">
+    <form id="repo-migrate-form" class="form form-align panel panel-radius" action="{{AppRootSubUrl}}/repo/migrate" method="post">
         {{.CsrfTokenHtml}}
         <div class="panel-header"><h2>{{.i18n.Tr "new_migrate"}}</h2></div>
         <div class="panel-content">
@@ -74,7 +74,7 @@
             <div class="field">
                 <label for="repo-create-submit"></label>
                 <button class="btn btn-large btn-blue btn-radius" id="repo-create-submit">{{.i18n.Tr "repo.migrate_repo"}}</button>
-                <a class="btn btn-small btn-gray btn-radius" id="repo-create-cancel" href="/"><strong>{{.i18n.Tr "cancel"}}</strong></a>
+                <a class="btn btn-small btn-gray btn-radius" id="repo-create-cancel" href="{{AppRootSubUrl}}/"><strong>{{.i18n.Tr "cancel"}}</strong></a>
             </div>
         </div>
     </form>

--- a/templates/repo/nav.tmpl
+++ b/templates/repo/nav.tmpl
@@ -2,7 +2,7 @@
     <div class="container">
         <div class="row">
             <div class="col-md-7">
-                <h3 class="name"><i class="fa fa-book fa-lg"></i><a href="{{.Owner.HomeLink}}">{{.Owner.Name}}</a> / <a href="/{{.Owner.Name}}/{{.Repository.Name}}">{{.Repository.Name}}</a> {{if .Repository.IsPrivate}}<span class="label label-default">Private</span>{{else if .Repository.IsMirror}}<span class="label label-default">Mirror</span>{{end}}</h3>
+                <h3 class="name"><i class="fa fa-book fa-lg"></i><a href="{{.Owner.HomeLink}}">{{.Owner.Name}}</a> / <a href="{{AppRootSubUrl}}/{{.Owner.Name}}/{{.Repository.Name}}">{{.Repository.Name}}</a> {{if .Repository.IsPrivate}}<span class="label label-default">Private</span>{{else if .Repository.IsMirror}}<span class="label label-default">Mirror</span>{{end}}</h3>
                 <p class="desc">{{.Repository.DescriptionHtml}}{{if .Repository.Website}} <a href="{{.Repository.Website}}">{{.Repository.Website}}</a>{{end}}</p>
             </div>
             <div class="col-md-5 actions text-right clone-group-btn">
@@ -32,7 +32,7 @@
                     </div>
                 </div>
                 {{if .IsSigned}}
-                <div class="btn-group {{if .IsRepositoryWatching}}watching{{else}}no-watching{{end}}" id="repo-watching" data-watch="/{{.Owner.Name}}/{{.Repository.Name}}/action/watch" data-unwatch="/{{.Owner.Name}}/{{.Repository.Name}}/action/unwatch">
+                <div class="btn-group {{if .IsRepositoryWatching}}watching{{else}}no-watching{{end}}" id="repo-watching" data-watch="{{AppRootSubUrl}}/{{.Owner.Name}}/{{.Repository.Name}}/action/watch" data-unwatch="{{AppRootSubUrl}}/{{.Owner.Name}}/{{.Repository.Name}}/action/unwatch">
                     {{if .IsRepositoryWatching}}
                     <button type="button" class="btn btn-default"><i class="fa fa-eye fa-lg fa-m"></i></button>
                     {{else}}
@@ -59,7 +59,7 @@
                 </div> -->
                 {{end}}
                 <!-- <div class="btn-group">
-                    <a type="button" {{if not .IsRepositoryOwner}}href="/{{.Username}}/{{.Reponame}}/fork"{{end}} class="btn btn-default" data-toggle="tooltip" data-placement="top" title="Fork"><i class="fa fa-code-fork fa-lg"></i>&nbsp;{{.Repository.NumForks}}</a>
+                    <a type="button" {{if not .IsRepositoryOwner}}href="{{AppRootSubUrl}}/{{.Username}}/{{.Reponame}}/fork"{{end}} class="btn btn-default" data-toggle="tooltip" data-placement="top" title="Fork"><i class="fa fa-code-fork fa-lg"></i>&nbsp;{{.Repository.NumForks}}</a>
                 </div> -->
             </div>
         </div>

--- a/templates/repo/release/list.tmpl
+++ b/templates/repo/release/list.tmpl
@@ -6,7 +6,7 @@
     <div id="release">
         <h4 id="release-head">
             <span class="release"><strong>Releases</strong></span><!--  /
-            <a class="tag" href="/{tag_link}">Tags</a> -->
+            <a class="tag" href="{{AppRootSubUrl}}/{tag_link}">Tags</a> -->
             <!-- comment : if in tag page, show a.release and span.tag please -->
         </h4>
         <ul id="release-list" class="list-unstyled">
@@ -28,7 +28,7 @@
                     <h4 class="title"><a href="{{$.RepoLink}}/src/{{.TagName}}">{{.Title}}</a> <small>(<a href="{{$.RepoLink}}/releases/edit/{{.TagName}}" rel="nofollow">edit</a>)</small></h4>
                     <p class="info">
                         <span class="author"><img class="avatar" src="{{.Publisher.AvatarLink}}" alt="" width="20">&nbsp;&nbsp;
-                        <a href="/user/{{.Publisher.Name}}">{{.Publisher.Name}}</a></span>
+                        <a href="{{AppRootSubUrl}}/user/{{.Publisher.Name}}">{{.Publisher.Name}}</a></span>
                         {{if .Created}}<span class="time">{{TimeSince .Created $.Lang}}</span>{{end}}
                         <span class="ahead"><strong>{{.NumCommitsBehind}}</strong> commits to {{.Target}} since this release</span>
                     </p>

--- a/templates/repo/setting_nav.tmpl
+++ b/templates/repo/setting_nav.tmpl
@@ -1,7 +1,7 @@
 <div id="user-setting-nav" class="col-md-2 repo-setting-nav">
     <ul class="list-group">
-        <li class="list-group-item{{if .IsRepoToolbarSetting}} active{{end}}"><a href="/{{.Owner.Name}}/{{.Repository.Name}}/settings">Options</a></li>
-        <li class="list-group-item{{if .IsRepoToolbarCollaboration}} active{{end}}"><a href="/{{.Owner.Name}}/{{.Repository.Name}}/settings/collaboration">Collaborators</a></li>
-        <li class="list-group-item{{if .IsRepoToolbarWebHooks}} active{{end}}"><a href="/{{.Owner.Name}}/{{.Repository.Name}}/settings/hooks">Webhooks</a></li>
+        <li class="list-group-item{{if .IsRepoToolbarSetting}} active{{end}}"><a href="{{AppRootSubUrl}}/{{.Owner.Name}}/{{.Repository.Name}}/settings">Options</a></li>
+        <li class="list-group-item{{if .IsRepoToolbarCollaboration}} active{{end}}"><a href="{{AppRootSubUrl}}/{{.Owner.Name}}/{{.Repository.Name}}/settings/collaboration">Collaborators</a></li>
+        <li class="list-group-item{{if .IsRepoToolbarWebHooks}} active{{end}}"><a href="{{AppRootSubUrl}}/{{.Owner.Name}}/{{.Repository.Name}}/settings/hooks">Webhooks</a></li>
     </ul>
 </div>

--- a/templates/repo/settings/collaboration.tmpl
+++ b/templates/repo/settings/collaboration.tmpl
@@ -18,7 +18,7 @@
 	                        		{{range .Collaborators}}
 	                        		<li class="collab">
 	                        			{{if not (eq .Id $.Owner.Id)}}<a href="{{$.RepoLink}}/settings/collaboration?remove={{.Name}}" class="remove-collab right"><i class="fa fa-times"></i></a>{{end}}
-										<a class="member" href="/{{.Name}}">
+										<a class="member" href="{{AppRootSubUrl}}/{{.Name}}">
 										    <img alt="{{.Name}}" class="pull-left avatar" src="{{.AvatarLink}}">
 										    <strong>{{.FullName}}</strong> ({{.Name}})
 										</a>

--- a/templates/repo/single.tmpl
+++ b/templates/repo/single.tmpl
@@ -12,7 +12,7 @@
                     <b class="caret"></b></a>
                 <ul class="dropdown-menu">
                     {{range .Branches}}
-                    <li><a {{if eq . $.BranchName}}class="current" {{end}}href="/{{$.Username}}/{{$.Reponame}}/src/{{.}}">{{.}}</a></li>
+                    <li><a {{if eq . $.BranchName}}class="current" {{end}}href="{{AppRootSubUrl}}/{{$.Username}}/{{$.Reponame}}/src/{{.}}">{{.}}</a></li>
                     {{end}}
                 </ul>
             </div>

--- a/templates/repo/single_list.tmpl
+++ b/templates/repo/single_list.tmpl
@@ -1,9 +1,9 @@
 <div class="panel panel-default info-box">
     <div class="panel-heading info-head">
-        <a href="/{{.Username}}/{{.Reponame}}/commit/{{.LastCommit.Id}}" rel="nofollow">{{.LastCommit.Summary}}</a>
+        <a href="{{AppRootSubUrl}}/{{.Username}}/{{.Reponame}}/commit/{{.LastCommit.Id}}" rel="nofollow">{{.LastCommit.Summary}}</a>
     </div>
     <div class="panel-body info-content">
-        <a href="/user/{{.LastCommit.Author.Name}}">{{.LastCommit.Author.Name}}</a> <span class="text-muted">{{TimeSince .LastCommit.Author.When}}</span>
+        <a href="{{AppRootSubUrl}}/user/{{.LastCommit.Author.Name}}">{{.LastCommit.Author.Name}}</a> <span class="text-muted">{{TimeSince .LastCommit.Author.When}}</span>
     </div>
     <table class="panel-footer table file-list">
         <thead class="hidden">
@@ -36,7 +36,7 @@
                         </span>
                     </td>
                     <td class="text">
-                        <span class="wrap"><a rel="nofollow" href="/{{$.Username}}/{{$.Reponame}}/commit/{{$commit.Id}}">{{$commit.Summary}}</a></span>
+                        <span class="wrap"><a rel="nofollow" href="{{AppRootSubUrl}}/{{$.Username}}/{{$.Reponame}}/commit/{{$commit.Id}}">{{$commit.Summary}}</a></span>
                     </td>
                     <td class="date">
                         <span class="wrap">{{TimeSince $commit.Committer.When}}</span>

--- a/templates/repo/view_list.tmpl
+++ b/templates/repo/view_list.tmpl
@@ -4,7 +4,7 @@
         <th colspan="4" class="clear">
             <span class="author left">
                 <img class="avatar-24 radius" src="{{AvatarLink .LastCommit.Author.Email}}" />
-                <a href="/user/email2user?email={{Md5 .LastCommit.Author.Email}}"><strong>{{.LastCommit.Author.Name}}</strong>:</a>
+                <a href="{{AppRootSubUrl}}/user/email2user?email={{Md5 .LastCommit.Author.Email}}"><strong>{{.LastCommit.Author.Name}}</strong>:</a>
             </span>
             <span class="last-commit"><a href="{{.RepoLink}}/commit/{{.LastCommit.Id}}" rel="nofollow">
                 <strong>{{ShortSha .LastCommit.Id.String}}</strong></a>
@@ -34,7 +34,7 @@
                     <a href="{{$.BranchLink}}/{{$.TreePath}}{{$entry.Name}}" class="text-truncate">{{$entry.Name}}</a>
                 </td>
                 <td class="msg">
-                    <a class="text-truncate" href="/{{$.Username}}/{{$.Reponame}}/commit/{{$commit.Id}}" rel="nofollow">{{$commit.Summary}}</a>
+                    <a class="text-truncate" href="{{AppRootSubUrl}}/{{$.Username}}/{{$.Reponame}}/commit/{{$commit.Id}}" rel="nofollow">{{$commit.Summary}}</a>
                 </td>
                 <td class="age">{{TimeSince $commit.Committer.When $.i18n.Lang}}</td>
             </tr>

--- a/templates/status/404.tmpl
+++ b/templates/status/404.tmpl
@@ -1,7 +1,7 @@
 {{template "ng/base/head" .}}
 {{template "ng/base/header" .}}
 <div class="container text-center">
-    <p style="margin-top: 100px"><img src="/img/404.png" alt="404"/></p>
+    <p style="margin-top: 100px"><img src="{{AppRootSubUrl}}/img/404.png" alt="404"/></p>
     <hr/>
     <br>
     <p>Application Version: {{AppVer}}</p>

--- a/templates/status/500.tmpl
+++ b/templates/status/500.tmpl
@@ -1,7 +1,7 @@
 {{template "ng/base/head" .}}
 {{template "ng/base/header" .}}
 <div id="body" class="container text-center">
-    <p style="margin-top: 100px"><img src="/img/500.png" alt="500"/></p>
+    <p style="margin-top: 100px"><img src="{{AppRootSubUrl}}/img/500.png" alt="500"/></p>
     <hr/>
     <br>
     {{if .ErrorMsg}}<p>An error has occurred : {{.ErrorMsg}}</p>{{end}}

--- a/templates/user/auth/activate.tmpl
+++ b/templates/user/auth/activate.tmpl
@@ -1,7 +1,7 @@
 {{template "ng/base/head" .}}
 {{template "ng/base/header" .}}
 <div id="sign-wrapper">
-    <form class="form-align form panel sign-panel sign-form container panel-radius" id="sign-up-form" action="/user/activate" method="post">
+    <form class="form-align form panel sign-panel sign-form container panel-radius" id="sign-up-form" action="{{AppRootSubUrl}}/user/activate" method="post">
         {{.CsrfTokenHtml}}
         <div class="panel-header">
             <h2>{{.i18n.Tr "auth.active_your_account"}}</h2>

--- a/templates/user/auth/forgot_passwd.tmpl
+++ b/templates/user/auth/forgot_passwd.tmpl
@@ -1,7 +1,7 @@
 {{template "ng/base/head" .}}
 {{template "ng/base/header" .}}
 <div id="sign-wrapper">
-    <form class="form-align form panel sign-panel sign-form container panel-radius" id="sign-up-form" action="/user/forget_password" method="post">
+    <form class="form-align form panel sign-panel sign-form container panel-radius" id="sign-up-form" action="{{AppRootSubUrl}}/user/forget_password" method="post">
         {{.CsrfTokenHtml}}
         <div class="panel-header">
             <h2>{{.i18n.Tr "auth.forgot_password"}}</h2>

--- a/templates/user/auth/reset_passwd.tmpl
+++ b/templates/user/auth/reset_passwd.tmpl
@@ -1,7 +1,7 @@
 {{template "ng/base/head" .}}
 {{template "ng/base/header" .}}
 <div id="sign-wrapper">
-    <form class="form-align form panel sign-panel sign-form container panel-radius" id="sign-up-form" action="/user/reset_password?code={{.Code}}" method="post">
+    <form class="form-align form panel sign-panel sign-form container panel-radius" id="sign-up-form" action="{{AppRootSubUrl}}/user/reset_password?code={{.Code}}" method="post">
         {{.CsrfTokenHtml}}
         <div class="panel-header">
             <h2>{{.i18n.Tr "auth.reset_password"}}</h2>

--- a/templates/user/auth/signin.tmpl
+++ b/templates/user/auth/signin.tmpl
@@ -1,7 +1,7 @@
 {{template "ng/base/head" .}}
 {{template "ng/base/header" .}}
 <div id="sign-wrapper">
-    <form class="form-align form panel sign-panel sign-form container panel-radius" id="sign-up-form" action="/user/login" method="post">
+    <form class="form-align form panel sign-panel sign-form container panel-radius" id="sign-up-form" action="{{AppRootSubUrl}}/user/login" method="post">
         <div class="panel-header">
             <h2>{{if .IsSocialLogin}}{{.i18n.Tr "social_sign_in" | Str2html}}{{else}}{{.i18n.Tr "sign_in"}}{{end}}</h2>
         </div>
@@ -24,12 +24,12 @@
             <div class="field">
                 <span class="form-label"></span>
                 <button class="btn btn-green btn-large btn-radius">{{.i18n.Tr "sign_in"}}</button>&nbsp;&nbsp;&nbsp;&nbsp;
-                {{if not .IsSocialLogin}}<a href="/user/forget_password">{{.i18n.Tr "auth.forget_password"}}</a>{{end}}
+                {{if not .IsSocialLogin}}<a href="{{AppRootSubUrl}}/user/forget_password">{{.i18n.Tr "auth.forget_password"}}</a>{{end}}
             </div>
             {{if not .IsSocialLogin}}
             <div class="field">
                 <label></label>
-                <a href="/user/sign_up">{{.i18n.Tr "auth.sign_up_now" | Str2html}}</a>
+                <a href="{{AppRootSubUrl}}/user/sign_up">{{.i18n.Tr "auth.sign_up_now" | Str2html}}</a>
             </div>
             {{if .OauthEnabled}}
             <hr/>

--- a/templates/user/auth/signup.tmpl
+++ b/templates/user/auth/signup.tmpl
@@ -1,7 +1,7 @@
 {{template "ng/base/head" .}}
 {{template "ng/base/header" .}}
 <div id="sign-wrapper">
-    <form class="form-align form panel panel-radius sign-panel sign-form container" id="sign-up-form" action="/user/sign_up" method="post">
+    <form class="form-align form panel panel-radius sign-panel sign-form container" id="sign-up-form" action="{{AppRootSubUrl}}/user/sign_up" method="post">
         <div class="panel-header">
             <h2>{{if .IsSocialLogin}}{{.i18n.Tr "social_sign_in" | Str2html}}{{else}}{{.i18n.Tr "sign_up"}}{{end}}</h2>
         </div>
@@ -40,7 +40,7 @@
             </div>
             <div class="field">
                 <span class="form-label"></span>
-                <a href="/user/login">{{if .IsSocialLogin}}{{.i18n.Tr "auth.social_register_hepler_msg"}}{{else}}{{.i18n.Tr "auth.register_hepler_msg"}}{{end}}</a>
+                <a href="{{AppRootSubUrl}}/user/login">{{if .IsSocialLogin}}{{.i18n.Tr "auth.social_register_hepler_msg"}}{{else}}{{.i18n.Tr "auth.register_hepler_msg"}}{{end}}</a>
             </div>
         	{{end}}
         </div>

--- a/templates/user/dashboard/dashboard.tmpl
+++ b/templates/user/dashboard/dashboard.tmpl
@@ -12,17 +12,17 @@
                 </div>
                 <div class="content left {{if eq .GetOpType 5}}push-news{{end}} grid-4-5">
                     <p class="text-bold">
-                        <a href="/{{.GetActUserName}}">{{.GetActUserName}}</a>
+                        <a href="{{AppRootSubUrl}}/{{.GetActUserName}}">{{.GetActUserName}}</a>
                         {{if eq .GetOpType 1}}
-                        {{$.i18n.Tr "action.create_repo" .GetRepoLink .GetRepoLink | Str2html}}
+                        {{$.i18n.Tr "action.create_repo" AppRootSubUrl .GetRepoLink .GetRepoLink | Str2html}}
                         {{else if eq .GetOpType 5}}
-                        {{$.i18n.Tr "action.commit_repo" .GetRepoLink .GetBranch .GetBranch .GetRepoLink .GetRepoLink | Str2html}}
+                        {{$.i18n.Tr "action.commit_repo" AppRootSubUrl .GetRepoLink .GetBranch .GetBranch AppRootSubUrl .GetRepoLink .GetRepoLink | Str2html}}
                         {{else if eq .GetOpType 6}}
                         {{ $index := index .GetIssueInfos 0}}
-                        {{$.i18n.Tr "action.create_issue" .GetRepoLink $index .GetRepoLink $index | Str2html}}
+                        {{$.i18n.Tr "action.create_issue" AppRootSubUrl .GetRepoLink $index .GetRepoLink $index | Str2html}}
                         {{else if eq .GetOpType 10}}
                         {{ $index := index .GetIssueInfos 0}}
-                        {{$.i18n.Tr "action.comment_issue" .GetRepoLink $index .GetRepoLink $index | Str2html}}
+                        {{$.i18n.Tr "action.comment_issue" AppRootSubUrl .GetRepoLink $index .GetRepoLink $index | Str2html}}
                         {{end}}
                     </p>
                     {{if eq .GetOpType 5}}
@@ -31,7 +31,7 @@
                             {{ $push := ActionContent2Commits .}}
                             {{ $repoLink := .GetRepoLink}}
                             {{range $push.Commits}}
-                            <li><img class="avatar-16" src="{{AvatarLink .AuthorEmail}}?s=16"> <a href="/{{$repoLink}}/commit/{{.Sha1}}">{{ShortSha .Sha1}}</a> <span class="text-truncate grid-4-5">{{.Message}}</span></li>
+                            <li><img class="avatar-16" src="{{AvatarLink .AuthorEmail}}?s=16"> <a href="{{AppRootSubUrl}}/{{$repoLink}}/commit/{{.Sha1}}">{{ShortSha .Sha1}}</a> <span class="text-truncate grid-4-5">{{.Message}}</span></li>
                             {{end}}
                         </ul>
                     </div>
@@ -58,9 +58,9 @@
                         <i class="octicon octicon-plus"></i>
                     </button>
                     <ul class="menu menu-vertical drop-down" id="dashboard-new-repo-menu">
-                        <li><a href="/repo/create"><i class="octicon octicon-repo-create"></i>{{.i18n.Tr "new_repo"}}</a></li>
-                        <li><a href="/repo/migrate"><i class="octicon octicon-repo-clone"></i>{{.i18n.Tr "new_migrate"}}</a></li>
-                        <li><a href="/org/create"><i class="octicon octicon-organization"></i>{{.i18n.Tr "new_org"}}</a></li>
+                        <li><a href="{{AppRootSubUrl}}/repo/create"><i class="octicon octicon-repo-create"></i>{{.i18n.Tr "new_repo"}}</a></li>
+                        <li><a href="{{AppRootSubUrl}}/repo/migrate"><i class="octicon octicon-repo-clone"></i>{{.i18n.Tr "new_migrate"}}</a></li>
+                        <li><a href="{{AppRootSubUrl}}/org/create"><i class="octicon octicon-organization"></i>{{.i18n.Tr "new_org"}}</a></li>
                     </ul>
                 </li>
             </ul>
@@ -75,7 +75,7 @@
                     <ul class="list-no-style">
                         {{range .Repos}}
                         <li {{if .IsPrivate}}class="private"{{end}}>
-                            <a href="/{{$.ContextUser.Name}}/{{.Name}}">
+                            <a href="{{AppRootSubUrl}}/{{$.ContextUser.Name}}/{{.Name}}">
                                 <i class="octicon octicon-{{if .IsPrivate}}lock{{else if .IsFork}}repo-forked{{else if .IsMirror}}repo-clone{{else}}repo{{end}}"></i>
                                 <span class="repo-name">
                                     <strong class="repo">{{.Name}}</strong>
@@ -125,7 +125,7 @@
                     <ul class="list-no-style">
                         {{range .ContextUser.Orgs}}
                         <li>
-                            <a href="/{{.Name}}">
+                            <a href="{{AppRootSubUrl}}/{{.Name}}">
                                 <i class="octicon octicon-organization"></i>
                                 <span class="repo-name">
                                     <strong class="repo">{{.Name}}</strong>
@@ -150,7 +150,7 @@
                     <ul class="list-no-style">
                         {{range .Mirrors}}
                         <li {{if .IsPrivate}}class="private"{{end}}>
-                            <a href="/{{$.ContextUser.Name}}/{{.Name}}">
+                            <a href="{{AppRootSubUrl}}/{{$.ContextUser.Name}}/{{.Name}}">
                                 <i class="octicon octicon-repo-clone"></i>
                                 <span class="repo-name">
                                     <strong class="repo">{{.Name}}</strong>

--- a/templates/user/dashboard/nav.tmpl
+++ b/templates/user/dashboard/nav.tmpl
@@ -9,7 +9,7 @@
                 <p class="panel-header"><strong>{{.i18n.Tr "home.switch_dashboard_context"}}</strong></p>
                 <ul class="menu menu-vertical switching-list" id="dashboard-switch-menu">
                     <li class="org {{if eq .ContextUser.Id .SignedUser.Id}}checked{{end}}">
-                        <a href="/">
+                        <a href="{{AppRootSubUrl}}/">
                             <i class="octicon octicon-check"></i>
                             <img class="avatar-24" src="{{.SignedUser.AvatarLink}}" alt="user-avatar" />
                             {{.SignedUser.Name}}
@@ -25,10 +25,10 @@
                     </li>
                     {{end}}
                     <!-- <li>
-                        <a href="/user/settings/orgs"><i class="octicon octicon-organization"></i>{{.i18n.Tr "manage_org"}}</a>
+                        <a href="{{AppRootSubUrl}}/user/settings/orgs"><i class="octicon octicon-organization"></i>{{.i18n.Tr "manage_org"}}</a>
                     </li> -->
                     <li>
-                        <a href="/org/create"><i class="octicon octicon-plus"></i>{{.i18n.Tr "new_org"}}</a>
+                        <a href="{{AppRootSubUrl}}/org/create"><i class="octicon octicon-plus"></i>{{.i18n.Tr "new_org"}}</a>
                     </li>
                 </ul>
             </div>

--- a/templates/user/issues.tmpl
+++ b/templates/user/issues.tmpl
@@ -3,10 +3,10 @@
 <div id="body-nav">
     <div class="container">
         <ul class="nav nav-pills pull-right">
-            <li><a href="/">News Feed</a></li>
-            <li class="active"><a href="/issues">Issues</a></li>
-            <!-- <li><a href="/pulls">Pull Requests</a></li>
-            <li><a href="/stars">Stars</a></li> -->
+            <li><a href="{{AppRootSubUrl}}/">News Feed</a></li>
+            <li class="active"><a href="{{AppRootSubUrl}}/issues">Issues</a></li>
+            <!-- <li><a href="{{AppRootSubUrl}}/pulls">Pull Requests</a></li>
+            <li><a href="{{AppRootSubUrl}}/stars">Stars</a></li> -->
         </ul>
         <h3>Your Issues</h3>
     </div>
@@ -17,30 +17,30 @@
     <div id="issue">
         <div class="col-md-3 filter-list">
             <ul class="list-unstyled">
-                <li><a href="/issues?state={{.State}}&repoid={{.RepoId}}"{{if eq .ViewType "all"}} class="active"{{end}}>In your repositories <strong class="pull-right">{{.IssueStats.AllCount}}</strong></a></li>
-                <li><a href="/issues?type=assigned&repoid={{.RepoId}}&state={{.State}}"{{if eq .ViewType "assigned"}} class="active"{{end}}>Assigned to you <strong class="pull-right">{{.IssueStats.AssignCount}}</strong></a></li>
-                <li><a href="/issues?type=created_by&repoid={{.RepoId}}&state={{.State}}"{{if eq .ViewType "created_by"}} class="active"{{end}}>Created by you <strong class="pull-right">{{.IssueStats.CreateCount}}</strong></a></li>
+                <li><a href="{{AppRootSubUrl}}/issues?state={{.State}}&repoid={{.RepoId}}"{{if eq .ViewType "all"}} class="active"{{end}}>In your repositories <strong class="pull-right">{{.IssueStats.AllCount}}</strong></a></li>
+                <li><a href="{{AppRootSubUrl}}/issues?type=assigned&repoid={{.RepoId}}&state={{.State}}"{{if eq .ViewType "assigned"}} class="active"{{end}}>Assigned to you <strong class="pull-right">{{.IssueStats.AssignCount}}</strong></a></li>
+                <li><a href="{{AppRootSubUrl}}/issues?type=created_by&repoid={{.RepoId}}&state={{.State}}"{{if eq .ViewType "created_by"}} class="active"{{end}}>Created by you <strong class="pull-right">{{.IssueStats.CreateCount}}</strong></a></li>
                 <li><hr/></li>
                 {{range .Repos}}
-                <li><a href="/issues?type={{$.ViewType}}{{if eq $.RepoId .Id}}{{else}}&repoid={{.Id}}{{end}}&state={{$.State}}" class="sm{{if eq $.RepoId .Id}} active{{end}}">{{$.SignedUser.Name}}/{{.Name}} <strong class="pull-right">{{if $.IsShowClosed}}{{.NumClosedIssues}}{{else}}{{.NumOpenIssues}}{{end}}</strong></a></li>
+                <li><a href="{{AppRootSubUrl}}/issues?type={{$.ViewType}}{{if eq $.RepoId .Id}}{{else}}&repoid={{.Id}}{{end}}&state={{$.State}}" class="sm{{if eq $.RepoId .Id}} active{{end}}">{{$.SignedUser.Name}}/{{.Name}} <strong class="pull-right">{{if $.IsShowClosed}}{{.NumClosedIssues}}{{else}}{{.NumOpenIssues}}{{end}}</strong></a></li>
                 {{end}}
             </ul>
         </div>
         <div class="col-md-9">
             <div class="filter-option">
                 <div class="btn-group">
-                    <a class="btn btn-default issue-open{{if not .IsShowClosed}} active{{end}}" href="/issues?type={{.ViewType}}&repoid={{.RepoId}}">Open</a>
-                    <a class="btn btn-default issue-close{{if .IsShowClosed}} active{{end}}" href="/issues?type={{.ViewType}}&repoid={{.RepoId}}&state=closed">Closed</a>
+                    <a class="btn btn-default issue-open{{if not .IsShowClosed}} active{{end}}" href="{{AppRootSubUrl}}/issues?type={{.ViewType}}&repoid={{.RepoId}}">Open</a>
+                    <a class="btn btn-default issue-close{{if .IsShowClosed}} active{{end}}" href="{{AppRootSubUrl}}/issues?type={{.ViewType}}&repoid={{.RepoId}}&state=closed">Closed</a>
                 </div>
             </div>
             <div class="issues list-group">
                 {{range .Issues}}{{if .}}
                 <div class="list-group-item issue-item" id="issue-{{.Id}}">
                     <span class="number pull-right">#{{.Index}}</span>
-                    <h5 class="title"><a href="/{{.Repo.Owner.Name}}/{{.Repo.Name}}/issues/{{.Index}}">{{.Name}}</a></h5>
+                    <h5 class="title"><a href="{{AppRootSubUrl}}/{{.Repo.Owner.Name}}/{{.Repo.Name}}/issues/{{.Index}}">{{.Name}}</a></h5>
                     <p class="info">
                         <span class="author"><img class="avatar" src="{{.Poster.AvatarLink}}" alt="" width="20"/>
-                        <a href="/user/{{.Poster.Name}}">{{.Poster.Name}}</a></span>
+                        <a href="{{AppRootSubUrl}}/user/{{.Poster.Name}}">{{.Poster.Name}}</a></span>
                         <span class="time">{{TimeSince .Created $.Lang}}</span>
                         <span class="comment"><i class="fa fa-comments"></i> {{.NumComments}}</span>
                     </p>

--- a/templates/user/profile.tmpl
+++ b/templates/user/profile.tmpl
@@ -66,7 +66,7 @@
                     <li>
                         <div class="meta pull-right"><!-- <i class="fa fa-star"></i> {{.NumStars}} --> <i class="fa fa-code-fork"></i> {{.NumForks}}</div>
                         <h4>
-                            <a href="/{{$.Owner.Name}}/{{.Name}}">{{.Name}}{{if .IsPrivate}} <span class="label label-default">Private</span>{{end}}</a>
+                            <a href="{{AppRootSubUrl}}/{{$.Owner.Name}}/{{.Name}}">{{.Name}}{{if .IsPrivate}} <span class="label label-default">Private</span>{{end}}</a>
                         </h4>
                         <p class="desc">{{.Description}}</p>
                         <div class="info">Last updated {{TimeSince .Updated $.Lang}}</div>

--- a/templates/user/settings/delete.tmpl
+++ b/templates/user/settings/delete.tmpl
@@ -11,7 +11,7 @@
                         <p class="panel-header"><strong>{{.i18n.Tr "settings.delete_account"}}</strong></p>
                         <div class="panel-body panel-content">
                             <span class="alert alert-red alert-radius block"><i class="octicon octicon-alert"></i>{{.i18n.Tr "settings.delete_prompt" | Str2html}}</span>
-                            <form  action="/user/settings/delete" method="post">
+                            <form  action="{{AppRootSubUrl}}/user/settings/delete" method="post">
                                 {{.CsrfTokenHtml}}
                                 <p class="field">
                                     <span class="form-label"></span>

--- a/templates/user/settings/nav.tmpl
+++ b/templates/user/settings/nav.tmpl
@@ -2,11 +2,11 @@
     <p class="panel-header"><strong>{{.i18n.Tr "settings"}}</strong></p>
     <div class="panel-body">
         <ul class="menu menu-vertical switching-list grid-1-5 left">
-            <li {{if .PageIsSettingsProfile}}class="current"{{end}}><a href="/user/settings">{{.i18n.Tr "settings.profile"}}</a></li>
-            <li {{if .PageIsSettingsPassword}}class="current"{{end}}><a href="/user/settings/password">{{.i18n.Tr "settings.password"}}</a></li>
-            <li {{if .PageIsSettingsSSHKeys}}class="current"{{end}}><a href="/user/settings/ssh">{{.i18n.Tr "settings.ssh_keys"}}</a></li>
-            <li {{if .PageIsSettingsSocial}}class="current"{{end}}><a href="/user/settings/social">{{.i18n.Tr "settings.social"}}</a></li>
-            <li {{if .PageIsSettingsDelete}}class="current"{{end}}><a href="/user/settings/delete">{{.i18n.Tr "settings.delete"}}</a></li>
+            <li {{if .PageIsSettingsProfile}}class="current"{{end}}><a href="{{AppRootSubUrl}}/user/settings">{{.i18n.Tr "settings.profile"}}</a></li>
+            <li {{if .PageIsSettingsPassword}}class="current"{{end}}><a href="{{AppRootSubUrl}}/user/settings/password">{{.i18n.Tr "settings.password"}}</a></li>
+            <li {{if .PageIsSettingsSSHKeys}}class="current"{{end}}><a href="{{AppRootSubUrl}}/user/settings/ssh">{{.i18n.Tr "settings.ssh_keys"}}</a></li>
+            <li {{if .PageIsSettingsSocial}}class="current"{{end}}><a href="{{AppRootSubUrl}}/user/settings/social">{{.i18n.Tr "settings.social"}}</a></li>
+            <li {{if .PageIsSettingsDelete}}class="current"{{end}}><a href="{{AppRootSubUrl}}/user/settings/delete">{{.i18n.Tr "settings.delete"}}</a></li>
         </ul>
     </div>
 </div>

--- a/templates/user/settings/password.tmpl
+++ b/templates/user/settings/password.tmpl
@@ -9,7 +9,7 @@
                 <div id="setting-content">
                     <div id="user-profile-setting-content" class="panel panel-radius">
                         <p class="panel-header"><strong>{{.i18n.Tr "settings.change_password"}}</strong></p>
-                        <form class="form form-align panel-body" id="user-profile-form" action="/user/settings/password" method="post">
+                        <form class="form form-align panel-body" id="user-profile-form" action="{{AppRootSubUrl}}/user/settings/password" method="post">
                             {{.CsrfTokenHtml}}
                             <p class="field">
                                 <label class="req" for="old-password">{{.i18n.Tr "settings.old_password"}}</label>

--- a/templates/user/settings/profile.tmpl
+++ b/templates/user/settings/profile.tmpl
@@ -11,7 +11,7 @@
                         <div class="panel-header">
                             <strong>{{.i18n.Tr "settings.public_profile"}}</strong>
                         </div>
-                        <form class="form form-align panel-body" id="user-profile-form" action="/user/settings" method="post">
+                        <form class="form form-align panel-body" id="user-profile-form" action="{{AppRootSubUrl}}/user/settings" method="post">
                             {{.CsrfTokenHtml}}
                         	<div class="text-center panel-desc">{{.i18n.Tr "settings.profile_desc"}}</div>
                             <div class="field">

--- a/templates/user/settings/social.tmpl
+++ b/templates/user/settings/social.tmpl
@@ -20,7 +20,7 @@
                                     <p class="print">{{.Identity}}</p>
                                     <p class="activity"><i>{{$.i18n.Tr "settings.add_on"}} {{DateFormat .Created "M d, Y"}} —  <i class="octicon octicon-info"></i>{{$.i18n.Tr "settings.last_used"}} {{DateFormat .Updated "M d, Y"}}</i></p>
                                 </div>
-                                <a class="right btn btn-small btn-red btn-header btn-radius" href="/user/settings/social?remove={{.Id}}">{{$.i18n.Tr "settings.unbind"}}</a>
+                                <a class="right btn btn-small btn-red btn-header btn-radius" href="{{AppRootSubUrl}}/user/settings/social?remove={{.Id}}">{{$.i18n.Tr "settings.unbind"}}</a>
                             </li>
                             {{end}}
                         </ul>

--- a/templates/user/settings/sshkeys.tmpl
+++ b/templates/user/settings/sshkeys.tmpl
@@ -23,7 +23,7 @@
                                     <p class="print">{{.Fingerprint}}</p>
                                     <p class="activity"><i>{{$.i18n.Tr "settings.add_on"}} {{DateFormat .Created "M d, Y"}} —  <i class="octicon octicon-info"></i>{{if .HasUsed}}{{$.i18n.Tr "settings.last_used"}} {{DateFormat .Updated "M d, Y"}}{{else}}{{$.i18n.Tr "settings.no_activity"}}{{end}}</i></p>
                                 </div>
-                                <form action="/user/settings/ssh" method="post">
+                                <form action="{{AppRootSubUrl}}/user/settings/ssh" method="post">
                                     {{$.CsrfTokenHtml}}
                                     <input name="_method" type="hidden" value="DELETE">
                                     <input name="id" type="hidden" value="{{.Id}}">
@@ -35,7 +35,7 @@
                     </div>
                     <p>{{.i18n.Tr "settings.ssh_helper" | Str2html}}</p>
                     <br>
-                    <form class="panel panel-radius form form-align hide" id="user-ssh-add-form" action="/user/settings/ssh" method="post">
+                    <form class="panel panel-radius form form-align hide" id="user-ssh-add-form" action="{{AppRootSubUrl}}/user/settings/ssh" method="post">
                         {{.CsrfTokenHtml}}
                         <p class="panel-header"><strong>{{.i18n.Tr "settings.add_new_key"}}</strong></p>
                         <div class="panel-body">


### PR DESCRIPTION
### Allow Gogs to run from a suburl behind a reverse proxy.

e.g. http://mydomain.com/gogs/

The suburl is taken from the **ROOT_URL** setting and applied to generated links and redirects.
So if ROOT_URL is set to http://mydomain.com/ everything works as it did before this change,
if ROOT_URL is set to http://mydomain.com/gogs/ the suburl setting (AppRootSubUrl) will 
be set to "/gogs" and used throughout the app to ensure correct links and urls.

nginx config example:

```
location /gogs/ {
    proxy_pass http://localhost:3000/; # note the trailing slash
    include proxy_params;
}
```

Known issues:
- Switching language redirects to /... instead of /suburl/... (macaron-contrib/i18n)
- Captcha renders wrong url to image, /captcha/x.png instead of /suburl/captcha/x.png (macaron-contrib/captcha)
