### PR TITLE
Fix issue 5502

### DIFF
--- a/public/css/gogs.css
+++ b/public/css/gogs.css
@@ -3034,6 +3034,7 @@ footer .ui.language .menu {
 }
 .feeds .news p {
   line-height: 1em;
+  overflow-wrap: break-word;
 }
 .feeds .news .time-since {
   font-size: 13px;

--- a/public/less/_dashboard.less
+++ b/public/less/_dashboard.less
@@ -61,6 +61,7 @@
 		}
 		p {
 			line-height: 1em;
+			overflow-wrap: break-word;
 		}
 		.time-since {
 			font-size: 13px;


### PR DESCRIPTION
Fixes issue #5502. I used `overflow-wrap: break-word` rather than `word-break: break-all` because it will break long words without breaking regular sentences.  