### PR TITLE
Fix x padding for #repo-content for width < 1170px

### DIFF
--- a/public/ng/less/gogs/repository.less
+++ b/public/ng/less/gogs/repository.less
@@ -89,7 +89,7 @@
     padding: 18px 0;
 }
 .repo-wide-wrapper {
-    padding: 18px 0;
+    padding: 18px;
     position: relative;
 }
 #repo-clone-url {


### PR DESCRIPTION
This pull request fixes the issue when resizing the window smaller than 1170 px, right now there is no padding/margin on sides and it looks broken.
