### PR TITLE
Update to ng/gogs.css to fix line number spacing

### DIFF
--- a/public/ng/css/gogs.css
+++ b/public/ng/css/gogs.css
@@ -1420,6 +1420,7 @@ The register and sign-in page style
 }
 .code-view .lines-code > pre > ol.linenums > li {
   padding: 0 10px;
+  line-height: 20px;
 }
 .code-view .lines-code > pre > ol.linenums > li.active {
   background: #ffffdd;


### PR DESCRIPTION
Issue with viewing source code in firefox, line numbers do not match up with displayed line numbers, this can be fixed by setting the line height to 20px
