### PR TITLE
add new Dockerfile.docker-ce for docker-ce(>=v17.06) to  build docker image

### DIFF
--- a/Dockerfile.docker-ce
+++ b/Dockerfile.docker-ce
@@ -1,0 +1,42 @@
+FROM golang:1.10.3-alpine AS binarybuilder
+# Install build deps
+RUN apk --no-cache --no-progress add --virtual build-deps build-base git linux-pam-dev
+WORKDIR /go/src/github.com/gogs/gogs
+COPY . .
+RUN make build TAGS="sqlite cert pam"
+
+FROM alpine:3.7
+# Install system utils & Gogs runtime dependencies
+ADD https://github.com/tianon/gosu/releases/download/1.10/gosu-amd64 /usr/sbin/gosu
+RUN chmod +x /usr/sbin/gosu \
+  && echo http://dl-2.alpinelinux.org/alpine/edge/community/ >> /etc/apk/repositories \
+  && apk --no-cache --no-progress add \
+    bash \
+    ca-certificates \
+    curl \
+    git \
+    linux-pam \
+    openssh \
+    s6 \
+    shadow \
+    socat \
+    tzdata
+
+ENV GOGS_CUSTOM /data/gogs
+
+# Configure LibC Name Service
+COPY docker/nsswitch.conf /etc/nsswitch.conf
+
+WORKDIR /app/gogs
+COPY docker ./docker
+COPY templates ./templates
+COPY public ./public
+COPY --from=binarybuilder /go/src/github.com/gogs/gogs/gogs .
+
+RUN ./docker/finalize-docker-ce.sh
+
+# Configure Docker Container
+VOLUME ["/data"]
+EXPOSE 22 3000
+ENTRYPOINT ["/app/gogs/docker/start.sh"]
+CMD ["/bin/s6-svscan", "/app/gogs/docker/s6/"]

--- a/docker/finalize-docker-ce.sh
+++ b/docker/finalize-docker-ce.sh
@@ -4,11 +4,12 @@
 set -x
 set -e
 
-# Move to final place
-mv /app/gogs/build/gogs /app/gogs/
+# Create git user for Gogs
+addgroup -S git
+adduser -G git -H -D -g 'Gogs Git User' git -h /data/git -s /bin/bash && usermod -p '*' git && passwd -u git
+echo "export GOGS_CUSTOM=${GOGS_CUSTOM}" >> /etc/profile
 
 # Final cleaning
-rm -rf /app/gogs/build
 rm /app/gogs/docker/build.sh
 rm /app/gogs/docker/build-go.sh
 rm /app/gogs/docker/finalize.sh
@@ -16,5 +17,3 @@ rm /app/gogs/docker/finalize-docker-ce.sh
 rm /app/gogs/docker/nsswitch.conf
 rm /app/gogs/docker/README.md
 
-rm -rf /tmp/go
-rm -rf /usr/local/go


### PR DESCRIPTION
Docker-CE can be given to a new build stage by adding `AS` name to the` FROM` instruction sine release version of v17.06. The Dockerfile's `FROM` instruction like below:
### FROM
```
FROM <image> [AS <name>]
```
Or
```
FROM <image>[:<tag>] [AS <name>]
```
Or
```
FROM <image>[@<digest>] [AS <name>]
```
* Optionally a name can be given to a new build stage by adding AS name to the FROM instruction. The name can be used in subsequent FROM and COPY --from=<name|index> instructions to refer to the image built in this stage.

Find Docker-ce official document [here](https://docs.docker.com/v17.06/engine/reference/builder/#from 'Docker official Document').

You can use this patch to build docker image if  docker-ce that version >=v17.06 is installed:
```
>docker version
Client:
 Version:      18.03.1-ce
 API version:  1.37
 Go version:   go1.9.5
 Git commit:   9ee9f40
 Built:        Thu Apr 26 07:20:16 2018
 OS/Arch:      linux/amd64
 Experimental: false
 Orchestrator: swarm

Server:
 Engine:
  Version:      18.03.1-ce
  API version:  1.37 (minimum version 1.12)
  Go version:   go1.9.5
  Git commit:   9ee9f40
  Built:        Thu Apr 26 07:23:58 2018
  OS/Arch:      linux/amd64
  Experimental: false
```
* Build docker image
```
>cd $GOPATH/src/github.com/gogs/gogs
>docker build -t <your/image-tag> -f Dockerfile.docker-ce .
```


