### PR TITLE
Correct pagination in repository search API

### DIFF
--- a/pkg/context/api.go
+++ b/pkg/context/api.go
@@ -43,7 +43,7 @@ func (c *APIContext) Error(status int, title string, obj interface{}) {
 	})
 }
 
-// SetLinkHeader sets pagination link header by given totol number and page size.
+// SetLinkHeader sets pagination link header by given total number and page size.
 func (c *APIContext) SetLinkHeader(total, pageSize int) {
 	page := paginater.New(total, pageSize, c.QueryInt("page"), 0)
 	links := make([]string, 0, 4)

--- a/routes/api/v1/repo/repo.go
+++ b/routes/api/v1/repo/repo.go
@@ -25,6 +25,7 @@ func Search(c *context.APIContext) {
 		Keyword:  path.Base(c.Query("q")),
 		OwnerID:  c.QueryInt64("uid"),
 		PageSize: convert.ToCorrectPageSize(c.QueryInt("limit")),
+		Page:     c.QueryInt("page"),
 	}
 
 	// Check visibility.
@@ -69,7 +70,7 @@ func Search(c *context.APIContext) {
 		results[i] = repos[i].APIFormat(nil)
 	}
 
-	c.SetLinkHeader(int(count), setting.API.MaxResponseItems)
+	c.SetLinkHeader(int(count), opts.PageSize)
 	c.JSON(200, map[string]interface{}{
 		"ok":   true,
 		"data": results,


### PR DESCRIPTION
When I access to repository search API, I get this response
```http
> curl -i -XGET 'http://localhost:3000/api/v1/repos/search?q=repo&limit=1&page=1'
HTTP/1.1 200 OK
Content-Type: application/json; charset=UTF-8
Link: <http://localhost:3000/api/v1/repos/search?page=2>; rel="next",<http://localhost:3000/api/v1/repos/search?page=21>; rel="last"
```
It tell me it have second page, I'm try, but it also return the same as first page data.

I found it is not accept `page` parameter in `repo.Search` function, and `SetLinkHeader` are not use `limit` parameter from request to calculate page link, so i fixed it.

I also found in `go-gogs-client` project's wiki exclude `page` parameter in [repository search API](https://github.com/gogs/go-gogs-client/wiki/Repositories#search-repositories). Need to add it?
