### PR TITLE
api/v1: fix status response in checkUserFollowing

### DIFF
--- a/routes/api/v1/user/follower.go
+++ b/routes/api/v1/user/follower.go
@@ -63,7 +63,7 @@ func ListFollowing(c *context.APIContext) {
 
 func checkUserFollowing(c *context.APIContext, u *models.User, followID int64) {
 	if u.IsFollowing(followID) {
-		c.NotFound()
+		c.NoContent()
 	} else {
 		c.NotFound()
 	}


### PR DESCRIPTION
It appears that the current behavior is to always return not found on a call to `checkUserFollowing`. This was introduced in f1e0ebfe937213be2af4a3180fae9f43949de00e, when `c.Status(204)` was incorrectly replaced with `c.NotFound()`. I have replaced this with `c.NoContent()`.

Found with [LGTM.com](https://lgtm.com/projects/g/gogs/gogs/alerts/?mode=list&lang=go), on which I am a developer.