### PR TITLE
Don't try to chown the git repos on startup (refs #4996).

### DIFF
--- a/docker/s6/gogs/setup
+++ b/docker/s6/gogs/setup
@@ -19,5 +19,4 @@ ln -sfn /data/gogs/data ./data
 # Backward Compatibility with Gogs Container v0.6.15
 ln -sfn /data/git /home/git
 
-chown -R git:git /data /app/gogs ~git/
 chmod 0755 /data /data/gogs ~git/


### PR DESCRIPTION
As per comments in issue, the recursive 'chown' command being removed in this patch causes problems with templates when run as a container, as well as delays service startup unnecessarily for users with large/slow repos.