### PR TITLE
docker: check "/app/gogs" separately on startup

### DIFF
--- a/docker/s6/gogs/setup
+++ b/docker/s6/gogs/setup
@@ -21,6 +21,13 @@ ln -sfn /data/git /home/git
 
 # Only chown for the first time, owner of '/data' is 'git' inside Docker after installation
 if [ $(stat -c '%U' /data) != 'git' ]; then
-	chown -R git:git /data /app/gogs ~git/
+    chown -R git:git /data ~git/
 fi
+
+# Check ownership of '/app/gogs' in case the image changed and '/data' is persistent
+if [ $(stat -c '%U' /app/gogs) != 'git' ]; then
+    chown -R git:git /app/gogs
+fi
+
+
 chmod 0755 /data /data/gogs ~git/


### PR DESCRIPTION
I was going to open an issue for this, but thought it would be simpler to fix it directly.

When running gogs after the first time, if the image has changed (update rebuild), the `/app/gogs` directory will have changed owner back to root:root, but `/data` will likely not be since the data directories are likely to be persistent.

Checking `/app/gogs` separately fixes this.

This is only an issue if the contents of `/app/gogs` aren't world readable which, by default, they are.  But if the image is built on a machine where the permissions aren't as expected (e.g., different umask), the startup will fail while trying to read `templates/.VERSION`.

Still, in the general case, the permissions of `/app/gogs` are changed to `git:git` on first run and rebuilding the container from a new image reverts the ownership to `root:root`.  The issue doesn't come up since the contents of the directory are only read by the service (never written), but it might affect future changes that assume the directory is writable.

The issue can be reproduced as follows:
- Change the permissions in the templates directory of the source repository to not be world readable: `chmod o-rwx -R templates`.
- Build the image: `docker build . -t local/gogs`.
- Build and run the container: `docker run --rm -d -v gogsdata:/data --name=gogs local/gogs`.
- Stop the container: `docker stop gogs`.
- The `--rm` flag will removed the `gogs` container, but since we attached `/data` to a named volume (`gogsdata`), the `/data` directory persists.
- Rebuild and run a new container with the same data volume: `docker run --rm -d -v gogsdata:/data --name=gogs local/gogs`.

The service will fail to start since the new container startup didn't fix the ownership of `/app/gogs` and the permissions don't allow access to all users.

