### PR TITLE
Add data urls support for markdown images (fix #5279)

### DIFF
--- a/pkg/markup/markup.go
+++ b/pkg/markup/markup.go
@@ -190,6 +190,12 @@ func wrapImgWithLink(urlPrefix string, buf *bytes.Buffer, token html.Token) {
 		return
 	}
 
+	// Skip in case the "src" is data url
+	if strings.HasPrefix(src, "data:") {
+		buf.WriteString(token.String())
+		return
+	}
+
 	// Prepend repository base URL for internal links
 	needPrepend := !isLink([]byte(src))
 	if needPrepend {

--- a/pkg/markup/sanitizer.go
+++ b/pkg/markup/sanitizer.go
@@ -36,6 +36,9 @@ func NewSanitizer() {
 		sanitizer.policy.AllowAttrs("type").Matching(regexp.MustCompile(`^checkbox$`)).OnElements("input")
 		sanitizer.policy.AllowAttrs("checked", "disabled").OnElements("input")
 
+		// Data URLs
+		sanitizer.policy.AllowURLSchemes("data")
+
 		// Custom URL-Schemes
 		sanitizer.policy.AllowURLSchemes(setting.Markdown.CustomURLSchemes...)
 	})


### PR DESCRIPTION
Allow to use !\[img](data:...) in markdown. (fix #5279)