### PR TITLE
Fail2ban with HTTP status and logger (#2291 #2384)

### DIFF
--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -137,13 +137,13 @@ func (c *Context) SubURLRedirect(location string, status ...int) {
 }
 
 // RenderWithErr used for page has form validation but need to prompt error to users.
-func (c *Context) RenderWithErr(msg, tpl string, f interface{}) {
+func (c *Context) RenderWithErr(msg, tpl string, f interface{}, http_status int) {
 	if f != nil {
 		form.Assign(f, c.Data)
 	}
 	c.Flash.ErrorMsg = msg
 	c.Data["Flash"] = c.Flash
-	c.HTML(http.StatusOK, tpl)
+	c.HTML(http_status, tpl)
 }
 
 // Handle handles and logs error by given status.

--- a/routes/admin/auths.go
+++ b/routes/admin/auths.go
@@ -6,6 +6,7 @@ package admin
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/Unknwon/com"
 	"github.com/go-xorm/core"
@@ -158,7 +159,7 @@ func NewAuthSourcePost(c *context.Context, f form.Authentication) {
 	}); err != nil {
 		if models.IsErrLoginSourceAlreadyExist(err) {
 			c.Data["Err_Name"] = true
-			c.RenderWithErr(c.Tr("admin.auths.login_source_exist", err.(models.ErrLoginSourceAlreadyExist).Name), AUTH_NEW, f)
+			c.RenderWithErr(c.Tr("admin.auths.login_source_exist", err.(models.ErrLoginSourceAlreadyExist).Name), AUTH_NEW, f, http.StatusBadRequest)
 		} else {
 			c.Handle(500, "CreateSource", err)
 		}

--- a/routes/admin/users.go
+++ b/routes/admin/users.go
@@ -6,6 +6,7 @@ package admin
 
 import (
 	"strings"
+	"net/http"
 
 	"github.com/Unknwon/com"
 	log "gopkg.in/clog.v1"
@@ -97,16 +98,16 @@ func NewUserPost(c *context.Context, f form.AdminCrateUser) {
 		switch {
 		case models.IsErrUserAlreadyExist(err):
 			c.Data["Err_UserName"] = true
-			c.RenderWithErr(c.Tr("form.username_been_taken"), USER_NEW, &f)
+			c.RenderWithErr(c.Tr("form.username_been_taken"), USER_NEW, &f, http.StatusBadRequest)
 		case models.IsErrEmailAlreadyUsed(err):
 			c.Data["Err_Email"] = true
-			c.RenderWithErr(c.Tr("form.email_been_used"), USER_NEW, &f)
+			c.RenderWithErr(c.Tr("form.email_been_used"), USER_NEW, &f, http.StatusBadRequest)
 		case models.IsErrNameReserved(err):
 			c.Data["Err_UserName"] = true
-			c.RenderWithErr(c.Tr("user.form.name_reserved", err.(models.ErrNameReserved).Name), USER_NEW, &f)
+			c.RenderWithErr(c.Tr("user.form.name_reserved", err.(models.ErrNameReserved).Name), USER_NEW, &f, http.StatusBadRequest)
 		case models.IsErrNamePatternNotAllowed(err):
 			c.Data["Err_UserName"] = true
-			c.RenderWithErr(c.Tr("user.form.name_pattern_not_allowed", err.(models.ErrNamePatternNotAllowed).Pattern), USER_NEW, &f)
+			c.RenderWithErr(c.Tr("user.form.name_pattern_not_allowed", err.(models.ErrNamePatternNotAllowed).Pattern), USER_NEW, &f, http.StatusBadRequest)
 		default:
 			c.Handle(500, "CreateUser", err)
 		}
@@ -217,7 +218,7 @@ func EditUserPost(c *context.Context, f form.AdminEditUser) {
 	if err := models.UpdateUser(u); err != nil {
 		if models.IsErrEmailAlreadyUsed(err) {
 			c.Data["Err_Email"] = true
-			c.RenderWithErr(c.Tr("form.email_been_used"), USER_EDIT, &f)
+			c.RenderWithErr(c.Tr("form.email_been_used"), USER_EDIT, &f, http.StatusBadRequest)
 		} else {
 			c.Handle(500, "UpdateUser", err)
 		}

--- a/routes/org/org.go
+++ b/routes/org/org.go
@@ -5,6 +5,7 @@
 package org
 
 import (
+	"net/http"
 	log "gopkg.in/clog.v1"
 
 	"github.com/gogits/gogs/models"
@@ -40,11 +41,11 @@ func CreatePost(c *context.Context, f form.CreateOrg) {
 		c.Data["Err_OrgName"] = true
 		switch {
 		case models.IsErrUserAlreadyExist(err):
-			c.RenderWithErr(c.Tr("form.org_name_been_taken"), CREATE, &f)
+			c.RenderWithErr(c.Tr("form.org_name_been_taken"), CREATE, &f, http.StatusBadRequest)
 		case models.IsErrNameReserved(err):
-			c.RenderWithErr(c.Tr("org.form.name_reserved", err.(models.ErrNameReserved).Name), CREATE, &f)
+			c.RenderWithErr(c.Tr("org.form.name_reserved", err.(models.ErrNameReserved).Name), CREATE, &f, http.StatusBadRequest)
 		case models.IsErrNamePatternNotAllowed(err):
-			c.RenderWithErr(c.Tr("org.form.name_pattern_not_allowed", err.(models.ErrNamePatternNotAllowed).Pattern), CREATE, &f)
+			c.RenderWithErr(c.Tr("org.form.name_pattern_not_allowed", err.(models.ErrNamePatternNotAllowed).Pattern), CREATE, &f, http.StatusBadRequest)
 		default:
 			c.Handle(500, "CreateOrganization", err)
 		}

--- a/routes/org/setting.go
+++ b/routes/org/setting.go
@@ -6,6 +6,7 @@ package org
 
 import (
 	"strings"
+	"net/http"
 
 	log "gopkg.in/clog.v1"
 
@@ -48,15 +49,15 @@ func SettingsPost(c *context.Context, f form.UpdateOrgSetting) {
 			return
 		} else if isExist {
 			c.Data["OrgName"] = true
-			c.RenderWithErr(c.Tr("form.username_been_taken"), SETTINGS_OPTIONS, &f)
+			c.RenderWithErr(c.Tr("form.username_been_taken"), SETTINGS_OPTIONS, &f, http.StatusBadRequest)
 			return
 		} else if err = models.ChangeUserName(org, f.Name); err != nil {
 			c.Data["OrgName"] = true
 			switch {
 			case models.IsErrNameReserved(err):
-				c.RenderWithErr(c.Tr("user.form.name_reserved"), SETTINGS_OPTIONS, &f)
+				c.RenderWithErr(c.Tr("user.form.name_reserved"), SETTINGS_OPTIONS, &f, http.StatusBadRequest)
 			case models.IsErrNamePatternNotAllowed(err):
-				c.RenderWithErr(c.Tr("user.form.name_pattern_not_allowed"), SETTINGS_OPTIONS, &f)
+				c.RenderWithErr(c.Tr("user.form.name_pattern_not_allowed"), SETTINGS_OPTIONS, &f, http.StatusBadRequest)
 			default:
 				c.Handle(500, "ChangeUserName", err)
 			}
@@ -114,7 +115,7 @@ func SettingsDelete(c *context.Context) {
 	if c.Req.Method == "POST" {
 		if _, err := models.UserSignIn(c.User.Name, c.Query("password")); err != nil {
 			if errors.IsUserNotExist(err) {
-				c.RenderWithErr(c.Tr("form.enterred_invalid_password"), SETTINGS_DELETE, nil)
+				c.RenderWithErr(c.Tr("form.enterred_invalid_password"), SETTINGS_DELETE, nil, http.StatusBadRequest)
 			} else {
 				c.Handle(500, "UserSignIn", err)
 			}

--- a/routes/org/teams.go
+++ b/routes/org/teams.go
@@ -6,6 +6,7 @@ package org
 
 import (
 	"path"
+	"net/http"
 
 	"github.com/Unknwon/com"
 	log "gopkg.in/clog.v1"
@@ -171,9 +172,9 @@ func NewTeamPost(c *context.Context, f form.CreateTeam) {
 		c.Data["Err_TeamName"] = true
 		switch {
 		case models.IsErrTeamAlreadyExist(err):
-			c.RenderWithErr(c.Tr("form.team_name_been_taken"), TEAM_NEW, &f)
+			c.RenderWithErr(c.Tr("form.team_name_been_taken"), TEAM_NEW, &f, http.StatusBadRequest)
 		case models.IsErrNameReserved(err):
-			c.RenderWithErr(c.Tr("org.form.team_name_reserved", err.(models.ErrNameReserved).Name), TEAM_NEW, &f)
+			c.RenderWithErr(c.Tr("org.form.team_name_reserved", err.(models.ErrNameReserved).Name), TEAM_NEW, &f, http.StatusBadRequest)
 		default:
 			c.Handle(500, "NewTeam", err)
 		}
@@ -249,7 +250,7 @@ func EditTeamPost(c *context.Context, f form.CreateTeam) {
 		c.Data["Err_TeamName"] = true
 		switch {
 		case models.IsErrTeamAlreadyExist(err):
-			c.RenderWithErr(c.Tr("form.team_name_been_taken"), TEAM_NEW, &f)
+			c.RenderWithErr(c.Tr("form.team_name_been_taken"), TEAM_NEW, &f, http.StatusBadRequest)
 		default:
 			c.Handle(500, "UpdateTeam", err)
 		}

--- a/routes/repo/editor.go
+++ b/routes/repo/editor.go
@@ -165,14 +165,14 @@ func editFilePost(c *context.Context, f form.EditRepoFile, isNewFile bool) {
 
 	if len(f.TreePath) == 0 {
 		c.FormErr("TreePath")
-		c.RenderWithErr(c.Tr("repo.editor.filename_cannot_be_empty"), EDIT_FILE, &f)
+		c.RenderWithErr(c.Tr("repo.editor.filename_cannot_be_empty"), EDIT_FILE, &f, http.StatusBadRequest)
 		return
 	}
 
 	if oldBranchName != branchName {
 		if _, err := c.Repo.Repository.GetBranch(branchName); err == nil {
 			c.FormErr("NewBranchName")
-			c.RenderWithErr(c.Tr("repo.editor.branch_already_exists", branchName), EDIT_FILE, &f)
+			c.RenderWithErr(c.Tr("repo.editor.branch_already_exists", branchName), EDIT_FILE, &f, http.StatusBadRequest)
 			return
 		}
 	}
@@ -193,17 +193,17 @@ func editFilePost(c *context.Context, f form.EditRepoFile, isNewFile bool) {
 		if index != len(treeNames)-1 {
 			if !entry.IsDir() {
 				c.FormErr("TreePath")
-				c.RenderWithErr(c.Tr("repo.editor.directory_is_a_file", part), EDIT_FILE, &f)
+				c.RenderWithErr(c.Tr("repo.editor.directory_is_a_file", part), EDIT_FILE, &f, http.StatusBadRequest)
 				return
 			}
 		} else {
 			if entry.IsLink() {
 				c.FormErr("TreePath")
-				c.RenderWithErr(c.Tr("repo.editor.file_is_a_symlink", part), EDIT_FILE, &f)
+				c.RenderWithErr(c.Tr("repo.editor.file_is_a_symlink", part), EDIT_FILE, &f, http.StatusBadRequest)
 				return
 			} else if entry.IsDir() {
 				c.FormErr("TreePath")
-				c.RenderWithErr(c.Tr("repo.editor.filename_is_a_directory", part), EDIT_FILE, &f)
+				c.RenderWithErr(c.Tr("repo.editor.filename_is_a_directory", part), EDIT_FILE, &f, http.StatusBadRequest)
 				return
 			}
 		}
@@ -214,7 +214,7 @@ func editFilePost(c *context.Context, f form.EditRepoFile, isNewFile bool) {
 		if err != nil {
 			if git.IsErrNotExist(err) {
 				c.FormErr("TreePath")
-				c.RenderWithErr(c.Tr("repo.editor.file_editing_no_longer_exists", oldTreePath), EDIT_FILE, &f)
+				c.RenderWithErr(c.Tr("repo.editor.file_editing_no_longer_exists", oldTreePath), EDIT_FILE, &f, http.StatusBadRequest)
 			} else {
 				c.ServerError("GetTreeEntryByPath", err)
 			}
@@ -229,7 +229,7 @@ func editFilePost(c *context.Context, f form.EditRepoFile, isNewFile bool) {
 
 			for _, file := range files {
 				if file == f.TreePath {
-					c.RenderWithErr(c.Tr("repo.editor.file_changed_while_editing", c.Repo.RepoLink+"/compare/"+lastCommit+"..."+c.Repo.CommitID), EDIT_FILE, &f)
+					c.RenderWithErr(c.Tr("repo.editor.file_changed_while_editing", c.Repo.RepoLink+"/compare/"+lastCommit+"..."+c.Repo.CommitID), EDIT_FILE, &f, http.StatusInternalServerError)
 					return
 				}
 			}
@@ -247,7 +247,7 @@ func editFilePost(c *context.Context, f form.EditRepoFile, isNewFile bool) {
 		}
 		if entry != nil {
 			c.FormErr("TreePath")
-			c.RenderWithErr(c.Tr("repo.editor.file_already_exists", f.TreePath), EDIT_FILE, &f)
+			c.RenderWithErr(c.Tr("repo.editor.file_already_exists", f.TreePath), EDIT_FILE, &f, http.StatusBadRequest)
 			return
 		}
 	}
@@ -277,7 +277,7 @@ func editFilePost(c *context.Context, f form.EditRepoFile, isNewFile bool) {
 		IsNewFile:    isNewFile,
 	}); err != nil {
 		c.FormErr("TreePath")
-		c.RenderWithErr(c.Tr("repo.editor.fail_to_update_file", f.TreePath, err), EDIT_FILE, &f)
+		c.RenderWithErr(c.Tr("repo.editor.fail_to_update_file", f.TreePath, err), EDIT_FILE, &f, http.StatusInternalServerError)
 		return
 	}
 
@@ -358,7 +358,7 @@ func DeleteFilePost(c *context.Context, f form.DeleteRepoFile) {
 	if oldBranchName != branchName {
 		if _, err := c.Repo.Repository.GetBranch(branchName); err == nil {
 			c.Data["Err_NewBranchName"] = true
-			c.RenderWithErr(c.Tr("repo.editor.branch_already_exists", branchName), DELETE_FILE, &f)
+			c.RenderWithErr(c.Tr("repo.editor.branch_already_exists", branchName), DELETE_FILE, &f, http.StatusBadRequest)
 			return
 		}
 	}
@@ -455,7 +455,7 @@ func UploadFilePost(c *context.Context, f form.UploadRepoFile) {
 	if oldBranchName != branchName {
 		if _, err := c.Repo.Repository.GetBranch(branchName); err == nil {
 			c.Data["Err_NewBranchName"] = true
-			c.RenderWithErr(c.Tr("repo.editor.branch_already_exists", branchName), UPLOAD_FILE, &f)
+			c.RenderWithErr(c.Tr("repo.editor.branch_already_exists", branchName), UPLOAD_FILE, &f, http.StatusBadRequest)
 			return
 		}
 	}
@@ -477,7 +477,7 @@ func UploadFilePost(c *context.Context, f form.UploadRepoFile) {
 		// User can only upload files to a directory.
 		if !entry.IsDir() {
 			c.Data["Err_TreePath"] = true
-			c.RenderWithErr(c.Tr("repo.editor.directory_is_a_file", part), UPLOAD_FILE, &f)
+			c.RenderWithErr(c.Tr("repo.editor.directory_is_a_file", part), UPLOAD_FILE, &f, http.StatusBadRequest)
 			return
 		}
 	}
@@ -501,7 +501,7 @@ func UploadFilePost(c *context.Context, f form.UploadRepoFile) {
 		Files:        f.Files,
 	}); err != nil {
 		c.Data["Err_TreePath"] = true
-		c.RenderWithErr(c.Tr("repo.editor.unable_to_upload_files", f.TreePath, err), UPLOAD_FILE, &f)
+		c.RenderWithErr(c.Tr("repo.editor.unable_to_upload_files", f.TreePath, err), UPLOAD_FILE, &f, http.StatusInternalServerError)
 		return
 	}
 

--- a/routes/repo/issue.go
+++ b/routes/repo/issue.go
@@ -1131,7 +1131,7 @@ func NewMilestonePost(c *context.Context, f form.CreateMilestone) {
 	deadline, err := time.ParseInLocation("2006-01-02", f.Deadline, time.Local)
 	if err != nil {
 		c.Data["Err_Deadline"] = true
-		c.RenderWithErr(c.Tr("repo.milestones.invalid_due_date_format"), MILESTONE_NEW, &f)
+		c.RenderWithErr(c.Tr("repo.milestones.invalid_due_date_format"), MILESTONE_NEW, &f, http.StatusBadRequest)
 		return
 	}
 
@@ -1191,7 +1191,7 @@ func EditMilestonePost(c *context.Context, f form.CreateMilestone) {
 	deadline, err := time.ParseInLocation("2006-01-02", f.Deadline, time.Local)
 	if err != nil {
 		c.Data["Err_Deadline"] = true
-		c.RenderWithErr(c.Tr("repo.milestones.invalid_due_date_format"), MILESTONE_NEW, &f)
+		c.RenderWithErr(c.Tr("repo.milestones.invalid_due_date_format"), MILESTONE_NEW, &f, http.StatusBadRequest)
 		return
 	}
 

--- a/routes/repo/pull.go
+++ b/routes/repo/pull.go
@@ -8,6 +8,7 @@ import (
 	"container/list"
 	"path"
 	"strings"
+	"net/http"
 
 	"github.com/Unknwon/com"
 	log "gopkg.in/clog.v1"
@@ -118,7 +119,7 @@ func ForkPost(c *context.Context, f form.CreateRepo) {
 
 	// Cannot fork to same owner
 	if ctxUser.ID == baseRepo.OwnerID {
-		c.RenderWithErr(c.Tr("repo.settings.cannot_fork_to_same_owner"), FORK, &f)
+		c.RenderWithErr(c.Tr("repo.settings.cannot_fork_to_same_owner"), FORK, &f, http.StatusBadRequest)
 		return
 	}
 
@@ -127,11 +128,11 @@ func ForkPost(c *context.Context, f form.CreateRepo) {
 		c.Data["Err_RepoName"] = true
 		switch {
 		case models.IsErrRepoAlreadyExist(err):
-			c.RenderWithErr(c.Tr("repo.settings.new_owner_has_same_repo"), FORK, &f)
+			c.RenderWithErr(c.Tr("repo.settings.new_owner_has_same_repo"), FORK, &f, http.StatusBadRequest)
 		case models.IsErrNameReserved(err):
-			c.RenderWithErr(c.Tr("repo.form.name_reserved", err.(models.ErrNameReserved).Name), FORK, &f)
+			c.RenderWithErr(c.Tr("repo.form.name_reserved", err.(models.ErrNameReserved).Name), FORK, &f, http.StatusBadRequest)
 		case models.IsErrNamePatternNotAllowed(err):
-			c.RenderWithErr(c.Tr("repo.form.name_pattern_not_allowed", err.(models.ErrNamePatternNotAllowed).Pattern), FORK, &f)
+			c.RenderWithErr(c.Tr("repo.form.name_pattern_not_allowed", err.(models.ErrNamePatternNotAllowed).Pattern), FORK, &f, http.StatusBadRequest)
 		default:
 			c.ServerError("ForkPost", err)
 		}

--- a/routes/repo/release.go
+++ b/routes/repo/release.go
@@ -7,6 +7,7 @@ package repo
 import (
 	"fmt"
 	"strings"
+	"net/http"
 
 	log "gopkg.in/clog.v1"
 
@@ -176,7 +177,7 @@ func NewReleasePost(c *context.Context, f form.NewRelease) {
 	}
 
 	if !c.Repo.GitRepo.IsBranchExist(f.Target) {
-		c.RenderWithErr(c.Tr("form.target_branch_not_exist"), RELEASE_NEW, &f)
+		c.RenderWithErr(c.Tr("form.target_branch_not_exist"), RELEASE_NEW, &f, http.StatusBadRequest)
 		return
 	}
 
@@ -224,9 +225,9 @@ func NewReleasePost(c *context.Context, f form.NewRelease) {
 		c.Data["Err_TagName"] = true
 		switch {
 		case models.IsErrReleaseAlreadyExist(err):
-			c.RenderWithErr(c.Tr("repo.release.tag_name_already_exist"), RELEASE_NEW, &f)
+			c.RenderWithErr(c.Tr("repo.release.tag_name_already_exist"), RELEASE_NEW, &f, http.StatusBadRequest)
 		case models.IsErrInvalidTagName(err):
-			c.RenderWithErr(c.Tr("repo.release.tag_name_invalid"), RELEASE_NEW, &f)
+			c.RenderWithErr(c.Tr("repo.release.tag_name_invalid"), RELEASE_NEW, &f, http.StatusBadRequest)
 		default:
 			c.Handle(500, "NewRelease", err)
 		}

--- a/routes/repo/setting.go
+++ b/routes/repo/setting.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"net/http"
 
 	log "gopkg.in/clog.v1"
 
@@ -60,11 +61,11 @@ func SettingsPost(c *context.Context, f form.RepoSetting) {
 				c.FormErr("RepoName")
 				switch {
 				case models.IsErrRepoAlreadyExist(err):
-					c.RenderWithErr(c.Tr("form.repo_name_been_taken"), SETTINGS_OPTIONS, &f)
+					c.RenderWithErr(c.Tr("form.repo_name_been_taken"), SETTINGS_OPTIONS, &f, http.StatusBadRequest)
 				case models.IsErrNameReserved(err):
-					c.RenderWithErr(c.Tr("repo.form.name_reserved", err.(models.ErrNameReserved).Name), SETTINGS_OPTIONS, &f)
+					c.RenderWithErr(c.Tr("repo.form.name_reserved", err.(models.ErrNameReserved).Name), SETTINGS_OPTIONS, &f, http.StatusBadRequest)
 				case models.IsErrNamePatternNotAllowed(err):
-					c.RenderWithErr(c.Tr("repo.form.name_pattern_not_allowed", err.(models.ErrNamePatternNotAllowed).Pattern), SETTINGS_OPTIONS, &f)
+					c.RenderWithErr(c.Tr("repo.form.name_pattern_not_allowed", err.(models.ErrNamePatternNotAllowed).Pattern), SETTINGS_OPTIONS, &f, http.StatusBadRequest)
 				default:
 					c.ServerError("ChangeRepositoryName", err)
 				}
@@ -163,7 +164,7 @@ func SettingsPost(c *context.Context, f form.RepoSetting) {
 			return
 		}
 		if repo.Name != f.RepoName {
-			c.RenderWithErr(c.Tr("form.enterred_invalid_repo_name"), SETTINGS_OPTIONS, nil)
+			c.RenderWithErr(c.Tr("form.enterred_invalid_repo_name"), SETTINGS_OPTIONS, nil, http.StatusBadRequest)
 			return
 		}
 
@@ -197,7 +198,7 @@ func SettingsPost(c *context.Context, f form.RepoSetting) {
 			return
 		}
 		if repo.Name != f.RepoName {
-			c.RenderWithErr(c.Tr("form.enterred_invalid_repo_name"), SETTINGS_OPTIONS, nil)
+			c.RenderWithErr(c.Tr("form.enterred_invalid_repo_name"), SETTINGS_OPTIONS, nil, http.StatusBadRequest)
 			return
 		}
 
@@ -214,13 +215,13 @@ func SettingsPost(c *context.Context, f form.RepoSetting) {
 			c.ServerError("IsUserExist", err)
 			return
 		} else if !isExist {
-			c.RenderWithErr(c.Tr("form.enterred_invalid_owner_name"), SETTINGS_OPTIONS, nil)
+			c.RenderWithErr(c.Tr("form.enterred_invalid_owner_name"), SETTINGS_OPTIONS, nil, http.StatusBadRequest)
 			return
 		}
 
 		if err = models.TransferOwnership(c.User, newOwner, repo); err != nil {
 			if models.IsErrRepoAlreadyExist(err) {
-				c.RenderWithErr(c.Tr("repo.settings.new_owner_has_same_repo"), SETTINGS_OPTIONS, nil)
+				c.RenderWithErr(c.Tr("repo.settings.new_owner_has_same_repo"), SETTINGS_OPTIONS, nil, http.StatusBadRequest)
 			} else {
 				c.ServerError("TransferOwnership", err)
 			}
@@ -236,7 +237,7 @@ func SettingsPost(c *context.Context, f form.RepoSetting) {
 			return
 		}
 		if repo.Name != f.RepoName {
-			c.RenderWithErr(c.Tr("form.enterred_invalid_repo_name"), SETTINGS_OPTIONS, nil)
+			c.RenderWithErr(c.Tr("form.enterred_invalid_repo_name"), SETTINGS_OPTIONS, nil, http.StatusBadRequest)
 			return
 		}
 
@@ -262,7 +263,7 @@ func SettingsPost(c *context.Context, f form.RepoSetting) {
 			return
 		}
 		if repo.Name != f.RepoName {
-			c.RenderWithErr(c.Tr("form.enterred_invalid_repo_name"), SETTINGS_OPTIONS, nil)
+			c.RenderWithErr(c.Tr("form.enterred_invalid_repo_name"), SETTINGS_OPTIONS, nil, http.StatusBadRequest)
 			return
 		}
 
@@ -603,10 +604,10 @@ func SettingsDeployKeysPost(c *context.Context, f form.AddSSHKey) {
 		switch {
 		case models.IsErrKeyAlreadyExist(err):
 			c.Data["Err_Content"] = true
-			c.RenderWithErr(c.Tr("repo.settings.key_been_used"), SETTINGS_DEPLOY_KEYS, &f)
+			c.RenderWithErr(c.Tr("repo.settings.key_been_used"), SETTINGS_DEPLOY_KEYS, &f, http.StatusBadRequest)
 		case models.IsErrKeyNameAlreadyUsed(err):
 			c.Data["Err_Title"] = true
-			c.RenderWithErr(c.Tr("repo.settings.key_name_used"), SETTINGS_DEPLOY_KEYS, &f)
+			c.RenderWithErr(c.Tr("repo.settings.key_name_used"), SETTINGS_DEPLOY_KEYS, &f, http.StatusBadRequest)
 		default:
 			c.Handle(500, "AddDeployKey", err)
 		}

--- a/routes/repo/wiki.go
+++ b/routes/repo/wiki.go
@@ -210,7 +210,7 @@ func NewWikiPost(c *context.Context, f form.NewWiki) {
 	if err := c.Repo.Repository.AddWikiPage(c.User, f.Title, f.Content, f.Message); err != nil {
 		if models.IsErrWikiAlreadyExist(err) {
 			c.Data["Err_Title"] = true
-			c.RenderWithErr(c.Tr("repo.wiki.page_already_exists"), WIKI_NEW, &f)
+			c.RenderWithErr(c.Tr("repo.wiki.page_already_exists"), WIKI_NEW, &f, 400)
 		} else {
 			c.Handle(500, "AddWikiPage", err)
 		}

--- a/routes/user/setting.go
+++ b/routes/user/setting.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
+	"net/http"
 	"html/template"
 	"image/png"
 	"io/ioutil"
@@ -86,7 +87,7 @@ func SettingsPost(c *context.Context, f form.UpdateProfile) {
 					return
 				}
 
-				c.RenderWithErr(msg, SETTINGS_PROFILE, &f)
+				c.RenderWithErr(msg, SETTINGS_PROFILE, &f, http.StatusBadRequest)
 				return
 			}
 
@@ -263,7 +264,7 @@ func SettingsEmailPost(c *context.Context, f form.AddEmail) {
 	}
 	if err := models.AddEmailAddress(email); err != nil {
 		if models.IsErrEmailAlreadyUsed(err) {
-			c.RenderWithErr(c.Tr("form.email_been_used"), SETTINGS_EMAILS, &f)
+			c.RenderWithErr(c.Tr("form.email_been_used"), SETTINGS_EMAILS, &f, http.StatusBadRequest)
 		} else {
 			c.ServerError("AddEmailAddress", err)
 		}
@@ -346,10 +347,10 @@ func SettingsSSHKeysPost(c *context.Context, f form.AddSSHKey) {
 		switch {
 		case models.IsErrKeyAlreadyExist(err):
 			c.FormErr("Content")
-			c.RenderWithErr(c.Tr("settings.ssh_key_been_used"), SETTINGS_SSH_KEYS, &f)
+			c.RenderWithErr(c.Tr("settings.ssh_key_been_used"), SETTINGS_SSH_KEYS, &f, http.StatusBadRequest)
 		case models.IsErrKeyNameAlreadyUsed(err):
 			c.FormErr("Title")
-			c.RenderWithErr(c.Tr("settings.ssh_key_name_used"), SETTINGS_SSH_KEYS, &f)
+			c.RenderWithErr(c.Tr("settings.ssh_key_name_used"), SETTINGS_SSH_KEYS, &f, http.StatusBadRequest)
 		default:
 			c.ServerError("AddPublicKey", err)
 		}
@@ -635,7 +636,7 @@ func SettingsDelete(c *context.Context) {
 	if c.Req.Method == "POST" {
 		if _, err := models.UserSignIn(c.User.Name, c.Query("password")); err != nil {
 			if errors.IsUserNotExist(err) {
-				c.RenderWithErr(c.Tr("form.enterred_invalid_password"), SETTINGS_DELETE, nil)
+				c.RenderWithErr(c.Tr("form.enterred_invalid_password"), SETTINGS_DELETE, nil, http.StatusUnauthorized)
 			} else {
 				c.ServerError("UserSignIn", err)
 			}


### PR DESCRIPTION
I'm not sure if this patch is acceptable. I never wrote golang before but I was needing this features.
- introduce a new context function RenderWithErrStatus that allows to
  specify an HTTP status when rendering errors on form datas
  - status 403 set on repository permission denied
  - status 401 set on authentication failure
  - status 401 set when no associated email found on forgotten password
    procedure
- add warning log message, containing client IP address, for
  authentication failure
- add warning log message in routers/user/auth.go AutoSignIn function
- add http_status int in returned values for routers/user/auth.go
  AutoSignIn function
- change default log level to Info
