### PR TITLE
Display multi-line commit message on commit diff page.

### DIFF
--- a/public/ng/css/gogs.css
+++ b/public/ng/css/gogs.css
@@ -1510,6 +1510,9 @@ The register and sign-in page style
 .commit-list .message span {
   max-width: 500px;
 }
+.commit-message {
+  white-space: pre-wrap;
+}
 .diff-head-box {
   margin-top: 10px;
 }

--- a/public/ng/less/gogs/repository.less
+++ b/public/ng/less/gogs/repository.less
@@ -535,6 +535,11 @@
         }
     }
 }
+
+.commit-message {
+	white-space: pre-wrap;
+}
+
 .diff-head-box {
     margin-top: 10px;
     .panel-body {

--- a/templates/repo/diff.tmpl
+++ b/templates/repo/diff.tmpl
@@ -17,7 +17,7 @@
         <div class="panel panel-info panel-radius diff-head-box">
             <div class="panel-header">
                 <a class="pull-right btn btn-blue btn-header btn-medium btn-radius" rel="nofollow" href="{{.SourcePath}}">{{.i18n.Tr "repo.diff.browse_source"}}</a>
-                <h4>{{.Commit.Message}}</h4>
+                <h4 class="commit-message">{{.Commit.Message}}</h4>
             </div>
             <div class="panel-body">
                 <span class="pull-right">


### PR DESCRIPTION
Display multilined message with respect of new line.

Not a good solution but it is better to display the commit message with line break on new line.

Actually the commit message should be split into header (first line) & body (remaining) and display separately.
But I can't touch go part, no go experience at all.
