### PR TITLE
docker: change how to check whether initial or not

### DIFF
--- a/docker/s6/gogs/setup
+++ b/docker/s6/gogs/setup
@@ -19,8 +19,8 @@ ln -sfn /data/gogs/data ./data
 # Backward Compatibility with Gogs Container v0.6.15
 ln -sfn /data/git /home/git
 
-# Only chown for the first time, '/data/gogs/conf/app.ini' must exist inside Docker after installation
-if ! test -f /data/gogs/conf/app.ini; then
+# Only chown for the first time, owner of '/data' is 'git' inside Docker after installation
+if [ $(stat -c '%U' /data) != 'git' ]; then
 	chown -R git:git /data /app/gogs ~git/
 fi
 chmod 0755 /data /data/gogs ~git/


### PR DESCRIPTION
When gogs on docker starts for the first time, change owner of /data, /app/gogs and ~git/ to git.
The current checking way is whether /data/gogs/conf/app.ini exists or not. (refer to https://github.com/gogs/gogs/pull/5724)

But if I already prepared app.ini file before and override /data/gogs/conf/app.ini, changing owner logic is skipped.
For example, I use docker-compose.yml as the following.

```
version: '3'
services:
  gogs:
    depends_on:
      - mysql
    image: gogs/gogs
    hostname: gogs
    networks:
      - default
    ports:
      - "3000:3000"
      - "10022:22"
    volumes:
      - git-data:/data/
      - ./gogs/conf/app.ini:/data/gogs/conf/app.ini
```

So, I changed initial checking logic that owner of /data is 'git' as the following.

```
if [ $(stat -c '%U' /data) != 'git' ]; then
```

When owner of /data is not 'git', change owner of /data, /app/gogs and ~git/ to git.