### PR TITLE
Support using remote login source in git interactive window

### DIFF
--- a/models/login_source.go
+++ b/models/login_source.go
@@ -324,6 +324,26 @@ func GetLoginSourceByID(id int64) (*LoginSource, error) {
 	return source, nil
 }
 
+// GetDefaultLoginSourceID retrieve default login source ID. If not found, return -1
+func GetDefaultLoginSourceID() (int64, error) {
+	var defaultLoginSource = &LoginSource{
+		IsDefault: true,
+	}
+	has, err := x.Get(defaultLoginSource)
+	if err != nil {
+		return -1, err
+	} else if has {
+		return defaultLoginSource.ID, nil
+	} else {
+		for i := range localLoginSources.sources {
+			if localLoginSources.sources[i].LocalFile != nil && localLoginSources.sources[i].IsDefault {
+				return localLoginSources.sources[i].ID, err
+			}
+		}
+	}
+	return -1, nil
+}
+
 // ResetNonDefaultLoginSources clean other default source flag
 func ResetNonDefaultLoginSources(source *LoginSource) error {
 	// update changes to DB


### PR DESCRIPTION
This PR is about remote login support in git operation window.

Nowadays if the app enable remote login, folks have to firstly login on the web before any git client operations in local. For example: git clone.

With this PR, the process is simple now. New users only need directly type their credential when clone a repository in local for example. With that being said, there is no need to firstly login the web to map the remote user in local database.

The benefit is obviously, this saves time and keep remote login simple.
