### PR TITLE
user/setting: check for IsErrEmailAlreadyUsed when updating user

### DIFF
--- a/internal/route/user/setting.go
+++ b/internal/route/user/setting.go
@@ -75,8 +75,6 @@ func SettingsPost(c *context.Context, f form.UpdateProfile) {
 				switch {
 				case db.IsErrUserAlreadyExist(err):
 					msg = c.Tr("form.username_been_taken")
-				case db.IsErrEmailAlreadyUsed(err):
-					msg = c.Tr("form.email_been_used")
 				case db.IsErrNameReserved(err):
 					msg = c.Tr("form.name_reserved")
 				case db.IsErrNamePatternNotAllowed(err):
@@ -103,6 +101,11 @@ func SettingsPost(c *context.Context, f form.UpdateProfile) {
 	c.User.Website = f.Website
 	c.User.Location = f.Location
 	if err := db.UpdateUser(c.User); err != nil {
+		if db.IsErrEmailAlreadyUsed(err) {
+			msg := c.Tr("form.email_been_used")
+			c.RenderWithErr(msg, SETTINGS_PROFILE, &f)
+			return
+		}
 		c.ServerError("UpdateUser", err)
 		return
 	}


### PR DESCRIPTION
Check for email collisions when updating the entire user information, not when the username is being changed.

Changing a user's email address through `/user/settings` to an email address that's already taken shows an internal server error instead of the appropriate error message.

The `ErrEmailAlreadyUsed` error type was incorrectly checked for during the username update in the same function, when it is impossible for that error to occur.  This PR performs the check after the `db.UpdateUser()` call, which can return the "email already used" error, and renders the error message on the form accordingly, instead of failing with an internal server error.

Fixes #5899
