### PR TITLE
fixed code view line height for firefox

### DIFF
--- a/public/ng/css/gogs.css
+++ b/public/ng/css/gogs.css
@@ -1416,7 +1416,7 @@ The register and sign-in page style
 }
 .code-view .lines-num span {
   font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
-  line-height: 1.6;
+  line-height: 20px;
   padding: 0 10px;
   cursor: pointer;
   display: block;

--- a/public/ng/less/gogs/repository.less
+++ b/public/ng/less/gogs/repository.less
@@ -447,7 +447,7 @@
         width: 1%;
         span {
             font-family: Monaco,Menlo,Consolas,"Courier New",monospace;
-            line-height: 1.6;
+            line-height: 20px;
             padding: 0 10px;  
             cursor: pointer;
             display: block;


### PR DESCRIPTION
It's good in WebKit browsers, but with gecko ...
**without fix:**
![gogsfix-before](https://cloud.githubusercontent.com/assets/1295945/5261227/8d3c8958-7a17-11e4-8ec4-1bd5480befa7.png)
**with fix:**
![gogsfix-after](https://cloud.githubusercontent.com/assets/1295945/5261228/91e29916-7a17-11e4-9ca1-64bef82b3293.png)

Please check if it's valid LESS syntax, because I don't have a LESS compiler installed ...
