### PR TITLE
Added "init.d" service script for Debian-based Linux.

### DIFF
--- a/scripts/init/debian/gogs
+++ b/scripts/init/debian/gogs
@@ -1,0 +1,129 @@
+#! /bin/sh
+### BEGIN INIT INFO
+# Provides:          gogs
+# Required-Start:    $syslog $network
+# Required-Stop:     $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: A self-hosted Git service written in Go.
+# Description:       A self-hosted Git service written in Go.
+### END INIT INFO
+
+# Author: Danny Boisvert
+
+# Do NOT "set -e"
+
+# PATH should only include /usr/* if it runs after the mountnfs.sh script
+PATH=/sbin:/usr/sbin:/bin:/usr/bin
+DESC="Go Git Service"
+NAME=gogs
+SERVICEVERBOSE=yes
+PIDFILE=/var/run/$NAME.pid
+SCRIPTNAME=/etc/init.d/$NAME
+WORKINGDIR=/home/git/gogs
+DAEMON=$WORKINGDIR/$NAME
+DAEMON_ARGS="web"
+USER=git
+
+# Read configuration variable file if it is present
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+# Exit if the package is not installed
+[ -x "$DAEMON" ] || exit 0
+
+# Prepare the starting daemon command depending on available non-mandatory variables
+STARTDEAMONEVALOPTS=""
+[ ! -z "$USER" ] && STARTDEAMONEVALOPTS="$STARTDEAMONEVALOPTS --chuid $USER "
+[ ! -z "$WORKINGDIR" ] && STARTDEAMONEVALOPTS="$STARTDEAMONEVALOPTS --chdir \"$WORKINGDIR\" "
+
+# Load the VERBOSE setting and other rcS variables
+. /lib/init/vars.sh
+
+# Define LSB log_* functions.
+# Depend on lsb-base (>= 3.2-14) to ensure that this file is present
+# and status_of_proc is working.
+. /lib/lsb/init-functions
+
+#
+# Function that starts the daemon/service
+#
+do_start()
+{
+	# Return
+	#   0 if daemon has been started
+	#   1 if daemon was already running
+	#   2 if daemon could not be started
+	sh -c "start-stop-daemon --start --quiet --pidfile $PIDFILE --make-pidfile \\
+			$STARTDEAMONEVALOPTS --exec $DAEMON -- $DAEMON_ARGS --test > /dev/null \\
+			|| return 1"
+	sh -c "start-stop-daemon --start --quiet --pidfile $PIDFILE --make-pidfile \\
+			$STARTDEAMONEVALOPTS --background --exec $DAEMON -- $DAEMON_ARGS \\
+			|| return 2"
+}
+
+#
+# Function that stops the daemon/service
+#
+do_stop()
+{
+	# Return
+	#   0 if daemon has been stopped
+	#   1 if daemon was already stopped
+	#   2 if daemon could not be stopped
+	#   other if a failure occurred
+	start-stop-daemon --stop --quiet --retry=TERM/10/KILL/5 --pidfile $PIDFILE --name $NAME
+	RETVAL="$?"
+	[ "$RETVAL" = 2 ] && return 2
+	start-stop-daemon --stop --quiet --oknodo --retry=0/10/KILL/5 --exec $DAEMON
+	[ "$?" = 2 ] && return 2
+	# Many daemons don't delete their pidfiles when they exit.
+	rm -f $PIDFILE
+	return "$RETVAL"
+}
+
+
+case "$1" in
+  start)
+	[ "$SERVICEVERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
+	do_start
+	case "$?" in
+		0|1) [ "$SERVICEVERBOSE" != no ] && log_end_msg 0 ;;
+		2) [ "$SERVICEVERBOSE" != no ] && log_end_msg 1 ;;
+	esac
+	;;
+  stop)
+	[ "$SERVICEVERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
+	do_stop
+	case "$?" in
+		0|1) [ "$SERVICEVERBOSE" != no ] && log_end_msg 0 ;;
+		2) [ "$SERVICEVERBOSE" != no ] && log_end_msg 1 ;;
+	esac
+	;;
+  status)
+	status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
+	;;
+  restart|force-reload)
+	log_daemon_msg "Restarting $DESC" "$NAME"
+	do_stop
+	case "$?" in
+	  0|1)
+		do_start
+		case "$?" in
+			0) log_end_msg 0 ;;
+			1) log_end_msg 1 ;; # Old process is still running
+			*) log_end_msg 1 ;; # Failed to start
+		esac
+		;;
+	  *)
+		# Failed to stop
+		log_end_msg 1
+		;;
+		esac
+	;;
+  *)
+		echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
+		exit 3
+		;;
+esac
+
+:


### PR DESCRIPTION
Compatible with "/etc/default/gogs" configuration file for adding or overwriting values.
Based on "/etc/init.d/skeleton" and tested on Raspbian 2014-06-20 (Debian 7.5 [Wheezy] ARM)

[TO FIX] For some reason, it's necessary to remove the value of `RUN_USER` from the `app.ini` configuration file because the following error occurs:
`2014/09/28 18:12:53 [setting.go:182 NewConfigContext()] [E] Expect user(git) but current user is:`
