### PR TITLE
Fix malformed address

### DIFF
--- a/modules/mailer/mailer.go
+++ b/modules/mailer/mailer.go
@@ -33,7 +33,7 @@ func (m Message) Content() string {
 	}
 
 	// create mail content
-	content := "From: " + m.From + "<" + m.User +
+	content := "From: \"" + m.From + "\" <" + m.User +
 		">\r\nSubject: " + m.Subject + "\r\nContent-Type: " + contentType + "\r\n\r\n" + m.Body
 	return content
 }


### PR DESCRIPTION
Hello

All mail sent by Gogs is automatacaly flaged as spam by my own MTA (based on exim).
It's because the header doesn't follow the Exim guidelines.

Only the "" (and the space after them) is missing around the From attribute.
Please see this link for more informations : https://github.com/Exim/exim/wiki/Q0087
