### PR TITLE
Use AppSubUrl as prefix for routes in FCGI mode

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -85,6 +85,9 @@ func newMacaron() *macaron.Macaron {
 	if setting.EnableGzip {
 		m.Use(macaron.Gziper())
 	}
+	if setting.Protocol == setting.FCGI {
+		m.SetURLPrefix(setting.AppSubUrl)
+	}
 	m.Use(macaron.Static(
 		path.Join(setting.StaticRootPath, "public"),
 		macaron.StaticOptions{


### PR DESCRIPTION
Minor fix to use `setting.AppSubUrl` as router URL prefix when in FCGI-mode.

Adds ability to run under a sub-URL when in FCGI-mode (e.g., `example.com/gogs/`)

Fixes remaining issues in #582.
