### PR TITLE
Include org in new mirror url

### DIFF
--- a/templates/user/dashboard/dashboard.tmpl
+++ b/templates/user/dashboard/dashboard.tmpl
@@ -107,7 +107,7 @@
 					<div class="ui top attached header">
 						{{.i18n.Tr "home.my_mirrors"}} <span class="ui grey label">{{.MirrorCount}}</span>
 						<div class="ui right">
-							<a class="poping up" href="{{AppSubURL}}/repo/migrate?mirror=1" data-content="{{.i18n.Tr "new_mirror"}}" data-variation="tiny inverted" data-position="left center">
+							<a class="poping up" href="{{AppSubURL}}/repo/migrate?mirror=1{{if .ContextUser.IsOrganization}}&org={{.ContextUser.ID}}{{end}}" data-content="{{.i18n.Tr "new_mirror"}}" data-variation="tiny inverted" data-position="left center">
 								<i class="plus icon"></i>
 								<span class="sr-only">{{.i18n.Tr "new_mirror"}}</span>
 							</a>


### PR DESCRIPTION
The organisation dashboard page includes a _Mirror_ tab which has a _New Mirror_ (+) button. At the moment clicking this button goes to the _New Migration_ page with _This repository will be a mirror_ checked, but doesn't select the previously viewed organisation. This change makes it work like the _New Repository_ button from the same dashboard page which does select the previously viewed organisation.

<img width="375" alt="screen shot 2018-11-29 at 9 04 48 pm" src="https://user-images.githubusercontent.com/14028/49214288-7095e980-f41a-11e8-8772-7eb6c29fe4ae.png">
