### PR TITLE
Add basic FCGI support

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -9,6 +9,7 @@ import (
 	"html/template"
 	"io/ioutil"
 	"net/http"
+	"net/http/fcgi"
 	"os"
 	"path"
 	"strings"
@@ -416,6 +417,8 @@ func runWeb(*cli.Context) {
 		err = http.ListenAndServe(listenAddr, m)
 	case setting.HTTPS:
 		err = http.ListenAndServeTLS(listenAddr, setting.CertFile, setting.KeyFile, m)
+	case setting.FCGI:
+		err = fcgi.Serve(nil, m)
 	default:
 		log.Fatal(4, "Invalid protocol: %s", setting.Protocol)
 	}

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -28,6 +28,7 @@ type Scheme string
 const (
 	HTTP  Scheme = "http"
 	HTTPS Scheme = "https"
+	FCGI  Scheme = "fcgi"
 )
 
 var (
@@ -180,6 +181,9 @@ func NewConfigContext() {
 		Protocol = HTTPS
 		CertFile = Cfg.MustValue("server", "CERT_FILE")
 		KeyFile = Cfg.MustValue("server", "KEY_FILE")
+	}
+	if Cfg.MustValue("server", "PROTOCOL") == "fcgi" {
+		Protocol = FCGI
 	}
 	Domain = Cfg.MustValue("server", "DOMAIN", "localhost")
 	HttpAddr = Cfg.MustValue("server", "HTTP_ADDR", "0.0.0.0")


### PR DESCRIPTION
Adds basic fcgi support, usable by spawn-fcgi with lighttpd and all.

Should be at least a start on #582, may need a wrapper shell script to work properly(if the webserver doesn't like starting it with parameters).
