### PR TITLE
Added some missing strings under the [action] category to german localization

### DIFF
--- a/conf/locale/locale_de-DE.ini
+++ b/conf/locale/locale_de-DE.ini
@@ -541,10 +541,11 @@ monitor.start = Startzeit
 monitor.execute_time = Ausführungszeit
 
 [action]
-create_repo = Repository erstellen <a href="%s/%s">%s</a>
-commit_repo = pushed to <a href="%s/%s/src/%s">%s</a> at <a href="%s/%s">%s</a>
-create_issue = opened issue <a href="%s/%s/issues/%s">%s#%s</a>
-comment_issue = commented on issue <a href="%s/%s/issues/%s">%s#%s</a>
+create_repo = hat Repository <a href="%s/%s">%s</a> erstellt
+commit_repo = hat nach <a href="%s/%s/src/%s">%s</a> in <a href="%s/%s">%s</a> gepusht
+create_issue = hat Issue <a href="%s/%s/issues/%s">%s#%s</a> eröffnet
+comment_issue = hat Issue <a href="%s/%s/issues/%s">%s#%s</a> kommentiert
+transfer_repo = hat Repository <code>%s</code> transferiert an <a href="/%s%s">%s</a>
 
 [tool]
 ago = vor
@@ -566,16 +567,3 @@ months = %d Monate %s
 years = %d Jahre %s
 raw_seconds = Sekunden
 raw_minutes = Minuten
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
added: `transfer_repo` string and translated some others in the same category. Changed the already translated string `create_repo`.

Judging from the English translation I aimed to have the strings form a complete sentence in context with the user name. I switched the tense to past participle because I find that to be more naturally sounding but I'm open to any comments on this.
