### PR TITLE
Support plaintext alt for HTML emails

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -250,6 +250,8 @@ USER =
 PASSWD =
 ; Use text/plain as format of content
 USE_PLAIN_TEXT = false
+; If sending html emails, then also attach a plaintext alternative to the MIME message, to support older mail clients and make spam filters happier.
+ADD_PLAIN_TEXT_ALT = false
 
 [cache]
 ; Either "memory", "redis", or "memcache", default is "memory"

--- a/pkg/mailer/mailer.go
+++ b/pkg/mailer/mailer.go
@@ -39,7 +39,7 @@ func NewMessageFrom(to []string, from, subject, htmlBody string) *Message {
 
 	contentType := "text/html"
 	body := htmlBody
-	if setting.MailService.UsePlainText {
+	if setting.MailService.UsePlainText || setting.MailService.AddPlainTextAlt {
 		plainBody, err := html2text.FromString(htmlBody)
 		if err != nil {
 			log.Error(2, "html2text.FromString: %v", err)
@@ -49,6 +49,9 @@ func NewMessageFrom(to []string, from, subject, htmlBody string) *Message {
 		}
 	}
 	msg.SetBody(contentType, body)
+	if setting.MailService.AddPlainTextAlt && !setting.MailService.UsePlainText {
+		msg.AddAlternative("text/html", htmlBody)
+	}
 	return &Message{
 		Message:     msg,
 		confirmChan: make(chan struct{}),

--- a/pkg/mailer/mailer.go
+++ b/pkg/mailer/mailer.go
@@ -39,6 +39,7 @@ func NewMessageFrom(to []string, from, subject, htmlBody string) *Message {
 
 	contentType := "text/html"
 	body := htmlBody
+	switchedToPlaintext := false
 	if setting.MailService.UsePlainText || setting.MailService.AddPlainTextAlt {
 		plainBody, err := html2text.FromString(htmlBody)
 		if err != nil {
@@ -46,10 +47,11 @@ func NewMessageFrom(to []string, from, subject, htmlBody string) *Message {
 		} else {
 			contentType = "text/plain"
 			body = plainBody
+			switchedToPlaintext = true
 		}
 	}
 	msg.SetBody(contentType, body)
-	if setting.MailService.AddPlainTextAlt && !setting.MailService.UsePlainText {
+	if switchedToPlaintext && setting.MailService.AddPlainTextAlt && !setting.MailService.UsePlainText {
 		msg.AddAlternative("text/html", htmlBody)
 	}
 	return &Message{

--- a/pkg/mailer/mailer.go
+++ b/pkg/mailer/mailer.go
@@ -52,6 +52,9 @@ func NewMessageFrom(to []string, from, subject, htmlBody string) *Message {
 	}
 	msg.SetBody(contentType, body)
 	if switchedToPlaintext && setting.MailService.AddPlainTextAlt && !setting.MailService.UsePlainText {
+		// The AddAlternative method name is confusing - adding html as an "alternative" will actually cause mail 
+		// clients to show it as first priority, and the text "main body" is the 2nd priority fallback.
+		// See: https://godoc.org/gopkg.in/gomail.v2#Message.AddAlternative
 		msg.AddAlternative("text/html", htmlBody)
 	}
 	return &Message{

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -861,6 +861,7 @@ type Mailer struct {
 	UseCertificate    bool
 	CertFile, KeyFile string
 	UsePlainText      bool
+	AddPlainTextAlt   bool
 }
 
 var (
@@ -876,18 +877,19 @@ func newMailService() {
 	}
 
 	MailService = &Mailer{
-		QueueLength:    sec.Key("SEND_BUFFER_LEN").MustInt(100),
-		SubjectPrefix:  sec.Key("SUBJECT_PREFIX").MustString("[" + AppName + "] "),
-		Host:           sec.Key("HOST").String(),
-		User:           sec.Key("USER").String(),
-		Passwd:         sec.Key("PASSWD").String(),
-		DisableHelo:    sec.Key("DISABLE_HELO").MustBool(),
-		HeloHostname:   sec.Key("HELO_HOSTNAME").String(),
-		SkipVerify:     sec.Key("SKIP_VERIFY").MustBool(),
-		UseCertificate: sec.Key("USE_CERTIFICATE").MustBool(),
-		CertFile:       sec.Key("CERT_FILE").String(),
-		KeyFile:        sec.Key("KEY_FILE").String(),
-		UsePlainText:   sec.Key("USE_PLAIN_TEXT").MustBool(),
+		QueueLength:     sec.Key("SEND_BUFFER_LEN").MustInt(100),
+		SubjectPrefix:   sec.Key("SUBJECT_PREFIX").MustString("[" + AppName + "] "),
+		Host:            sec.Key("HOST").String(),
+		User:            sec.Key("USER").String(),
+		Passwd:          sec.Key("PASSWD").String(),
+		DisableHelo:     sec.Key("DISABLE_HELO").MustBool(),
+		HeloHostname:    sec.Key("HELO_HOSTNAME").String(),
+		SkipVerify:      sec.Key("SKIP_VERIFY").MustBool(),
+		UseCertificate:  sec.Key("USE_CERTIFICATE").MustBool(),
+		CertFile:        sec.Key("CERT_FILE").String(),
+		KeyFile:         sec.Key("KEY_FILE").String(),
+		UsePlainText:    sec.Key("USE_PLAIN_TEXT").MustBool(),
+		AddPlainTextAlt: sec.Key("ADD_PLAIN_TEXT_ALT").MustBool(),
 	}
 	MailService.From = sec.Key("FROM").MustString(MailService.User)
 


### PR DESCRIPTION
This makes the sent messages less likely to be thrown away by spam filters, even if you DO want to be able to send HTML messages in general.

I know there's no opened issue or request for this, but I did it for myself and thought it would be nice to give you the chance to also add this very small feature that could potentially help people later on.