### PR TITLE
Intial commit for systemd support

### DIFF
--- a/scripts/systemd/gogs.service
+++ b/scripts/systemd/gogs.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Gogs (Go Git Service) server
+After=syslog.target
+After=network.target
+#After=mysqld.service
+#After=postgresql.service
+#After=memcached.service
+#After=redis.service
+
+[Service]
+Type=simple
+User=git
+Group=git
+ExecStart=/home/git/gogs/gogs/start.sh
+WorkingDirectory=/home/git/gogs
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
It put it in the script directory, because in a normal linux installation the systemd service file will be installed in to following location. `/usr/lib/systemd/system/`
