### PR TITLE
bugfix, suburl defaults to empty string when suburl is undefined

### DIFF
--- a/public/ng/js/gogs.js
+++ b/public/ng/js/gogs.js
@@ -616,7 +616,7 @@ function initProfile() {
 }
 
 $(document).ready(function () {
-    Gogs.AppSubUrl = $('head').data('suburl');
+    Gogs.AppSubUrl = $('head').data('suburl') || '';
     initCore();
     if ($('#user-profile-setting').length) {
         initUserSetting();


### PR DESCRIPTION
My gogs  server address is `http://127.0.0.1:3333/`.
It will redirect to `http://127.0.0.1:3333/undefined/user/sign_up` when clicking `sign-up` or `sign-in`.
