### PR TITLE
Add rsync to Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN chmod +x /usr/sbin/gosu \
     s6 \
     shadow \
     socat \
+    rsync \
     tzdata
 
 ENV GOGS_CUSTOM /data/gogs

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -14,6 +14,7 @@ RUN chmod +x /usr/sbin/gosu \
     s6 \
     shadow \
     socat \
+    rsync \
     tzdata
 
 ENV GOGS_CUSTOM /data/gogs

--- a/Dockerfile.rpi
+++ b/Dockerfile.rpi
@@ -14,6 +14,7 @@ RUN chmod +x /usr/sbin/gosu \
     s6 \
     shadow \
     socat \
+    rsync \
     tzdata
 
 ENV GOGS_CUSTOM /data/gogs

--- a/Dockerfile.rpihub
+++ b/Dockerfile.rpihub
@@ -30,6 +30,7 @@ RUN chmod +x /usr/sbin/gosu \
     s6 \
     shadow \
     socat \
+    rsync \
     tzdata
 
 # Configure LibC Name Service


### PR DESCRIPTION
Add rsync to docker.
Rsync is nearly a necessity to optimize backup inside Openshift container.

The pull request will be closed without any reasons if it does not satisfy any of following requirements:

1. Please make sure you are targeting the `develop` branch.
2. Please read contributing guidelines:
https://github.com/gogits/gogs/wiki/Contributing-Code
3. Please describe what your pull request does and which issue you're targeting
4. ... if it is not related to any particular issues, explain why we should not reject your pull request.

**You MUST delete above content including this line before posting; too lazy to take this action considered invalid pull request.**
