### PR TITLE
Added rel="me" to website link on user profile

### DIFF
--- a/templates/user/profile.tmpl
+++ b/templates/user/profile.tmpl
@@ -31,7 +31,7 @@
 							{{if .Owner.Website}}
 								<li>
 									<i class="octicon octicon-link"></i>
-									<a target="_blank" rel="noopener noreferrer" href="{{.Owner.Website}}">{{.Owner.Website}}</a>
+									<a target="_blank" rel="noopener noreferrer me" href="{{.Owner.Website}}">{{.Owner.Website}}</a>
 								</li>
 							{{end}}
 							<li><i class="octicon octicon-clock"></i> {{.i18n.Tr "user.join_on"}} {{DateFmtShort .Owner.Created}}</li>


### PR DESCRIPTION
I added "me" to the value of the "rel" attribute on links pointing to a user's website, so this can be used for authentication in an IndieWeb context.

This targets issue #5008.