### PR TITLE
Fix x padding for #repo-content for width < 1170px

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -9,6 +9,7 @@ import (
 	"html/template"
 	"io/ioutil"
 	"net/http"
+	"net/http/fcgi"
 	"os"
 	"path"
 	"strings"
@@ -416,6 +417,8 @@ func runWeb(*cli.Context) {
 		err = http.ListenAndServe(listenAddr, m)
 	case setting.HTTPS:
 		err = http.ListenAndServeTLS(listenAddr, setting.CertFile, setting.KeyFile, m)
+	case setting.FCGI:
+		err = fcgi.Serve(nil, m)
 	default:
 		log.Fatal(4, "Invalid protocol: %s", setting.Protocol)
 	}

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -28,6 +28,7 @@ type Scheme string
 const (
 	HTTP  Scheme = "http"
 	HTTPS Scheme = "https"
+	FCGI  Scheme = "fcgi"
 )
 
 var (
@@ -180,6 +181,9 @@ func NewConfigContext() {
 		Protocol = HTTPS
 		CertFile = Cfg.MustValue("server", "CERT_FILE")
 		KeyFile = Cfg.MustValue("server", "KEY_FILE")
+	}
+	if Cfg.MustValue("server", "PROTOCOL") == "fcgi" {
+		Protocol = FCGI
 	}
 	Domain = Cfg.MustValue("server", "DOMAIN", "localhost")
 	HttpAddr = Cfg.MustValue("server", "HTTP_ADDR", "0.0.0.0")


### PR DESCRIPTION
This pull request fixes the issue when resizing the window smaller than 1170 px, right now there is no padding/margin on sides and it looks broken.

This is a correction of #599.
