### PR TITLE
Add default Authentication Switch

### DIFF
--- a/models/login_source.go
+++ b/models/login_source.go
@@ -410,8 +410,7 @@ func (s *LocalLoginSources) UpdateLoginSource(source *LoginSource) {
 	for i := range s.sources {
 		if s.sources[i].ID == source.ID {
 			*s.sources[i] = *source
-		} else if source.IsDefault {
-			s.sources[i].IsDefault = false
+			break
 		}
 	}
 }

--- a/models/login_source.go
+++ b/models/login_source.go
@@ -305,16 +305,12 @@ func ResetNonDefaultLoginSources(source *LoginSource) error {
 	}
 	// write changes to local authentications
 	for i := range localLoginSources.sources {
-		localSource := &LoginSource{}
-		*localSource = *localLoginSources.sources[i]
-		if localSource.LocalFile != nil {
-			if localSource.ID != source.ID {
-				localSource.LocalFile.SetGeneral("is_default", "false")
-				if err := localSource.LocalFile.SetConfig(source.Cfg); err != nil {
-					return fmt.Errorf("LocalFile.SetConfig: %v", err)
-				} else if err = localSource.LocalFile.Save(); err != nil {
-					return fmt.Errorf("LocalFile.Save: %v", err)
-				}
+		if localLoginSources.sources[i].LocalFile != nil && localLoginSources.sources[i].ID != source.ID {
+			localLoginSources.sources[i].LocalFile.SetGeneral("is_default", "false")
+			if err := localLoginSources.sources[i].LocalFile.SetConfig(source.Cfg); err != nil {
+				return fmt.Errorf("LocalFile.SetConfig: %v", err)
+			} else if err = localLoginSources.sources[i].LocalFile.Save(); err != nil {
+				return fmt.Errorf("LocalFile.Save: %v", err)
 			}
 		}
 	}
@@ -342,9 +338,7 @@ func UpdateLoginSource(source *LoginSource) error {
 	} else if err = source.LocalFile.Save(); err != nil {
 		return fmt.Errorf("LocalFile.Save: %v", err)
 	}
-	ResetNonDefaultLoginSources(source)
-
-	return nil
+	return ResetNonDefaultLoginSources(source)
 }
 
 func DeleteSource(source *LoginSource) error {

--- a/models/login_source.go
+++ b/models/login_source.go
@@ -307,13 +307,9 @@ func ResetNonDefaultLoginSources(id int64) error {
 func UpdateLoginSource(source *LoginSource) error {
 	if source.LocalFile == nil {
 		if _, err := x.Id(source.ID).AllCols().Update(source); err != nil {
-			if source.IsDefault {
-				return ResetNonDefaultLoginSources(source.ID)
-			} else {
-				return err
-			}
+			return err
 		} else {
-			return nil
+			return ResetNonDefaultLoginSources(source.ID)
 		}
 
 	}
@@ -384,11 +380,7 @@ func (s *LocalLoginSources) ActivatedList() []*LoginSource {
 		}
 		source := &LoginSource{}
 		*source = *s.sources[i]
-		if s.sources[i].IsDefault {
-			list = append([]*LoginSource{source}, list...)
-		} else {
-			list = append(list, source)
-		}
+		list = append(list, source)
 	}
 	return list
 }

--- a/pkg/form/auth.go
+++ b/pkg/form/auth.go
@@ -32,6 +32,7 @@ type Authentication struct {
 	GroupMemberUID    string
 	UserUID           string
 	IsActive          bool
+	IsDefault         bool
 	SMTPAuth          string
 	SMTPHost          string
 	SMTPPort          int

--- a/routes/admin/auths.go
+++ b/routes/admin/auths.go
@@ -69,6 +69,7 @@ func NewAuthSource(c *context.Context) {
 	c.Data["CurrentSecurityProtocol"] = models.SecurityProtocolNames[ldap.SECURITY_PROTOCOL_UNENCRYPTED]
 	c.Data["smtp_auth"] = "PLAIN"
 	c.Data["is_active"] = true
+	c.Data["is_default"] = true
 	c.Data["AuthSources"] = authSources
 	c.Data["SecurityProtocols"] = securityProtocols
 	c.Data["SMTPAuths"] = models.SMTPAuths
@@ -152,6 +153,7 @@ func NewAuthSourcePost(c *context.Context, f form.Authentication) {
 		Type:      models.LoginType(f.Type),
 		Name:      f.Name,
 		IsActived: f.IsActive,
+		IsDefault: f.IsDefault,
 		Cfg:       config,
 	}); err != nil {
 		if models.IsErrLoginSourceAlreadyExist(err) {
@@ -225,11 +227,13 @@ func EditAuthSourcePost(c *context.Context, f form.Authentication) {
 
 	source.Name = f.Name
 	source.IsActived = f.IsActive
+	source.IsDefault = f.IsDefault
 	source.Cfg = config
 	if err := models.UpdateLoginSource(source); err != nil {
 		c.ServerError("UpdateLoginSource", err)
 		return
 	}
+
 	log.Trace("Authentication changed by admin '%s': %d", c.User.Name, source.ID)
 
 	c.Flash.Success(c.Tr("admin.auths.update_success"))

--- a/routes/user/auth.go
+++ b/routes/user/auth.go
@@ -113,7 +113,15 @@ func Login(c *context.Context) {
 		return
 	}
 	c.Data["LoginSources"] = loginSources
-
+	for i := range loginSources {
+		if loginSources[i].IsDefault {
+			c.Data["DefaultSource"] = *loginSources[i]
+			c.Data["login_source"] = loginSources[i].ID
+			newLoginSources := append(loginSources[:i], loginSources[i+1:]...)
+			c.Data["LoginSources"] = newLoginSources
+			break
+		}
+	}
 	c.Success(LOGIN)
 }
 
@@ -172,6 +180,15 @@ func LoginPost(c *context.Context, f form.SignIn) {
 
 		default:
 			c.ServerError("UserLogin", err)
+		}
+		for i := range loginSources {
+			if loginSources[i].IsDefault {
+				c.Data["DefaultSource"] = *loginSources[i]
+				c.Data["login_source"] = loginSources[i].ID
+				newLoginSources := append(loginSources[:i], loginSources[i+1:]...)
+				c.Data["LoginSources"] = newLoginSources
+				break
+			}
 		}
 		return
 	}

--- a/templates/admin/auth/edit.tmpl
+++ b/templates/admin/auth/edit.tmpl
@@ -186,7 +186,12 @@
 								<input name="is_active" type="checkbox" {{if .Source.IsActived}}checked{{end}}>
 							</div>
 						</div>
-
+						<div class="inline field">
+							<div class="ui checkbox">
+								<label><strong>{{.i18n.Tr "admin.auths.default_auth"}}</strong></label>
+								<input name="is_default" type="checkbox" {{if .Source.IsDefault}}checked{{end}}>
+							</div>
+						</div>
 						<div class="field">
 							<button class="ui green button">{{.i18n.Tr "admin.auths.update"}}</button>
 							{{if not .Source.LocalFile}}

--- a/templates/admin/auth/list.tmpl
+++ b/templates/admin/auth/list.tmpl
@@ -16,6 +16,7 @@
 								<th>{{.i18n.Tr "admin.auths.name"}}</th>
 								<th>{{.i18n.Tr "admin.auths.type"}}</th>
 								<th>{{.i18n.Tr "admin.auths.enabled"}}</th>
+								<th>{{.i18n.Tr "admin.auths.default"}}</th>
 								<th>{{.i18n.Tr "admin.auths.updated"}}</th>
 								<th>{{.i18n.Tr "admin.users.created"}}</th>
 								<th>{{.i18n.Tr "admin.users.edit"}}</th>
@@ -28,6 +29,7 @@
 									<td><a href="{{AppSubURL}}/admin/auths/{{.ID}}">{{.Name}}</a></td>
 									<td>{{.TypeName}}</td>
 									<td><i class="fa fa{{if .IsActived}}-check{{end}}-square-o"></i></td>
+									<td><i class="fa fa{{if .IsDefault}}-check{{end}}-square-o"></i></td>
 									<td><span class="poping up" data-content="{{DateFmtLong .Updated}}" data-variation="tiny">{{DateFmtShort .Updated}}</span></td>
 									<td>
 										{{if .Created.IsZero}}

--- a/templates/admin/auth/new.tmpl
+++ b/templates/admin/auth/new.tmpl
@@ -176,10 +176,18 @@
 								<input name="skip_verify" type="checkbox" {{if .skip_verify}}checked{{end}}>
 							</div>
 						</div>
+
 						<div class="inline field">
 							<div class="ui checkbox">
 								<label><strong>{{.i18n.Tr "admin.auths.activated"}}</strong></label>
 								<input name="is_active" type="checkbox" {{if .is_active}}checked{{end}}>
+							</div>
+						</div>
+
+						<div class="inline field">
+							<div class="ui checkbox">
+								<label><strong>{{.i18n.Tr "admin.auths.default_auth"}}</strong></label>
+								<input name="is_default" type="checkbox" {{if .is_default}}checked{{end}}>
 							</div>
 						</div>
 

--- a/templates/user/auth/login.tmpl
+++ b/templates/user/auth/login.tmpl
@@ -22,16 +22,30 @@
 							<label for="password">{{.i18n.Tr "auth.auth_source"}}</label>
 							<div class="ui selection dropdown">
 								<input type="hidden" id="login_source" name="login_source" value="{{.login_source}}" required>
-								<span class="text">
-									{{.i18n.Tr "auth.local"}}
-								</span>
-								<i class="dropdown icon"></i>
-								<div class="menu">
-									<div class="item" data-value="0">{{.i18n.Tr "auth.local"}}</div>
-									{{range .LoginSources}}
-										<div class="item" data-value="{{.ID}}">{{.Name}}</div>
-									{{end}}
-								</div>
+								{{if .DefaultSource}}
+									<span class="text">
+										{{.DefaultSource.Name}}
+									</span>
+									<i class="dropdown icon"></i>
+									<div class="menu">
+										<div class="item" data-value="{{.DefaultSource.ID}}">{{.DefaultSource.Name}}</div>
+										<div class="item" data-value="0">{{.i18n.Tr "auth.local"}}</div>
+										{{range .LoginSources}}
+											<div class="item" data-value="{{.ID}}">{{.Name}}</div>
+										{{end}}
+									</div>
+								{{else}}
+									<span class="text">
+										{{.i18n.Tr "auth.local"}}
+									</span>
+									<i class="dropdown icon"></i>
+									<div class="menu">
+										<div class="item" data-value="0">{{.i18n.Tr "auth.local"}}</div>
+										{{range .LoginSources}}
+											<div class="item" data-value="{{.ID}}">{{.Name}}</div>
+										{{end}}
+									</div>
+								{{end}}
 							</div>
 						</div>
 					{{end}}


### PR DESCRIPTION
The changes will add a default authentication switch so that user doesn't need select their authentication source every time on the login page. This will save engineers time and money.

For example, if this select action from dropdown list will cost 1s and Gogs has 1,000,000 users, it will then cost 11.6 days on switching different authentication method. If one second will cost developer 1 cent, it will then save $10,000 money!
