### PR TITLE
add coverage result to codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ go:
   - 1.7
   - 1.8
   - master
+  
+go_import_path: github.com/gogits/gogs
 
 before_install:
   - sudo apt-get update -qq
@@ -12,6 +14,20 @@ before_install:
 env:
   - GO15VENDOREXPERIMENT=1
 
-script: 
+script:
   - go build -v -tags "pam"
-  - go test -v -cover -race ./...
+  - |#!/usr/bin/env bash
+
+    set -e
+    echo "" > coverage.txt
+
+    for d in $(go list ./... | grep -v vendor); do
+        go test -race -coverprofile=profile.out -covermode=atomic $d
+        if [ -f profile.out ]; then
+            cat profile.out >> coverage.txt
+            rm profile.out
+        fi
+    done
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
**Targeting**: 
    
To enhance the issue #2293, support code coverage result.

**Reason**: 

gogs now has so large code size, without some good unit testing or integration testing, 
we are not sure whether the pull requests will break current function or not, and afraid to accept a little bigger code changes. 

Code coverage is a good measure used to describe the degree to which the source code of a program is executed when a particular test suite runs. And the codecov service will check the coverage of newlines, if the newlines is uncovered, it will block the pull requests. By this strategy, the coverage percentage will grow up.

**Instructions**:

1. Enable the [Codecov](codecov.io) service by click here [https://github.com/marketplace/codecov](https://github.com/marketplace/codecov), 

2. Create a new plan, it is free for opensource projects
<img width="1011" alt="codecov" src="https://user-images.githubusercontent.com/1264866/30845227-091c281a-a258-11e7-8bbd-9ee41ee21b47.png">

3.  Check the bill info and click 
<img width="1021" alt="cover2" src="https://user-images.githubusercontent.com/1264866/30845235-1c27796e-a258-11e7-9333-696a7d0eb10f.png">

4. Enable for the gogs repository
<img width="607" alt="codecov3" src="https://user-images.githubusercontent.com/1264866/30845242-248493f8-a258-11e7-9c00-81090f2770d5.png">

