### PR TITLE
Add function argument missing

### DIFF
--- a/modules/cron/doc.go
+++ b/modules/cron/doc.go
@@ -7,9 +7,9 @@ Callers may register Funcs to be invoked on a given schedule.  Cron will run
 them in their own goroutines.
 
 	c := cron.New()
-	c.AddFunc("0 30 * * * *", func() { fmt.Println("Every hour on the half hour") })
-	c.AddFunc("@hourly",      func() { fmt.Println("Every hour") })
-	c.AddFunc("@every 1h30m", func() { fmt.Println("Every hour thirty") })
+	c.AddFunc("Every hour on the half hour","0 30 * * * *", func() { fmt.Println("Every hour on the half hour") })
+	c.AddFunc("Every hour","@hourly", func() { fmt.Println("Every hour") })
+	c.AddFunc("Every hour and a half","@every 1h30m", func() { fmt.Println("Every hour thirty") })
 	c.Start()
 	..
 	// Funcs are invoked in their own goroutine, asynchronously.


### PR DESCRIPTION
Not enough arguments in call to c.AddFunc when I copied and pasted from cron documents.
