### PR TITLE
Hide dashboard org creation when not allowed

### DIFF
--- a/templates/user/dashboard/dashboard.tmpl
+++ b/templates/user/dashboard/dashboard.tmpl
@@ -76,12 +76,14 @@
 					<div class="ui tab list" data-tab="orgs">
 						<div class="ui top attached header">
 							{{.i18n.Tr "home.my_orgs"}} <span class="ui grey label">{{.ContextUser.GetOrganizationCount}}</span>
+							{{if .LoggedUser.CanCreateOrganization}}
 							<div class="ui right">
 								<a class="poping up" href="{{AppSubURL}}/org/create" data-content="{{.i18n.Tr "new_org"}}" data-variation="tiny inverted" data-position="left center">
 									<i class="plus icon"></i>
 									<span class="sr-only">{{.i18n.Tr "new_org"}}</span>
 								</a>
 							</div>
+							{{end}}
 						</div>
 						<div class="ui attached table segment">
 							<ul class="repo-owner-name-list">


### PR DESCRIPTION
The admin -> DISABLE_REGULAR_ORG_CREATION setting hides organization creation in the header, but not in the dashboard. The current button gives a 404 page.

This PR simply hides the button, using the same conditional found in the header template.