### PR TITLE
Show file name in window/tab title

### DIFF
--- a/internal/route/repo/view.go
+++ b/internal/route/repo/view.go
@@ -132,6 +132,7 @@ func renderFile(c *context.Context, entry *git.TreeEntry, treeLink, rawLink stri
 		return
 	}
 
+	c.Data["Title"] = blob.Name() + " - " + c.Data["Title"]
 	c.Data["FileSize"] = blob.Size()
 	c.Data["FileName"] = blob.Name()
 	c.Data["HighlightClass"] = highlight.FileNameToHighlightClass(blob.Name())


### PR DESCRIPTION
I've just encountered the problem that when browsing multiple files in different tabs, the tab title does not show the file name, which makes browsing a repository a happy game of memory for the entire family. This PR takes the fun away and should just display the file name in the title.

The pull request will be closed without any reasons if it does not satisfy any of following requirements:
