### PR TITLE
Add rsync to dockerDevelop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ RUN chmod +x /usr/sbin/gosu \
     s6 \
     shadow \
     socat \
-    tzdata
+    tzdata \
+    rsync
 
 ENV GOGS_CUSTOM /data/gogs
 

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -14,7 +14,8 @@ RUN chmod +x /usr/sbin/gosu \
     s6 \
     shadow \
     socat \
-    tzdata
+    tzdata \
+    rsync
 
 ENV GOGS_CUSTOM /data/gogs
 

--- a/Dockerfile.rpi
+++ b/Dockerfile.rpi
@@ -14,7 +14,8 @@ RUN chmod +x /usr/sbin/gosu \
     s6 \
     shadow \
     socat \
-    tzdata
+    tzdata \
+    rsync
 
 ENV GOGS_CUSTOM /data/gogs
 

--- a/Dockerfile.rpihub
+++ b/Dockerfile.rpihub
@@ -30,7 +30,8 @@ RUN chmod +x /usr/sbin/gosu \
     s6 \
     shadow \
     socat \
-    tzdata
+    tzdata \
+    rsync
 
 # Configure LibC Name Service
 COPY docker/nsswitch.conf /etc/nsswitch.conf


### PR DESCRIPTION
Add rsync to docker.
Rsync is nearly a necessity to optimize backup inside Openshift container.
Using TAR (default without Rsync), the process of external backup constantly stops at the middle.
