### PR TITLE
sort tags in descending order by version number

### DIFF
--- a/modules/git/repo_tag.go
+++ b/modules/git/repo_tag.go
@@ -22,7 +22,19 @@ func (repo *Repository) IsTagExist(tagName string) bool {
 
 // GetTags returns all tags of given repository.
 func (repo *Repository) GetTags() ([]string, error) {
+	if gitVer.AtLeast(MustParseVersion("2.0.0")) {
+		return repo.getTagsReversed()
+	}
 	stdout, stderr, err := com.ExecCmdDir(repo.Path, "git", "tag", "-l")
+	if err != nil {
+		return nil, errors.New(stderr)
+	}
+	tags := strings.Split(stdout, "\n")
+	return tags[:len(tags)-1], nil
+}
+
+func (repo *Repository) getTagsReversed() ([]string, error) {
+	stdout, stderr, err := com.ExecCmdDir(repo.Path, "git", "tag", "-l", "--sort=-v:refname")
 	if err != nil {
 		return nil, errors.New(stderr)
 	}

--- a/modules/git/version.go
+++ b/modules/git/version.go
@@ -74,6 +74,10 @@ func (v *Version) LessThan(that *Version) bool {
 	return v.Compare(that) < 0
 }
 
+func (v *Version) AtLeast(that *Version) bool {
+	return v.Compare(that) >= 0
+}
+
 // GetVersion returns current Git version installed.
 func GetVersion() (*Version, error) {
 	if gitVer != nil {


### PR DESCRIPTION
If git >= 2.0, sort tags in descending order by version number
