### PR TITLE
Cert command stub should return a non-zero exit code

### DIFF
--- a/cmd/cert_stub.go
+++ b/cmd/cert_stub.go
@@ -8,6 +8,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/codegangsta/cli"
@@ -31,4 +32,5 @@ Outputs to 'cert.pem' and 'key.pem' and will overwrite existing files.`,
 
 func runCert(ctx *cli.Context) {
 	fmt.Println("Command cert not available, please use build tags 'cert' to rebuild.")
+	os.Exit(1)
 }


### PR DESCRIPTION
`gogs cert` should fail unconditionally if `gogs` was built without the `cert` tag. At present, it succeeds unconditionally. This obscures its failure from things like configuration management tools and, in at least my case, prompted needless troubleshooting.

(And, come to think of it, maybe the message should go to standard error instead…)
