### PR TITLE
README: add LunaNode cloud deployment URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ There are 5 ways to install Gogs:
 - [sloppy.io](https://github.com/sloppyio/quickstarters/tree/master/gogs)
 - [YunoHost](https://github.com/YunoHost-Apps/gogs_ynh)
 - [DPlatform](https://github.com/j8r/DPlatform)
+- [LunaNode](https://github.com/LunaNode/launchgogs)
 
 ## Software and Service Support
 


### PR DESCRIPTION
I developed a simple Gogs launcher to allow our users to easily deploy Gogs on our cloud platform at https://github.com/LunaNode/launchgogs

It sets up Gogs via the Docker package and adds an HTTPS-enabled nginx reverse proxy. We're displaying the launcher internally but I noticed the Deploy to Cloud section and it'd be great if it can be added there as well!