### PR TITLE
Implement issue title and content prefilling

### DIFF
--- a/routes/repo/issue.go
+++ b/routes/repo/issue.go
@@ -345,6 +345,8 @@ func NewIssue(c *context.Context) {
 	c.Data["PageIsIssueList"] = true
 	c.Data["RequireHighlightJS"] = true
 	c.Data["RequireSimpleMDE"] = true
+	c.Data["title"] = c.Query("title")
+	c.Data["content"] = c.Query("content")
 	setTemplateIfExists(c, ISSUE_TEMPLATE_KEY, IssueTemplateCandidates)
 	renderAttachmentSettings(c)
 


### PR DESCRIPTION
Resolves #5302.

Just added some code to the `GET /:user/:repo/issues/new` route to add `title` and `content` query string parameters to the context, so that they are prefilled in the from template when provided. The feature request mentioned using `body`, but `content` was already used in the template file so I went with that.

One thing to note is, with the current setup in [templates/repo/issue/comment_tab.tmpl](https://github.com/gogs/gogs/blob/master/templates/repo/issue/comment_tab.tmpl#L8), a repository's issue template takes precedence over the provided `content` query string parameter when templating the issue body, contrary to how it works on Github. @Unknwon Interested to see what your take on this is.
