### PR TITLE
Removes ticks around the path to the ini file. Fixes #5619

### DIFF
--- a/models/ssh_key.go
+++ b/models/ssh_key.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	_TPL_PUBLICK_KEY = `command="%s serv key-%d --config='%s'",no-port-forwarding,no-X11-forwarding,no-agent-forwarding,no-pty %s` + "\n"
+	_TPL_PUBLICK_KEY = `command="%s serv key-%d --config=%s",no-port-forwarding,no-X11-forwarding,no-agent-forwarding,no-pty %s` + "\n"
 )
 
 var sshOpLocker sync.Mutex


### PR DESCRIPTION
This pull requests fixes, the problem described in #5619.

On Windows the ticks prevent gogs to find the INI file.

I do not know how it behaves having spaces in the file name.
