### PR TITLE
Use the avatar.HashEmail function instead of hashing email directly.

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Unknwon/com"
 	"github.com/nfnt/resize"
 
+	"github.com/gogits/gogs/modules/avatar"
 	"github.com/gogits/gogs/modules/base"
 	"github.com/gogits/gogs/modules/git"
 	"github.com/gogits/gogs/modules/log"
@@ -276,8 +277,8 @@ func CreateUser(u *User) error {
 	}
 
 	u.LowerName = strings.ToLower(u.Name)
-	u.Avatar = base.EncodeMd5(u.Email)
 	u.AvatarEmail = u.Email
+	u.Avatar = avatar.HashEmail(u.AvatarEmail)
 	u.Rands = GetUserSalt()
 	u.Salt = GetUserSalt()
 	u.EncodePasswd()
@@ -435,6 +436,11 @@ func UpdateUser(u *User) error {
 	if len(u.Description) > 255 {
 		u.Description = u.Description[:255]
 	}
+
+	if u.AvatarEmail == "" {
+		u.AvatarEmail = u.Email
+	}
+	u.Avatar = avatar.HashEmail(u.AvatarEmail)
 
 	_, err = x.Id(u.Id).AllCols().Update(u)
 	return err


### PR DESCRIPTION
- **Bug Description**: When assigning User.Avatar the email is not being correctly pre-processed so uppercase characters in emails will cause the wrong gravatar hashes to be used.
- **Gogs Version**:  `Gogs version 0.5.8.1118 Beta`
- **Git Version**: `N/A`
- **System Type**: `N/A`
- **Error Log**: `N/A`
- **Other information**: 
  -- I have already fixed this and will submitting a pull request shortly.
  -- Originally issue: #700 
  -- Original PR (but to wrong branch): #701 
## Steps
- Create/edit a user with the Avatar email:  `erebusbat@gmail.com`  notice that the gravatar loads correctly.  
- Edit the avatar email to be `ErebusBat@gmail.com` and notice the gravatar does not load

According to the [Gravatar API](https://en.gravatar.com/site/implement/hash/) either version should work.
