### PR TITLE
Remove standard mailer port lines

### DIFF
--- a/modules/mailer/mailer.go
+++ b/modules/mailer/mailer.go
@@ -73,10 +73,6 @@ func sendMail(settings *setting.Mailer, from string, recipients []string, msgCon
 		return err
 	}
 
-	if len(port) == 0 {
-		port = "587"
-	}
-
 	tlsconfig := &tls.Config{
 		InsecureSkipVerify: settings.SkipVerify,
 		ServerName:         host,


### PR DESCRIPTION
This lines got committed by accident. They do actually nothing, as SplitHostPort will give an error if port is not given.
