### PR TITLE
Rewrite of SendMail function

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -94,7 +94,10 @@ SUBJECT = %(APP_NAME)s
 ; Mail server
 ; Gmail: smtp.gmail.com:587
 ; QQ: smtp.qq.com:25
+; Note, if the port ends with "465", SMTPS will be used. Using STARTTLS on port 587 is recommended per RFC 6409. If the server supports STARTTLS it will always be used.
 HOST =
+; Do not verify the certificate of the server. Only use this for self-signed certificates
+SKIP_VERIFY = 
 ; Mail from address
 FROM =
 ; Mailer user name and password

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -437,6 +437,7 @@ type Mailer struct {
 	Host         string
 	From         string
 	User, Passwd string
+	SkipVerify   bool
 }
 
 type OauthInfo struct {
@@ -463,10 +464,11 @@ func newMailService() {
 	}
 
 	MailService = &Mailer{
-		Name:   Cfg.MustValue("mailer", "NAME", AppName),
-		Host:   Cfg.MustValue("mailer", "HOST"),
-		User:   Cfg.MustValue("mailer", "USER"),
-		Passwd: Cfg.MustValue("mailer", "PASSWD"),
+		Name:       Cfg.MustValue("mailer", "NAME", AppName),
+		Host:       Cfg.MustValue("mailer", "HOST"),
+		User:       Cfg.MustValue("mailer", "USER"),
+		Passwd:     Cfg.MustValue("mailer", "PASSWD"),
+		SkipVerify: Cfg.MustBool("mailer", "SKIP_VERIFY", false),
 	}
 	MailService.From = Cfg.MustValue("mailer", "FROM", MailService.User)
 	log.Info("Mail Service Enabled")


### PR DESCRIPTION
The SendMail function is rewritten and has the following new functionality:
- It is optional to skip verification of keys. The config option SKIP_VERIFY is added
- If the port is 465, or ending on 465, the TLS(/SSL) connection is started first.

Should resolve #749 
