### PR TITLE
pkg/context: Render live notice banner from file

### DIFF
--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -327,6 +327,8 @@ func Contexter() macaron.Handler {
 		c.Data["ShowFooterBranding"] = setting.ShowFooterBranding
 		c.Data["ShowFooterVersion"] = setting.ShowFooterVersion
 
+		c.Data["ServerNotice"] = readServerNotice()
+
 		ctx.Map(c)
 	}
 }

--- a/pkg/context/notice.go
+++ b/pkg/context/notice.go
@@ -20,7 +20,6 @@ import (
 // on all pages.
 func readServerNotice() map[string]interface{} {
 	fpath := path.Join(setting.CustomPath, "notice")
-
 	if !com.IsExist(fpath) {
 		return nil
 	}

--- a/pkg/context/notice.go
+++ b/pkg/context/notice.go
@@ -1,0 +1,63 @@
+package context
+
+import (
+	"os"
+	"path"
+	"strings"
+
+	"github.com/Unknwon/com"
+	"github.com/gogs/gogs/pkg/setting"
+	"github.com/gogs/gogs/pkg/tool"
+	log "gopkg.in/clog.v1"
+)
+
+// readServerNotice checks if a notice file exists and loads the message to display
+// on all pages.
+func readServerNotice() map[string]interface{} {
+	fileloc := path.Join(setting.CustomPath, "notice")
+
+	// Limit size to prevent very large messages from breaking pages
+	var maxlen int64 = 1024
+
+	if !com.IsExist(fileloc) {
+		return nil
+	}
+
+	log.Trace("Found notice file")
+	fp, err := os.Open(fileloc)
+	if err != nil {
+		log.Error(2, "Failed to open notice file %s: %v", fileloc, err)
+		return nil
+	}
+	defer fp.Close()
+
+	finfo, err := fp.Stat()
+	if err != nil {
+		log.Error(2, "Failed to stat notice file %s: %v", fileloc, err)
+		return nil
+	}
+
+	if finfo.Size() > maxlen { // Refuse to print very long messages
+		log.Error(2, "Notice file %s size too large [%d > %d]: refusing to render", fileloc, finfo.Size(), maxlen)
+		return nil
+	}
+
+	buf := make([]byte, maxlen)
+	n, err := fp.Read(buf)
+	if err != nil {
+		log.Error(2, "Failed to read notice file: %v", err)
+		return nil
+	}
+	buf = buf[:n]
+
+	if !tool.IsTextFile(buf) {
+		log.Error(2, "Notice file %s does not appear to be a text file: aborting", fileloc)
+		return nil
+	}
+
+	noticetext := strings.SplitN(string(buf), "\n", 2)
+	return map[string]interface{}{
+		"Title":   noticetext[0],
+		"Message": noticetext[1],
+	}
+}

--- a/pkg/context/notice.go
+++ b/pkg/context/notice.go
@@ -16,9 +16,6 @@ import (
 func readServerNotice() map[string]interface{} {
 	fileloc := path.Join(setting.CustomPath, "notice")
 
-	// Limit size to prevent very large messages from breaking pages
-	var maxlen int64 = 1024
-
 	if !com.IsExist(fileloc) {
 		return nil
 	}
@@ -37,12 +34,15 @@ func readServerNotice() map[string]interface{} {
 		return nil
 	}
 
-	if finfo.Size() > maxlen { // Refuse to print very long messages
-		log.Error(2, "Notice file %s size too large [%d > %d]: refusing to render", fileloc, finfo.Size(), maxlen)
+	// Limit size to prevent very large messages from breaking pages
+	var maxSize int64 = 1024
+
+	if finfo.Size() > maxSize { // Refuse to print very long messages
+		log.Error(2, "Notice file %s size too large [%d > %d]: refusing to render", fileloc, finfo.Size(), maxSize)
 		return nil
 	}
 
-	buf := make([]byte, maxlen)
+	buf := make([]byte, maxSize)
 	n, err := fp.Read(buf)
 	if err != nil {
 		log.Error(2, "Failed to read notice file: %v", err)

--- a/pkg/context/notice.go
+++ b/pkg/context/notice.go
@@ -24,7 +24,6 @@ func readServerNotice() map[string]interface{} {
 		return nil
 	}
 
-	log.Trace("Found notice file")
 	fp, err := os.Open(fileloc)
 	if err != nil {
 		log.Error(2, "Failed to open notice file %s: %v", fileloc, err)

--- a/pkg/context/notice.go
+++ b/pkg/context/notice.go
@@ -58,7 +58,5 @@ func readServerNotice() string {
 		return ""
 	}
 
-	// noticetext := strings.SplitN(string(buf), "\n", 2)
-
 	return string(markup.RawMarkdown(buf, ""))
 }

--- a/pkg/context/notice.go
+++ b/pkg/context/notice.go
@@ -10,43 +10,44 @@ import (
 	"strings"
 
 	"github.com/Unknwon/com"
+	log "gopkg.in/clog.v1"
+
 	"github.com/gogs/gogs/pkg/setting"
 	"github.com/gogs/gogs/pkg/tool"
-	log "gopkg.in/clog.v1"
 )
 
 // readServerNotice checks if a notice file exists and loads the message to display
 // on all pages.
 func readServerNotice() map[string]interface{} {
-	fileloc := path.Join(setting.CustomPath, "notice")
+	fpath := path.Join(setting.CustomPath, "notice")
 
-	if !com.IsExist(fileloc) {
+	if !com.IsExist(fpath) {
 		return nil
 	}
 
-	fp, err := os.Open(fileloc)
+	f, err := os.Open(fpath)
 	if err != nil {
-		log.Error(2, "Failed to open notice file %s: %v", fileloc, err)
+		log.Error(2, "Failed to open notice file %s: %v", fpath, err)
 		return nil
 	}
-	defer fp.Close()
+	defer f.Close()
 
-	finfo, err := fp.Stat()
+	fi, err := f.Stat()
 	if err != nil {
-		log.Error(2, "Failed to stat notice file %s: %v", fileloc, err)
+		log.Error(2, "Failed to stat notice file %s: %v", fpath, err)
 		return nil
 	}
 
 	// Limit size to prevent very large messages from breaking pages
 	var maxSize int64 = 1024
 
-	if finfo.Size() > maxSize { // Refuse to print very long messages
-		log.Error(2, "Notice file %s size too large [%d > %d]: refusing to render", fileloc, finfo.Size(), maxSize)
+	if fi.Size() > maxSize { // Refuse to print very long messages
+		log.Error(2, "Notice file %s size too large [%d > %d]: refusing to render", fpath, fi.Size(), maxSize)
 		return nil
 	}
 
 	buf := make([]byte, maxSize)
-	n, err := fp.Read(buf)
+	n, err := f.Read(buf)
 	if err != nil {
 		log.Error(2, "Failed to read notice file: %v", err)
 		return nil
@@ -54,7 +55,7 @@ func readServerNotice() map[string]interface{} {
 	buf = buf[:n]
 
 	if !tool.IsTextFile(buf) {
-		log.Error(2, "Notice file %s does not appear to be a text file: aborting", fileloc)
+		log.Error(2, "Notice file %s does not appear to be a text file: aborting", fpath)
 		return nil
 	}
 

--- a/pkg/context/notice.go
+++ b/pkg/context/notice.go
@@ -1,3 +1,7 @@
+// Copyright 2019 The Gogs Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
 package context
 
 import (

--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -196,10 +196,7 @@
 		{{if .ServerNotice}}
 			<div class="ui container grid warning message">
 				<div class="content">
-					<div class="header">
-						{{.ServerNotice.Title}}
-					</div>
-					<p>{{.ServerNotice.Message | Str2HTML}}</p>
+					{{.ServerNotice | Str2HTML}}
 				</div>
 			</div>
 		{{end}}

--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -192,6 +192,17 @@
 				</div><!-- end container -->
 			</div><!-- end bar -->
 		{{end}}
+
+		{{if .ServerNotice}}
+			<div class="ui container grid warning message">
+				<div class="content">
+					<div class="header">
+						{{.ServerNotice.Title}}
+					</div>
+					<p>{{.ServerNotice.Message | Str2HTML}}</p>
+				</div>
+			</div>
+		{{end}}
 {{/*
 	</div>
 </body>


### PR DESCRIPTION
As discussed already on the forum (https://discuss.gogs.io/t/contributing-new-features-from-fork/2645), this PR adds a live notice banner to all GOGS pages when a notice file is found in the custom configuration directory.

In summary:
- Contexter checks if there is a file called `notice` under the `GOGS_CUSTOM` directory and loads it.
- The first line is treated as a header/title and everything else as the message body.
- Message body is rendered as HTML (tags allowed).
- File size is limited to 1024 bytes.
- File mime type must be text.
- Notice is rendered in `head.tmpl` for all pages.


I'm not sure whether it would be best for certain aspects of this to be configurable.  Perhaps the location and name of the file could be an optional setting (`$GOGS_CUSTOM/notice` by default), as well as the max file size.

Let me know

The screenshots below show how the following text file is rendered:
```
Upcoming scheduled downtime

<p>This <b>Friday (19 July, 2019)</b> there will be a scheduled service
interruption for maintenance.  The service will be unavailable starting
<b>17:00 UTC</b> and we expect the downtime to last approximately <b>2
hours</b>.</p>

<p>Please refer to the <a href=announcement.html>announcements page</a> for
more details. </p>

```

![front-page](https://user-images.githubusercontent.com/2369197/61314084-148ea280-a7fc-11e9-8c23-6206009468df.png)
![login-page](https://user-images.githubusercontent.com/2369197/61314085-148ea280-a7fc-11e9-92f8-666dab0d0682.png)
![repository-view](https://user-images.githubusercontent.com/2369197/61314087-148ea280-a7fc-11e9-8e7f-c542a17d2a3f.png)
