### PR TITLE
require autosize when repo/settings/options is rendered

### DIFF
--- a/routes/repo/setting.go
+++ b/routes/repo/setting.go
@@ -44,6 +44,7 @@ func Settings(c *context.Context) {
 func SettingsPost(c *context.Context, f form.RepoSetting) {
 	c.Title("repo.settings")
 	c.PageIs("SettingsOptions")
+	c.RequireAutosize()
 
 	repo := c.Repo.Repository
 


### PR DESCRIPTION
https://github.com/gogs/gogs/blob/dfd494c113cfa2a25ee0c2f5a12c6403f24742a4/public/js/gogs.js#L1267 requires autosize to execute, which executes for "repo/settings/options". without this change, you get a JS error.

Technically, autoresize is only required for code with `SETTINGS_OPTIONS` rendering, but I found it kinda messy handling each case, so I guess browsers will take a minor JS loading hit. Let me know if this is good enough.

fixes #5314 