### PR TITLE
Fix and update packager.io build files

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -1,15 +1,13 @@
 targets:
-  debian-7: &debian
+  debian-8: &debian
     build_dependencies:
       - libpam0g-dev
     dependencies:
       - libpam0g
       - git
-  debian-8:
-    <<: *debian
   debian-9:
     <<: *debian
-  ubuntu-12.04:
+  debian-10:
     <<: *debian
   ubuntu-14.04:
     <<: *debian
@@ -18,6 +16,8 @@ targets:
     build_dependencies:
       - bzr
       - mercurial
+  ubuntu-18.04:
+    <<: *debian
   centos-6: &el
     build_dependencies:
       - pam-devel
@@ -33,4 +33,7 @@ before:
 after:
   - mv bin/gogs gogs
 after_install: ./packager/hooks/postinst
-buildpack: https://github.com/heroku/heroku-buildpack-go.git#v62
+# Can be updated after CentOS 6 support is dropped, otherwise fails with
+# `fatal: bad config file line 2 in /home/pkgr/.gitconfig` because of
+# https://github.com/heroku/heroku-buildpack-go/blob/f96ebebfa7605fd3916521e42ab050c81c9b947a/lib/common.sh#L238
+buildpack: https://github.com/heroku/heroku-buildpack-go.git#v76

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1,5 +1,9 @@
 {
 	"comment": "",
+	"heroku": {
+		"install": ["."],
+		"sync": false
+	},
 	"ignore": "test",
 	"package": [
 		{


### PR DESCRIPTION
This PR fixes packager.io builds based on this repo, removes Debian 7 and Ubuntu 12.04 which are out of support, and adds Debian 10 and Ubuntu 18.04.
Builds are available at https://packager.io/gh/half-duplex/gogs/refs/develop - I don't have machines other than Debian 10 available to test, but I haven't had any problems there.

The existing deb repo, built from https://github.com/pkgr/gogs/tree/pkgr, is very out-of-date, see https://github.com/gogs/docs/pull/232. Is there any interest in just enabling packager.io for this repo directly? It's a couple clicks by a maintainer at https://packager.io/apps/new, and maybe changing branches to `master,develop` to offer pre-release builds.

Possible concerns:
- Are there any other officially supported heroku-related things that the vendor.json change may affect?
- packager.io seems to build the latest commit but label it as the latest tag - is this behavior appropriate on master, or does the specific tag commit need to be put in a dedicated repo/branch for it to grab?
- I'm not sure what the previously-added bzr and mercurial build dependencies are for, if cruft removal is desired I can spin up some VMs to test