### PR TITLE
Set cookiepath to AppSubUrl

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -97,9 +97,10 @@ func newMacaron() *macaron.Macaron {
 		Config:   *setting.SessionConfig,
 	}))
 	m.Use(csrf.Generate(csrf.Options{
-		Secret:    setting.SecretKey,
-		SetCookie: true,
-		Header:    "X-Csrf-Token",
+		Secret:     setting.SecretKey,
+		SetCookie:  true,
+		Header:     "X-Csrf-Token",
+		CookiePath: setting.AppSubUrl,
 	}))
 	m.Use(toolbox.Toolboxer(m, toolbox.Options{
 		HealthCheckFuncs: []*toolbox.HealthCheckFuncDesc{

--- a/modules/middleware/auth.go
+++ b/modules/middleware/auth.go
@@ -48,7 +48,7 @@ func Toggle(options *ToggleOptions) macaron.Handler {
 				if strings.HasSuffix(ctx.Req.RequestURI, "watch") {
 					return
 				}
-				ctx.SetCookie("redirect_to", "/"+url.QueryEscape(setting.AppSubUrl+ctx.Req.RequestURI))
+				ctx.SetCookie("redirect_to", "/"+url.QueryEscape(setting.AppSubUrl+ctx.Req.RequestURI), 0, setting.AppSubUrl)
 				ctx.Redirect(setting.AppSubUrl + "/user/login")
 				return
 			} else if !ctx.User.IsActive && setting.Service.RegisterEmailConfirm {

--- a/modules/middleware/repo.go
+++ b/modules/middleware/repo.go
@@ -298,7 +298,7 @@ func RequireTrueOwner() macaron.Handler {
 	return func(ctx *Context) {
 		if !ctx.Repo.IsTrueOwner && !ctx.Repo.IsAdmin {
 			if !ctx.IsSigned {
-				ctx.SetCookie("redirect_to", "/"+url.QueryEscape(setting.AppSubUrl+ctx.Req.RequestURI))
+				ctx.SetCookie("redirect_to", "/"+url.QueryEscape(setting.AppSubUrl+ctx.Req.RequestURI), 0, setting.AppSubUrl)
 				ctx.Redirect(setting.AppSubUrl + "/user/login")
 				return
 			}

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -380,6 +380,7 @@ func newSessionService() {
 	SessionConfig = new(session.Config)
 	SessionConfig.ProviderConfig = strings.Trim(Cfg.MustValue("session", "PROVIDER_CONFIG"), "\" ")
 	SessionConfig.CookieName = Cfg.MustValue("session", "COOKIE_NAME", "i_like_gogits")
+	SessionConfig.CookiePath = AppSubUrl
 	SessionConfig.Secure = Cfg.MustBool("session", "COOKIE_SECURE")
 	SessionConfig.EnableSetCookie = Cfg.MustBool("session", "ENABLE_SET_COOKIE", true)
 	SessionConfig.Gclifetime = Cfg.MustInt64("session", "GC_INTERVAL_TIME", 86400)

--- a/routers/repo/issue.go
+++ b/routers/repo/issue.go
@@ -54,7 +54,7 @@ func Issues(ctx *middleware.Context) {
 	isShowClosed := ctx.Query("state") == "closed"
 
 	if viewType != "all" && !ctx.IsSigned {
-		ctx.SetCookie("redirect_to", "/"+url.QueryEscape(setting.AppSubUrl+ctx.Req.RequestURI))
+		ctx.SetCookie("redirect_to", "/"+url.QueryEscape(setting.AppSubUrl+ctx.Req.RequestURI), 0, setting.AppSubUrl)
 		ctx.Redirect(setting.AppSubUrl + "/user/login")
 		return
 	}

--- a/routers/user/auth.go
+++ b/routers/user/auth.go
@@ -52,8 +52,8 @@ func SignIn(ctx *middleware.Context) {
 	defer func() {
 		if !isSucceed {
 			log.Trace("auto-login cookie cleared: %s", uname)
-			ctx.SetCookie(setting.CookieUserName, "", -1)
-			ctx.SetCookie(setting.CookieRememberName, "", -1)
+			ctx.SetCookie(setting.CookieUserName, "", -1, setting.AppSubUrl)
+			ctx.SetCookie(setting.CookieRememberName, "", -1, setting.AppSubUrl)
 			return
 		}
 	}()
@@ -77,7 +77,7 @@ func SignIn(ctx *middleware.Context) {
 	ctx.Session.Set("uid", u.Id)
 	ctx.Session.Set("uname", u.Name)
 	if redirectTo, _ := url.QueryUnescape(ctx.GetCookie("redirect_to")); len(redirectTo) > 0 {
-		ctx.SetCookie("redirect_to", "", -1)
+		ctx.SetCookie("redirect_to", "", -1, setting.AppSubUrl)
 		ctx.Redirect(redirectTo)
 		return
 	}
@@ -113,9 +113,9 @@ func SignInPost(ctx *middleware.Context, form auth.SignInForm) {
 
 	if form.Remember {
 		days := 86400 * setting.LogInRememberDays
-		ctx.SetCookie(setting.CookieUserName, u.Name, days)
+		ctx.SetCookie(setting.CookieUserName, u.Name, days, setting.AppSubUrl)
 		ctx.SetSuperSecureCookie(base.EncodeMd5(u.Rands+u.Passwd),
-			setting.CookieRememberName, u.Name, days)
+			setting.CookieRememberName, u.Name, days, setting.AppSubUrl)
 	}
 
 	// Bind with social account.
@@ -135,7 +135,7 @@ func SignInPost(ctx *middleware.Context, form auth.SignInForm) {
 	ctx.Session.Set("uid", u.Id)
 	ctx.Session.Set("uname", u.Name)
 	if redirectTo, _ := url.QueryUnescape(ctx.GetCookie("redirect_to")); len(redirectTo) > 0 {
-		ctx.SetCookie("redirect_to", "", -1)
+		ctx.SetCookie("redirect_to", "", -1, setting.AppSubUrl)
 		ctx.Redirect(redirectTo)
 		return
 	}
@@ -149,8 +149,8 @@ func SignOut(ctx *middleware.Context) {
 	ctx.Session.Delete("socialId")
 	ctx.Session.Delete("socialName")
 	ctx.Session.Delete("socialEmail")
-	ctx.SetCookie(setting.CookieUserName, "", -1)
-	ctx.SetCookie(setting.CookieRememberName, "", -1)
+	ctx.SetCookie(setting.CookieUserName, "", -1, setting.AppSubUrl)
+	ctx.SetCookie(setting.CookieRememberName, "", -1, setting.AppSubUrl)
 	ctx.Redirect(setting.AppSubUrl + "/")
 }
 


### PR DESCRIPTION
Set cookiepath to AppSubUrl instead of domain root (if a suburl is configured) so the cookie won't be sent to other applications running on the same domain if a suburl is used.

Requires pull requests:
https://github.com/macaron-contrib/session/pull/1
https://github.com/macaron-contrib/csrf/pull/2
