### PR TITLE
tls: update default CurvePreferences and CipherSuites

### DIFF
--- a/internal/cmd/web.go
+++ b/internal/cmd/web.go
@@ -719,13 +719,15 @@ func runWeb(c *cli.Context) error {
 		}
 		server := &http.Server{Addr: listenAddr, TLSConfig: &tls.Config{
 			MinVersion:               tlsMinVersion,
-			CurvePreferences:         []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},
+			CurvePreferences:         []tls.CurveID{tls.X25519, tls.CurveP256, tls.CurveP384, tls.CurveP521},
 			PreferServerCipherSuites: true,
 			CipherSuites: []uint16{
+				tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, // Required for HTTP/2 support.
-				tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-				tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+				tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+				tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
 			},
 		}, Handler: m}
 		err = server.ListenAndServeTLS(setting.CertFile, setting.KeyFile)


### PR DESCRIPTION
* Enable X25519 curve and reorder curve list to improve key exchange performance
* Enable ECDSA ciphers for EC certs
* Enable CHACHA20_POLY1305 ciphers
* Disable RSA key exchange algorithm which don't provide PFS
* Disable non-AEAD ciphers