### PR TITLE
Add CentOS init script

### DIFF
--- a/scripts/init/centos/gogs
+++ b/scripts/init/centos/gogs
@@ -42,7 +42,7 @@ RETVAL=0
 DAEMON_OPTS=""
 
 # Set additional options, if any
-[ ! -z "$GOGS_USER" ] && DAEMON_OPTS="$DAEMON_OPTS --user=${USER}"
+[ ! -z "$GOGS_USER" ] && DAEMON_OPTS="$DAEMON_OPTS --user=${GOGS_USER}"
 
 start() {
   cd ${GOGS_HOME}


### PR DESCRIPTION
This PR adds an init script for CentOS (<= 6). It also supports reading from /etc/sysconfig/gogs if present to override the defaults put in.

It has only seen limited testing! More tests are welcome.
