### PR TITLE
force the use of InnoDB as db engine for all tables, fixes #59

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -129,7 +129,7 @@ func NewEngine() (err error) {
 	if err = SetEngine(); err != nil {
 		return err
 	}
-	if err = x.Sync2(tables...); err != nil {
+	if err = x.StoreEngine("InnoDB").Sync2(tables...); err != nil {
 		return fmt.Errorf("sync database struct error: %v\n", err)
 	}
 	return nil


### PR DESCRIPTION
See #59 for more detail.
