### PR TITLE
Include the Sha in webhook create payloads.

### DIFF
--- a/models/action.go
+++ b/models/action.go
@@ -604,6 +604,7 @@ func CommitRepoAction(opts CommitRepoActionOptions) error {
 		if err = PrepareWebhooks(repo, HOOK_EVENT_CREATE, &api.CreatePayload{
 			Ref:           refName,
 			RefType:       "tag",
+			Sha:           opts.NewCommitID,
 			DefaultBranch: repo.DefaultBranch,
 			Repo:          apiRepo,
 			Sender:        apiPusher,

--- a/vendor/github.com/gogs/go-gogs-client/repo_hook.go
+++ b/vendor/github.com/gogs/go-gogs-client/repo_hook.go
@@ -114,6 +114,7 @@ var (
 type CreatePayload struct {
 	Ref           string      `json:"ref"`
 	RefType       string      `json:"ref_type"`
+	Sha           string      `json:"sha"`
 	DefaultBranch string      `json:"default_branch"`
 	Repo          *Repository `json:"repository"`
 	Sender        *User       `json:"sender"`


### PR DESCRIPTION
This goes along with https://github.com/gogs/go-gogs-client/issues/103 and https://github.com/gogs/go-gogs-client/pull/104

For Drone CI integrations, having the commit Sha in a create (tag) webhook event is being relied on for docker builds. See drone-plugins/drone-docker#229

This adds it to the payload.

Git tea does make this available, visible here https://github.com/go-gitea/go-sdk/blob/2858b80da5f75fa2eea3fcf3205a5e6fd16da0ec/gitea/hook.go#L196