### PR TITLE
Store password hashes prefixed with the used scheme/algorithm + BCRYPT support

### DIFF
--- a/cmd/admin.go
+++ b/cmd/admin.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gogits/gogs/models"
 	"github.com/gogits/gogs/modules/setting"
+	"github.com/gogits/gogs/modules/password"
 )
 
 var (
@@ -54,6 +55,7 @@ func runCreateUser(c *cli.Context) error {
 	setting.NewContext()
 	models.LoadConfigs()
 	models.SetEngine()
+	password.UseHashAlgorithm(setting.Cfg.Section("security").Key("PASSWORD_HASH_ALGORITHM").String())
 
 	if err := models.CreateUser(&models.User{
 		Name:     c.String("name"),

--- a/cmd/admin.go
+++ b/cmd/admin.go
@@ -54,7 +54,6 @@ func runCreateUser(c *cli.Context) error {
 	setting.NewContext()
 	models.LoadConfigs()
 	models.SetEngine()
-	models.UpdateHashAlgorithm()
 
 	if err := models.CreateUser(&models.User{
 		Name:     c.String("name"),

--- a/cmd/admin.go
+++ b/cmd/admin.go
@@ -54,6 +54,7 @@ func runCreateUser(c *cli.Context) error {
 	setting.NewContext()
 	models.LoadConfigs()
 	models.SetEngine()
+	models.UpdateHashAlgorithm()
 
 	if err := models.CreateUser(&models.User{
 		Name:     c.String("name"),

--- a/conf/app.ini
+++ b/conf/app.ini
@@ -167,7 +167,7 @@ COOKIE_USERNAME = gogs_awesome
 COOKIE_REMEMBER_NAME = gogs_incredible
 ; Reverse proxy authentication header name of user name
 REVERSE_PROXY_AUTHENTICATION_USER = X-WEBAUTH-USER
-; Password Hashing Algorithm
+; Password Hashing Algorithm (available options: sha256, sha512)
 PASSWORD_HASH_ALGORITHM = "sha256"
 
 [service]

--- a/conf/app.ini
+++ b/conf/app.ini
@@ -167,6 +167,8 @@ COOKIE_USERNAME = gogs_awesome
 COOKIE_REMEMBER_NAME = gogs_incredible
 ; Reverse proxy authentication header name of user name
 REVERSE_PROXY_AUTHENTICATION_USER = X-WEBAUTH-USER
+; Password Hashing Algorithm
+PASSWORD_HASH_ALGORITHM = "sha256"
 
 [service]
 ACTIVE_CODE_LIVE_MINUTES = 180

--- a/conf/app.ini
+++ b/conf/app.ini
@@ -167,8 +167,6 @@ COOKIE_USERNAME = gogs_awesome
 COOKIE_REMEMBER_NAME = gogs_incredible
 ; Reverse proxy authentication header name of user name
 REVERSE_PROXY_AUTHENTICATION_USER = X-WEBAUTH-USER
-; Password Hashing Algorithm (available options: sha256, sha512)
-PASSWORD_HASH_ALGORITHM = "sha256"
 
 [service]
 ACTIVE_CODE_LIVE_MINUTES = 180

--- a/conf/app.ini
+++ b/conf/app.ini
@@ -167,6 +167,8 @@ COOKIE_USERNAME = gogs_awesome
 COOKIE_REMEMBER_NAME = gogs_incredible
 ; Reverse proxy authentication header name of user name
 REVERSE_PROXY_AUTHENTICATION_USER = X-WEBAUTH-USER
+; Default password hash algorithm, either "BCRYPT", "PBKDF2-HMAC-SHA512" or "PBKDF2-HMAC-SHA256"
+PASSWORD_HASH_ALGORITHM = PBKDF2-HMAC-SHA512
 
 [service]
 ACTIVE_CODE_LIVE_MINUTES = 180

--- a/glide.yaml
+++ b/glide.yaml
@@ -44,6 +44,7 @@ import:
 - package: golang.org/x/crypto
   subpackages:
   - ssh
+  - pbkdf2
 - package: golang.org/x/net
   subpackages:
   - html

--- a/models/user.go
+++ b/models/user.go
@@ -315,7 +315,7 @@ func (u *User) NewGitSig() *git.Signature {
 
 // EncodePasswd encodes password to safe format.
 func (u *User) EncodePasswd() {
-	newPasswd, err := password.Hash(u.Passwd, u.Salt, 10000, 50, "PBKDF2-HMAC-SHA256")
+	newPasswd, err := password.Hash(u.Passwd)
 	if(err != nil) {
 		panic("password encoding failed")
 	}
@@ -329,7 +329,7 @@ func (u *User) ValidatePassword(clear string) bool {
 	if(err != nil) {
 
 		// try with backwards compatibility
-		return password.VerifyBackwardsCompatible(clear, u.Passwd, u.Salt)
+		return password.VerifyBackwardsCompatible(clear, u.Passwd, []byte(u.Salt))
 
 	}
 
@@ -557,7 +557,7 @@ func CreateUser(u *User) (err error) {
 	u.AvatarEmail = u.Email
 	u.Avatar = base.HashEmail(u.AvatarEmail)
 	u.Rands = GetUserSalt()
-	u.Salt = GetUserSalt()
+	u.Salt = ""
 	u.EncodePasswd()
 	u.MaxRepoCreation = -1
 

--- a/models/user.go
+++ b/models/user.go
@@ -111,7 +111,7 @@ type User struct {
 
 var hashAlgorithm func() hash.Hash
 
-func updateHashAlgorithm() {
+func UpdateHashAlgorithm() {
 	if(hashAlgorithm != nil) {
 		return
 	}
@@ -334,7 +334,6 @@ func (u *User) NewGitSig() *git.Signature {
 
 // EncodePasswd encodes password to safe format.
 func (u *User) EncodePasswd() {
-	updateHashAlgorithm()
 	newPasswd := base.PBKDF2([]byte(u.Passwd), []byte(u.Salt), 10000, 50, hashAlgorithm)
 	u.Passwd = fmt.Sprintf("%x", newPasswd)
 }

--- a/models/user.go
+++ b/models/user.go
@@ -115,7 +115,7 @@ func UpdateHashAlgorithm() {
 	if(hashAlgorithm != nil) {
 		return
 	}
-	hashAlgorithmName := setting.Cfg.Section("security").Key("PASSWORD_HASH_ALGORITHM").String()
+	hashAlgorithmName := setting.PasswordHashAlgorithm
 	switch hashAlgorithmName {
 	case "sha256":
 		hashAlgorithm = sha256.New

--- a/models/user.go
+++ b/models/user.go
@@ -10,6 +10,7 @@ import (
 	"hash"
 	"crypto/sha256"
 	"crypto/sha512"
+	"golang.org/x/crypto/pbkdf2"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -334,7 +335,7 @@ func (u *User) NewGitSig() *git.Signature {
 
 // EncodePasswd encodes password to safe format.
 func (u *User) EncodePasswd() {
-	newPasswd := base.PBKDF2([]byte(u.Passwd), []byte(u.Salt), 10000, 50, hashAlgorithm)
+	newPasswd := pbkdf2.Key([]byte(u.Passwd), []byte(u.Salt), 10000, 50, hashAlgorithm)
 	u.Passwd = fmt.Sprintf("%x", newPasswd)
 }
 

--- a/modules/base/tool.go
+++ b/modules/base/tool.go
@@ -5,14 +5,12 @@
 package base
 
 import (
-	"crypto/hmac"
 	"crypto/md5"
 	"crypto/rand"
 	"crypto/sha1"
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
-	"hash"
 	"html/template"
 	"math"
 	"net/http"
@@ -94,45 +92,6 @@ func GetRandomString(n int, alphabets ...byte) string {
 		}
 	}
 	return string(bytes)
-}
-
-// http://code.google.com/p/go/source/browse/pbkdf2/pbkdf2.go?repo=crypto
-// FIXME: use https://godoc.org/golang.org/x/crypto/pbkdf2?
-func PBKDF2(password, salt []byte, iter, keyLen int, h func() hash.Hash) []byte {
-	prf := hmac.New(h, password)
-	hashLen := prf.Size()
-	numBlocks := (keyLen + hashLen - 1) / hashLen
-
-	var buf [4]byte
-	dk := make([]byte, 0, numBlocks*hashLen)
-	U := make([]byte, hashLen)
-	for block := 1; block <= numBlocks; block++ {
-		// N.B.: || means concatenation, ^ means XOR
-		// for each block T_i = U_1 ^ U_2 ^ ... ^ U_iter
-		// U_1 = PRF(password, salt || uint(i))
-		prf.Reset()
-		prf.Write(salt)
-		buf[0] = byte(block >> 24)
-		buf[1] = byte(block >> 16)
-		buf[2] = byte(block >> 8)
-		buf[3] = byte(block)
-		prf.Write(buf[:4])
-		dk = prf.Sum(dk)
-		T := dk[len(dk)-hashLen:]
-		copy(U, T)
-
-		// U_n = PRF(password, U_(n-1))
-		for n := 2; n <= iter; n++ {
-			prf.Reset()
-			prf.Write(U)
-			U = U[:0]
-			U = prf.Sum(U)
-			for x := range U {
-				T[x] ^= U[x]
-			}
-		}
-	}
-	return dk[:keyLen]
 }
 
 // verify time limit code

--- a/modules/password/password.go
+++ b/modules/password/password.go
@@ -55,6 +55,10 @@ func Verify(clear string, passwd string) (bool, error) {
     verified = VerifyBCRYPT(clear, hashInfo.checksum)
   }
 
+  if(hashInfo.digest != DEFAULT_DIGEST) {
+    return (verified == true), errors.New("password hash digest is deprecated")
+  }
+
   return (verified == true), nil
 
 }

--- a/modules/password/password.go
+++ b/modules/password/password.go
@@ -7,92 +7,130 @@ import (
   "strings"
   "bytes"
   "strconv"
+  "crypto/rand"
   "crypto/sha256"
   "crypto/sha512"
   "encoding/base64"
   "golang.org/x/crypto/pbkdf2"
+  "golang.org/x/crypto/bcrypt"
 )
 
-var SUPPORTED_HASHES = map[string]func() hash.Hash{
-  "PBKDF2-HMAC-SHA256": sha256.New,
-  "PBKDF2-HMAC-SHA512": sha512.New,
+var SUPPORTED_HASHES = []string{
+  "PBKDF2-HMAC-SHA256",
+  "PBKDF2-HMAC-SHA512",
+  "BCRYPT",
 }
 
+const (
+  DEFAULT_DIGEST string = "BCRYPT"
+  DEFAULT_PBKDF2_ITERATIONS int = 10000
+  DEFAULT_PBKDF2_SALT_LENGTH = 64 // byte
+  DEFAULT_PBKDF2_OUTPUT_LENGTH = 64
+  DEFAULT_BCRYPT_COST = 10
+)
+
 type Password struct {
+  digest string
+  checksum []byte
+  // pkbdf2
   iterations int
   keyLength int
+  salt []byte
   hashAlgorithm func() hash.Hash
-  checksum []byte
-  salt string
 }
 
 func Verify(clear string, passwd string) (bool, error) {
 
-  password, err := Identify(passwd)
+  hashInfo, err := Identify(passwd)
   if(err != nil) {
     return false, err
   }
 
-  return VerifyManual(clear, password.checksum, password.salt, password.iterations, password.keyLength, password.hashAlgorithm)
+  verified := false;
+
+  switch getDigestMethod(hashInfo.digest) {
+  case "PBKDF2":
+    verified = VerifyPBKDF2(clear, hashInfo.checksum, hashInfo.salt, hashInfo.iterations, hashInfo.keyLength, hashInfo.hashAlgorithm)
+  case "BCRYPT":
+    verified = VerifyBCRYPT(clear, hashInfo.checksum)
+  }
+
+  return (verified == true), nil
 
 }
 
-func VerifyBackwardsCompatible(clear string, checksum string, salt string) bool {
-
+func VerifyBackwardsCompatible(clear string, checksum string, salt []byte) bool {
   newChecksum := encrypt(clear, salt, 10000, 50, sha256.New)
   compatibleChecksum := fmt.Sprintf("%x", newChecksum)
-
   return checksum == compatibleChecksum
-
 }
 
-func VerifyManual(clear string, checksum []byte, salt string, iterations int, keyLength int, hashAlgorithm func() hash.Hash) (bool, error) {
+func VerifyPBKDF2(clear string, checksum []byte, salt []byte, iterations int, keyLength int, hashAlgorithm func() hash.Hash) bool {
   newChecksum := encrypt(clear, salt, iterations, keyLength, hashAlgorithm);
   result := bytes.Equal(checksum, newChecksum)
-  return result, nil
+  return result
+}
+
+func VerifyBCRYPT(clear string, checksum []byte) bool {
+  err := bcrypt.CompareHashAndPassword(checksum, []byte(clear));
+  return (err == nil)
 }
 
 func Identify(passwd string) (Password, error) {
 
   var result Password
 
-  for digest, algo := range SUPPORTED_HASHES {
+  for _, digest := range SUPPORTED_HASHES {
 
     scheme := "{" + digest + "}";
     if strings.HasPrefix(strings.ToUpper(passwd), scheme) {
 
-      result.hashAlgorithm = algo
+      result.digest = digest
 
-      passwordParameters := strings.Split(passwd, "$")
-      if(len(passwordParameters) != 4) {
-        return result, errors.New("password identification failed: invalid number of parameters")
+      if strings.HasPrefix(digest, "PBKDF2-") {
+
+        hashAlgorithm, err := getHashAlgorithm(digest)
+        if err != nil {
+          return result, err
+        }
+        result.hashAlgorithm = hashAlgorithm
+
+        passwordParameters := strings.Split(passwd, "$")
+        if(len(passwordParameters) != 4) {
+          return result, errors.New("password identification failed: invalid number of parameters")
+        }
+
+        // parse iterations
+        iterations, err := strconv.Atoi(passwordParameters[1])
+        if (err != nil) || (iterations <= 0) {
+          return result, errors.New("password identification failed: invalid amount of iterations")
+        }
+        result.iterations = iterations
+
+        // parse salt
+        salt, err := base64.StdEncoding.DecodeString(passwordParameters[2])
+        if err != nil {
+          return result, errors.New("password identification failed: decoding of base64 salt failed")
+        }
+        result.salt = salt
+
+        // parse checksum
+        checksum, err := base64.StdEncoding.DecodeString(passwordParameters[3])
+        if err != nil {
+          return result, errors.New("password identification failed: decoding of base64 checksum failed")
+        }
+        result.checksum = checksum
+
+        // calculate keyLength from checksum length
+        result.keyLength = len(result.checksum)
+        return result, nil
+
+      } else if (digest == "BCRYPT") {
+
+        result.checksum = []byte(passwd[8:])
+        return result, nil
+
       }
-
-      // parse iterations
-      iterations, err := strconv.Atoi(passwordParameters[1])
-      if (err != nil) || (iterations <= 0) {
-        return result, errors.New("password identification failed: invalid amount of iterations")
-      }
-      result.iterations = iterations
-
-      // parse salt
-      salt, err := base64.StdEncoding.DecodeString(passwordParameters[2])
-      if err != nil {
-        return result, errors.New("password identification failed: decoding of base64 salt failed")
-      }
-      result.salt = string(salt[:])
-
-      // parse checksum
-      checksum, err := base64.StdEncoding.DecodeString(passwordParameters[3])
-      if err != nil {
-        return result, errors.New("password identification failed: decoding of base64 checksum failed")
-      }
-      result.checksum = checksum
-
-      // calculate keyLength from checksum length
-      result.keyLength = len(result.checksum)
-
-      return result, nil
 
     }
 
@@ -102,34 +140,73 @@ func Identify(passwd string) (Password, error) {
 
 }
 
-func Hash(clear string, salt string, iterations int, keyLength int, digest string) (string, error) {
+func Hash(clear string) (string, error) {
 
-  hashAlgorithm, err := GetHashAlgorithm(digest);
-  if(err != nil) {
-    // ToDo: Exit with real error
-    return "", err
+  switch getDigestMethod(DEFAULT_DIGEST) {
+  case "BCRYPT":
+    return HashBCRYPT(clear, DEFAULT_BCRYPT_COST)
+  case "PBKDF2":
+    return HashPBKDF2(clear, generateSalt(), DEFAULT_PBKDF2_ITERATIONS, DEFAULT_PBKDF2_OUTPUT_LENGTH, DEFAULT_DIGEST)
   }
 
+  return "", errors.New("invalid default hash digest: unknown hash method")
+
+}
+
+func HashBCRYPT(clear string, cost int) (string, error) {
+  encrypted, err := bcrypt.GenerateFromPassword([]byte(clear), cost)
+  if(err != nil) {
+    return "", err
+  }
+  return "{BCRYPT}" + string(encrypted[:]), nil
+}
+
+func HashPBKDF2(clear string, salt []byte, iterations int, keyLength int, digest string) (string, error) {
+  hashAlgorithm, err := getHashAlgorithm(digest)
+  if(err != nil) {
+    return "", errors.New("invalid default hash digest: unknown hash algorithm")
+  }
   output := []string{
     "{" + digest + "}",
     strconv.Itoa(iterations),
-    base64.StdEncoding.EncodeToString([]byte(salt)),
+    base64.StdEncoding.EncodeToString(salt),
     base64.StdEncoding.EncodeToString(encrypt(clear, salt, iterations, keyLength, hashAlgorithm)),
   }
-
   return strings.Join(output, "$"), nil
-
 }
 
-func GetHashAlgorithm(digest string) (func() hash.Hash, error) {
-  if hashAlgorithm, ok := SUPPORTED_HASHES[digest]; ok {
-    return hashAlgorithm, nil
-  } else {
-    return nil, errors.New("Cannot calculate hash with unknown digest: " + digest)
+func getHashAlgorithm(digest string) (func() hash.Hash, error) {
+  
+  switch strings.ToUpper(digest) {
+  case "PBKDF2-HMAC-SHA256":
+    return sha256.New, nil
+  case "PBKDF2-HMAC-SHA512":
+    return sha512.New, nil
   }
+
+  return nil, errors.New("cannot getHashAlgorithm from unknown digest: " + digest)
+
 }
 
-func encrypt(clear string, salt string, iterations int, keyLength int, hashAlgorithm func() hash.Hash) []byte {
-  out := pbkdf2.Key([]byte(clear), []byte(salt), iterations, keyLength, hashAlgorithm)
+func encrypt(clear string, salt []byte, iterations int, keyLength int, hashAlgorithm func() hash.Hash) []byte {
+  out := pbkdf2.Key([]byte(clear), salt, iterations, keyLength, hashAlgorithm)
   return out;
+}
+
+func generateSalt() []byte {
+  n := DEFAULT_PBKDF2_SALT_LENGTH
+  b := make([]byte, n)
+  _, err := rand.Read(b)
+  if err != nil {
+    // ToDo: Panic, RNG is failing
+  }
+  return b
+}
+
+func getDigestMethod(digest string) string {
+  firstSeparatorIndex := strings.Index(digest, "-")
+  if firstSeparatorIndex < 1 {
+    return digest
+  }
+  return digest[0:firstSeparatorIndex]
 }

--- a/modules/password/password.go
+++ b/modules/password/password.go
@@ -1,0 +1,135 @@
+package password
+
+import (
+  "fmt"
+  "errors"
+  "hash"
+  "strings"
+  "bytes"
+  "strconv"
+  "crypto/sha256"
+  "crypto/sha512"
+  "encoding/base64"
+  "golang.org/x/crypto/pbkdf2"
+)
+
+var SUPPORTED_HASHES = map[string]func() hash.Hash{
+  "PBKDF2-HMAC-SHA256": sha256.New,
+  "PBKDF2-HMAC-SHA512": sha512.New,
+}
+
+type Password struct {
+  iterations int
+  keyLength int
+  hashAlgorithm func() hash.Hash
+  checksum []byte
+  salt string
+}
+
+func Verify(clear string, passwd string) (bool, error) {
+
+  password, err := Identify(passwd)
+  if(err != nil) {
+    return false, err
+  }
+
+  return VerifyManual(clear, password.checksum, password.salt, password.iterations, password.keyLength, password.hashAlgorithm)
+
+}
+
+func VerifyBackwardsCompatible(clear string, checksum string, salt string) bool {
+
+  newChecksum := encrypt(clear, salt, 10000, 50, sha256.New)
+  compatibleChecksum := fmt.Sprintf("%x", newChecksum)
+
+  return checksum == compatibleChecksum
+
+}
+
+func VerifyManual(clear string, checksum []byte, salt string, iterations int, keyLength int, hashAlgorithm func() hash.Hash) (bool, error) {
+  newChecksum := encrypt(clear, salt, iterations, keyLength, hashAlgorithm);
+  result := bytes.Equal(checksum, newChecksum)
+  return result, nil
+}
+
+func Identify(passwd string) (Password, error) {
+
+  var result Password
+
+  for digest, algo := range SUPPORTED_HASHES {
+
+    scheme := "{" + digest + "}";
+    if strings.HasPrefix(strings.ToUpper(passwd), scheme) {
+
+      result.hashAlgorithm = algo
+
+      passwordParameters := strings.Split(passwd, "$")
+      if(len(passwordParameters) != 4) {
+        return result, errors.New("password identification failed: invalid number of parameters")
+      }
+
+      // parse iterations
+      iterations, err := strconv.Atoi(passwordParameters[1])
+      if (err != nil) || (iterations <= 0) {
+        return result, errors.New("password identification failed: invalid amount of iterations")
+      }
+      result.iterations = iterations
+
+      // parse salt
+      salt, err := base64.StdEncoding.DecodeString(passwordParameters[2])
+      if err != nil {
+        return result, errors.New("password identification failed: decoding of base64 salt failed")
+      }
+      result.salt = string(salt[:])
+
+      // parse checksum
+      checksum, err := base64.StdEncoding.DecodeString(passwordParameters[3])
+      if err != nil {
+        return result, errors.New("password identification failed: decoding of base64 checksum failed")
+      }
+      result.checksum = checksum
+
+      // calculate keyLength from checksum length
+      result.keyLength = len(result.checksum)
+
+      return result, nil
+
+    }
+
+  }
+
+  return result, errors.New("password identification failed: no supported algorithm found")
+
+}
+
+func Hash(clear string, salt string, iterations int, keyLength int, digest string) (string, error) {
+
+  hashAlgorithm, err := GetHashAlgorithm(digest);
+  if(err != nil) {
+    // ToDo: Exit with real error
+    return "", err
+  }
+
+  output := []string{
+    "{" + digest + "}",
+    strconv.Itoa(iterations),
+    base64.StdEncoding.EncodeToString([]byte(salt)),
+    base64.StdEncoding.EncodeToString(encrypt(clear, salt, iterations, keyLength, hashAlgorithm)),
+  }
+
+  return strings.Join(output, "$"), nil
+
+}
+
+func GetHashAlgorithm(digest string) (func() hash.Hash, error) {
+  if hashAlgorithm, ok := SUPPORTED_HASHES[digest]; ok {
+    return hashAlgorithm, nil
+  } else {
+    return nil, errors.New("Cannot calculate hash with unknown digest: " + digest)
+  }
+}
+
+func encrypt(clear string, salt string, iterations int, keyLength int, hashAlgorithm func() hash.Hash) []byte {
+  out := pbkdf2.Key([]byte(clear), []byte(salt), iterations, keyLength, hashAlgorithm)
+  return out;
+}

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -92,6 +92,7 @@ var (
 	CookieUserName       string
 	CookieRememberName   string
 	ReverseProxyAuthUser string
+	PasswordHashAlgorithm string
 
 	// Database settings
 	UseSQLite3    bool
@@ -450,6 +451,7 @@ func NewContext() {
 	CookieUserName = sec.Key("COOKIE_USERNAME").String()
 	CookieRememberName = sec.Key("COOKIE_REMEMBER_NAME").String()
 	ReverseProxyAuthUser = sec.Key("REVERSE_PROXY_AUTHENTICATION_USER").MustString("X-WEBAUTH-USER")
+	PasswordHashAlgorithm = sec.Key("PASSWORD_HASH_ALGORITHM").MustString("sha256")
 
 	sec = Cfg.Section("attachment")
 	AttachmentPath = sec.Key("PATH").MustString(path.Join(AppDataPath, "attachments"))

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -92,7 +92,6 @@ var (
 	CookieUserName       string
 	CookieRememberName   string
 	ReverseProxyAuthUser string
-	PasswordHashAlgorithm string
 
 	// Database settings
 	UseSQLite3    bool
@@ -451,7 +450,6 @@ func NewContext() {
 	CookieUserName = sec.Key("COOKIE_USERNAME").String()
 	CookieRememberName = sec.Key("COOKIE_REMEMBER_NAME").String()
 	ReverseProxyAuthUser = sec.Key("REVERSE_PROXY_AUTHENTICATION_USER").MustString("X-WEBAUTH-USER")
-	PasswordHashAlgorithm = sec.Key("PASSWORD_HASH_ALGORITHM").MustString("sha256")
 
 	sec = Cfg.Section("attachment")
 	AttachmentPath = sec.Key("PATH").MustString(path.Join(AppDataPath, "attachments"))

--- a/routers/install.go
+++ b/routers/install.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gogits/gogs/modules/ssh"
 	"github.com/gogits/gogs/modules/template/highlight"
 	"github.com/gogits/gogs/modules/user"
+	"github.com/gogits/gogs/modules/password"
 )
 
 const (
@@ -72,6 +73,8 @@ func GlobalInit() {
 
 		models.LoadRepoConfig()
 		models.NewRepoContext()
+
+		password.UseHashAlgorithm(setting.Cfg.Section("security").Key("PASSWORD_HASH_ALGORITHM").String())
 
 		// Booting long running goroutines.
 		cron.NewContext()

--- a/routers/install.go
+++ b/routers/install.go
@@ -72,7 +72,6 @@ func GlobalInit() {
 
 		models.LoadRepoConfig()
 		models.NewRepoContext()
-		models.UpdateHashAlgorithm()
 
 		// Booting long running goroutines.
 		cron.NewContext()

--- a/routers/install.go
+++ b/routers/install.go
@@ -72,6 +72,7 @@ func GlobalInit() {
 
 		models.LoadRepoConfig()
 		models.NewRepoContext()
+		models.UpdateHashAlgorithm()
 
 		// Booting long running goroutines.
 		cron.NewContext()

--- a/routers/user/setting.go
+++ b/routers/user/setting.go
@@ -189,7 +189,6 @@ func SettingsPasswordPost(ctx *context.Context, form auth.ChangePasswordForm) {
 		ctx.Flash.Error(ctx.Tr("form.password_not_match"))
 	} else {
 		ctx.User.Passwd = form.Password
-		ctx.User.Salt = models.GetUserSalt()
 		ctx.User.EncodePasswd()
 		if err := models.UpdateUser(ctx.User); err != nil {
 			ctx.Handle(500, "UpdateUser", err)


### PR DESCRIPTION
- Stores the password scheme and hash options among with the hash itself.
- Users can still sign in with their deprecated passwords (which allows password hash migration paths on existing installations)
- `PASSWORD_HASH_ALGORITHM` can be configured in app.ini
- New users are always created with the configured hash algorithm
- Stored hashes are updated on next successful user login
### Supported Hash Functions
- BCRYPT _(default)_
- PBKDF2-HMAC-SHA256
- PBKDF2-HMAC-SHA512
