### PR TITLE
Apply hardening for systemd unit

### DIFF
--- a/scripts/systemd/gogs.service
+++ b/scripts/systemd/gogs.service
@@ -18,6 +18,10 @@ WorkingDirectory=/home/git/gogs
 ExecStart=/home/git/gogs/gogs web
 Restart=always
 Environment=USER=git HOME=/home/git
+# Hardening
+ProtectSystem=full
+PrivateDevices=yes
+PrivateTmp=yes
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Disallow modifications to the system, disallow access to devices and separate temporary directory.

ProtectSystem=full # Make /boot, /etc and /usr read-only
PrivateDevices=yes # Disallow access to devices
PrivateTmp=yes # Make separate /tmp directory for gogs.