### PR TITLE
fix make build failure when enviroment of GOPATH have multiple items

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-LDFLAGS += -X "github.com/gogits/gogs/pkg/setting.BuildTime=$(shell date -u '+%Y-%m-%d %I:%M:%S %Z')"
-LDFLAGS += -X "github.com/gogits/gogs/pkg/setting.BuildGitHash=$(shell git rev-parse HEAD)"
+LDFLAGS += -X "github.com/gogs/gogs/pkg/setting.BuildTime=$(shell date -u '+%Y-%m-%d %I:%M:%S %Z')"
+LDFLAGS += -X "github.com/gogs/gogs/pkg/setting.BuildGitHash=$(shell git rev-parse HEAD)"
 
 DATA_FILES := $(shell find conf | sed 's/ /\\ /g')
 LESS_FILES := $(wildcard public/less/gogs.less public/less/_*.less)

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ RELEASE_ROOT = "release"
 RELEASE_GOGS = "release/gogs"
 NOW = $(shell date -u '+%Y%m%d%I%M%S')
 GOVET = go tool vet -composites=false -methods=false -structtags=false
+GOPATH = $(shell echo $${PWD%%src*})
 
 .PHONY: build pack release bindata clean
 


### PR DESCRIPTION
```
[alimy@rover gogs]$ pwd
/home/alimy/art/arg/src/github.com/gogs/gogs
[alimy@rover gogs]$ echo $GOPATH
/home/alimy/art/ago:/home/alimy/art/arg
[alimy@rover gogs]$ make
go install "-v" -ldflags '-X "github.com/gogs/gogs/pkg/setting.BuildTime=2018-06-04 06:17:19 UTC" -X "github.com/gogs/gogs/pkg/setting.BuildGitHash=c08aab90ec696b7fcc56b8da0a468e74d266b89e"' -tags '""'
cp '/home/alimy/art/ago:/home/alimy/art/arg/bin/gogs' .
cp: cannot stat '/home/alimy/art/ago:/home/alimy/art/arg/bin/gogs': No such file or directory
Makefile:36: recipe for target 'build' failed
make: *** [build] Error 1
```
in this scene GOPATH have two item (/home/alimy/art/ago and /home/alimy/art/arg) and gogs source is not in first GOPATH items, when excecute go install ... will install to path that contain the source of gogs's GOPATH items. when cp gogs file back will occur error like above.
this patch fixed this problem.
```
[alimy@rover gogs]$ echo $GOPATH
/home/alimy/art/ago:/home/alimy/art/arg
[alimy@rover gogs]$ pwd
/home/alimy/art/arg/src/github.com/gogs/gogs
[alimy@rover gogs]$ echo ${PWD%%src*}
/home/alimy/art/arg/
```