### PR TITLE
docker: prevent Gogs from running a recursive chown on each boot

### DIFF
--- a/docker/s6/gogs/setup
+++ b/docker/s6/gogs/setup
@@ -20,7 +20,7 @@ ln -sfn /data/gogs/data ./data
 ln -sfn /data/git /home/git
 
 # Only chown for the first time, '/data/gogs/conf/app.ini' must exist inside Docker after installation
-if ! test -d /data/gogs/conf/app.ini; then
+if ! test -f /data/gogs/conf/app.ini; then
 	chown -R git:git /data /app/gogs ~git/
 fi
 chmod 0755 /data /data/gogs ~git/


### PR DESCRIPTION
The `chown` command in the setup file of Gogs is supposed to be executed just once. As soon as the app.ini file exists, this step should be skipped. However, the test was checking if a directory with the name app.ini exists instead of a file. Therefore, the `chown` command was executed on each boot.