### PR TITLE
make repo show if any part is public

### DIFF
--- a/models/repo.go
+++ b/models/repo.go
@@ -1647,11 +1647,11 @@ func SearchRepositoryByName(opts *SearchRepoOptions) (repos []*Repository, count
 	// this does not include other people's private repositories even if opts.UserID is an admin.
 	if !opts.Private && opts.UserID > 0 {
 		sess.Join("LEFT", "access", "access.repo_id = repo.id").
-			Where("(repo.owner_id = ? OR access.user_id = ? OR repo.is_private = ?)", opts.UserID, opts.UserID, false)
+			Where("(repo.owner_id = ? OR access.user_id = ? OR repo.is_private = ? OR (repo.is_private = ? AND (repo.allow_public_wiki = ? OR repo.allow_public_issues = ?)))", opts.UserID, opts.UserID, false, true, true, true)
 	} else {
 		// Only return public repositories if opts.Private is not set
 		if !opts.Private {
-			sess.And("repo.is_private = ?", false)
+			sess.And("(repo.is_private = ? OR (repo.is_private = ? AND (repo.allow_public_wiki = ? OR repo.allow_public_issues = ?))", false, true, true, true)
 		}
 	}
 	if len(opts.Keyword) > 0 {


### PR DESCRIPTION
This pull request addresses issue #4973 

essentially if a repo is set to private and either (or both) the wiki or issue tracker are set to allow public access, they cannot be accessed without knowing the URL. The repo doesn't show in search or explore.

With these changes if the repo is private and either issue tracker or wiki are set to public then the repo will show in search and explore, but only the public pages can be accessed.

I'd suggest that maybe this behaviour should be enabled through a config option (per repo or for whole installation) but i'm not sufficiently capable with go to be able to implement that.