### PR TITLE
update slack hook to use new format

### DIFF
--- a/models/slack.go
+++ b/models/slack.go
@@ -16,8 +16,6 @@ const (
 )
 
 type Slack struct {
-	Domain  string `json:"domain"`
-	Token   string `json:"token"`
 	Channel string `json:"channel"`
 }
 
@@ -34,14 +32,6 @@ type SlackPayload struct {
 type SlackAttachment struct {
 	Color string `json:"color"`
 	Text  string `json:"text"`
-}
-
-func GetSlackURL(domain string, token string) string {
-	return fmt.Sprintf(
-		"https://%s.slack.com/services/hooks/incoming-webhook?token=%s",
-		domain,
-		token,
-	)
 }
 
 func (p SlackPayload) GetJSONPayload() ([]byte, error) {

--- a/modules/auth/repo_form.go
+++ b/modules/auth/repo_form.go
@@ -81,8 +81,7 @@ func (f *NewWebhookForm) Validate(ctx *macaron.Context, errs binding.Errors) bin
 
 type NewSlackHookForm struct {
 	HookTaskType string `form:"hook_type" binding:"Required"`
-	Domain       string `form:"domain" binding:"Required`
-	Token        string `form:"token" binding:"Required"`
+	PayloadUrl   string `form:"payload_url" binding:"Required`
 	Channel      string `form:"channel" binding:"Required"`
 	PushOnly     bool   `form:"push_only"`
 	Active       bool   `form:"active"`

--- a/routers/repo/setting.go
+++ b/routers/repo/setting.go
@@ -483,9 +483,7 @@ func SlackHooksNewPost(ctx *middleware.Context, form auth.NewSlackHookForm) {
 	}
 
 	meta, err := json.Marshal(&models.Slack{
-		Domain:  form.Domain,
 		Channel: form.Channel,
-		Token:   form.Token,
 	})
 	if err != nil {
 		ctx.Handle(500, "SlackHooksNewPost: JSON marshal failed: ", err)
@@ -494,7 +492,7 @@ func SlackHooksNewPost(ctx *middleware.Context, form auth.NewSlackHookForm) {
 
 	w := &models.Webhook{
 		RepoId:      orCtx.RepoId,
-		Url:         models.GetSlackURL(form.Domain, form.Token),
+		Url:         form.PayloadUrl,
 		ContentType: models.JSON,
 		Secret:      "",
 		HookEvent: &models.HookEvent{
@@ -551,16 +549,14 @@ func SlackHooksEditPost(ctx *middleware.Context, form auth.NewSlackHookForm) {
 		return
 	}
 	meta, err := json.Marshal(&models.Slack{
-		Domain:  form.Domain,
 		Channel: form.Channel,
-		Token:   form.Token,
 	})
 	if err != nil {
 		ctx.Handle(500, "SlackHooksNewPost: JSON marshal failed: ", err)
 		return
 	}
 
-	w.Url = models.GetSlackURL(form.Domain, form.Token)
+	w.Url = form.PayloadUrl
 	w.Meta = string(meta)
 	w.HookEvent = &models.HookEvent{
 		PushOnly: form.PushOnly,

--- a/templates/repo/settings/hook_slack.tmpl
+++ b/templates/repo/settings/hook_slack.tmpl
@@ -4,12 +4,8 @@
     <input type="hidden" name="hook_type" value="slack">
     <div class="text-center panel-desc">{{.i18n.Tr "repo.settings.add_slack_hook_desc" | Str2html}}</div>
     <div class="field">
-        <label class="req" for="domain">{{.i18n.Tr "repo.settings.slack_domain"}}</label>
-        <input class="ipt ipt-large ipt-radius {{if .Err_UserName}}ipt-error{{end}}" id="domain" name="domain" type="text" value="{{.SlackHook.Domain}}" placeholde="myslack" required />
-    </div>
-    <div class="field">
-        <label class="req" for="token">{{.i18n.Tr "repo.settings.slack_token"}}</label>
-        <input class="ipt ipt-large ipt-radius {{if .Err_UserName}}ipt-error{{end}}" id="token" name="token" type="text" value="{{.SlackHook.Token}}" autocomplete="off" required />
+        <label class="req" for="payload-url">{{.i18n.Tr "repo.settings.payload_url"}}</label>
+        <input class="ipt ipt-large ipt-radius {{if .Err_UserName}}ipt-error{{end}}" id="payload-url" name="payload_url" type="url" value="{{.Webhook.Url}}" required />
     </div>
     <div class="field">
         <label class="req" for="channel">{{.i18n.Tr "repo.settings.slack_channel"}}</label>


### PR DESCRIPTION
Updating slack incoming webhook format to match their format for incoming webhooks (which is a unique URL with token - `https://hooks.slack.com/services/<token1>/<token2>`). You just need to use this webhook url directly.

Note - this is a breaking change. If you have an existing slack hook in the old format, you'll need to delete it and it back with the new format.

The prior format seems to be supported, but unsure for how long.
