### PR TITLE
templates/base/head: Add meta viewport for iPad, etc.

### DIFF
--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head data-suburl="{{AppSubURL}}">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 	<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
 	{{if not .PageIsAdmin}}


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Mozilla/Mobile/Viewport_meta_tag

Without this patch:

![5798D602-CDD4-4564-A2AD-C81E62CC4F1C](https://user-images.githubusercontent.com/529003/55695659-72def600-596e-11e9-9af6-7a2da26dc326.png)

With this patch:

![4205E420-2527-4ED7-8FC1-4E56D45D46A3](https://user-images.githubusercontent.com/529003/55695666-7a9e9a80-596e-11e9-9a31-1f1943d61e27.png)