### PR TITLE
Dockerfile.aarch64hub: install shadow package

### DIFF
--- a/Dockerfile.aarch64hub
+++ b/Dockerfile.aarch64hub
@@ -19,7 +19,7 @@ RUN [ "cross-build-start" ]
 # Install system utils & Gogs runtime dependencies
 ADD https://github.com/tianon/gosu/releases/download/1.10/gosu-arm64 /usr/sbin/gosu
 RUN chmod +x /usr/sbin/gosu \
- && apk --no-cache --no-progress add ca-certificates bash git linux-pam s6 curl openssh socat tzdata go=1.10.1-r0
+ && apk --no-cache --no-progress add ca-certificates bash git linux-pam s6 curl openssh shadow socat tzdata go=1.10.1-r0
 
 
 


### PR DESCRIPTION
The shadow package contains the `usermod(8)` utility which is used by `start.sh` and `finalize.sh` to configure the git user.

The other Dockerfiles **do** install this package, for some reason it appears to have been missed in the aarch64hub variant. Further, I'm not sure that Dockerfile.aarch64hub is being used, but while trying to use it for building an aarch64 image I discovered issues with ssh login and the git user having the wrong uid/gid. Ultimately was able to debug this down to missing the usermod/groupmod utilities -- simple fix.