### PR TITLE
Fix critical CSRF vulnerabilities on api routes (issue #5398 #5355)

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -59,6 +59,7 @@ func SignedInID(c *macaron.Context, sess session.Store) int64 {
 			if err = models.UpdateAccessToken(t); err != nil {
 				log.Error(2, "UpdateAccessToken: %v", err)
 			}
+			c.Data["IsApiToken"] = true
 			return t.UID
 		}
 	}
@@ -134,7 +135,7 @@ func SignedInUser(ctx *macaron.Context, sess session.Store) (*models.User, bool)
 					}
 					return nil, false
 				}
-
+				c.Data["IsApiToken"] = true
 				return u, true
 			}
 		}

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -135,7 +135,7 @@ func SignedInUser(ctx *macaron.Context, sess session.Store) (*models.User, bool)
 					}
 					return nil, false
 				}
-				c.Data["IsApiToken"] = true
+				ctx.Data["IsApiToken"] = true
 				return u, true
 			}
 		}

--- a/routes/api/v1/api.go
+++ b/routes/api/v1/api.go
@@ -86,7 +86,7 @@ func repoAssignment() macaron.Handler {
 // Contexter middleware already checks token for user sign in process.
 func reqToken() macaron.Handler {
 	return func(c *context.Context) {
-		if !c.IsLogged {
+		if true != c.Data["IsApiToken"] {
 			c.Error(401)
 			return
 		}


### PR DESCRIPTION
Current Drone integration relies on basic auth in API routes to work. This PR treats a valid basic auth header as the equivalent of presenting a valid token. 

When enforced, API routes with reqToken middleware will be available only if a valid token is presented. Some JavaScript code may need adjustment if the code is accessing API routes with cookie.

Please review the test suite and update the logic. 