### PR TITLE
Create English locale keys for multiple e-mails feature

### DIFF
--- a/conf/locale/locale_en-US.ini
+++ b/conf/locale/locale_en-US.ini
@@ -220,6 +220,7 @@ change_password_success = Password is changed successfully. You can now sign in 
 emails = E-mail Addresses
 manage_emails = Manage e-mail addresses
 email_desc = Current e-mail addresses
+primary = Primary
 primary_email = Make primary
 delete_email = Delete
 add_new_email = Add new e-mail address

--- a/templates/user/settings/email.tmpl
+++ b/templates/user/settings/email.tmpl
@@ -16,7 +16,7 @@
                             {{range .Emails}}
                             <li class="email clear">
                                 <div class="email-content left">
-									<p><strong>{{.Email}}</strong> {{if .IsPrimary}} <span class="email-primary">Primary</span> {{end}}</p>
+									<p><strong>{{.Email}}</strong> {{if .IsPrimary}} <span class="email-primary">{{$.i18n.Tr "settings.primary"}}</span> {{end}}</p>
 							   </div>
 							   {{if not .IsPrimary}}
 							   {{if .IsActivated}}


### PR DESCRIPTION
Also, change all current 'emails' to 'e-mails'.
Still todo: some CSS for the user/settings/email page, but that is not my specialty
