### PR TITLE
Fix layout misalignment in Firefox for Linux

### DIFF
--- a/public/less/_repository.less
+++ b/public/less/_repository.less
@@ -134,6 +134,7 @@
 			border-radius: 0;
 			padding: 5px 10px;
 			max-width: 190px;
+			width: 190px;
 		}
 
 		.clone.button {

--- a/public/less/_repository.less
+++ b/public/less/_repository.less
@@ -128,11 +128,12 @@
 	#clone-panel {
 		margin-top: -8px;
 		margin-left: 5px;
-		width: 350px;
+		width: auto;
 
 		input {
 			border-radius: 0;
 			padding: 5px 10px;
+			max-width: 190px;
 		}
 
 		.clone.button {


### PR DESCRIPTION
A fix for issue #5299.

Fixed by simple style modification.

I changed the width of `#clone-panel` to `auto`, but in Ubuntu, the length of `#repo-clone-url` is getting longer.
![screenshot from 2018-06-26 22-39-55](https://user-images.githubusercontent.com/22613611/41943189-7610ea5c-79dd-11e8-82e3-1be87d262785.png)

So I set `max-width` and `width` in `#clone-panel input`.
![screenshot from 2018-06-26 22-43-06](https://user-images.githubusercontent.com/22613611/41943312-e4c9c022-79dd-11e8-9021-1d1c9d523c46.png)
