### PR TITLE
repo/http: update CORS headers to allow custom user-agent

### DIFF
--- a/routes/repo/http.go
+++ b/routes/repo/http.go
@@ -47,7 +47,7 @@ func HTTPContexter() macaron.Handler {
 		if len(setting.HTTP.AccessControlAllowOrigin) > 0 {
 			// Set CORS headers for browser-based git clients
 			c.Resp.Header().Set("Access-Control-Allow-Origin", setting.HTTP.AccessControlAllowOrigin)
-			c.Resp.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+			c.Resp.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, User-Agent")
 
 			// Handle preflight OPTIONS request
 			if c.Req.Method == "OPTIONS" {


### PR DESCRIPTION
At some point after #4970 was merged, isomorphic-git started sending a custom User-Agent in its HTTP requests to deal with some services (\*cough\* gists \*cough\*) which filtered git traffic by User-Agent. Sadly, this broke cloning from Gogs using isomorphic-git in the browser (https://github.com/isomorphic-git/isomorphic-git/issues/555). This PR fixes it by telling browsers it is OK for CORS requests to send a custom User-Agent header.