### PR TITLE
repo: able fill pull request title by template from md file

### DIFF
--- a/internal/route/repo/pull.go
+++ b/internal/route/repo/pull.go
@@ -8,7 +8,6 @@ import (
 	"container/list"
 	"path"
 	"strings"
-	"fmt"
 	"github.com/unknwon/com"
 	log "gopkg.in/clog.v1"
 

--- a/internal/route/repo/pull.go
+++ b/internal/route/repo/pull.go
@@ -8,7 +8,7 @@ import (
 	"container/list"
 	"path"
 	"strings"
-
+	"fmt"
 	"github.com/unknwon/com"
 	log "gopkg.in/clog.v1"
 
@@ -29,6 +29,7 @@ const (
 	PULL_FILES   = "repo/pulls/files"
 
 	PULL_REQUEST_TEMPLATE_KEY = "PullRequestTemplate"
+	PULL_REQUEST_TITLE_TEMPLATE_KEY = "PullRequestTitleTemplate"
 )
 
 var (
@@ -36,6 +37,14 @@ var (
 		"PULL_REQUEST.md",
 		".gogs/PULL_REQUEST.md",
 		".github/PULL_REQUEST.md",
+	}
+)
+
+var (
+	PullRequestTitleTemplateCandidates = []string{
+		"PULL_REQUEST_TITLE.md",
+		".gogs/PULL_REQUEST_TITLE.md",
+		".github/PULL_REQUEST_TITLE.md",
 	}
 )
 
@@ -637,6 +646,16 @@ func CompareAndPullRequest(c *context.Context) {
 	}
 
 	c.Data["IsSplitStyle"] = c.Query("style") == "split"
+	setTemplateIfExists(c, PULL_REQUEST_TITLE_TEMPLATE_KEY, PullRequestTitleTemplateCandidates)
+
+	if c.Data[PULL_REQUEST_TITLE_TEMPLATE_KEY] != nil {
+		customTitle := c.Data[PULL_REQUEST_TITLE_TEMPLATE_KEY].(string)
+		r := strings.NewReplacer("{{headBranch}}", headBranch,"{{baseBranch}}", baseBranch)
+		c.Data["title"] = r.Replace(customTitle)
+	} else {
+		fmt.Sprintf("Merge %s into %s", headBranch, baseBranch)
+	}
+
 	c.Success(COMPARE_PULL)
 }
 

--- a/internal/route/repo/pull.go
+++ b/internal/route/repo/pull.go
@@ -8,7 +8,7 @@ import (
 	"container/list"
 	"path"
 	"strings"
-	
+
 	"github.com/unknwon/com"
 	log "gopkg.in/clog.v1"
 

--- a/internal/route/repo/pull.go
+++ b/internal/route/repo/pull.go
@@ -8,6 +8,7 @@ import (
 	"container/list"
 	"path"
 	"strings"
+	
 	"github.com/unknwon/com"
 	log "gopkg.in/clog.v1"
 

--- a/internal/route/repo/pull.go
+++ b/internal/route/repo/pull.go
@@ -37,9 +37,7 @@ var (
 		".gogs/PULL_REQUEST.md",
 		".github/PULL_REQUEST.md",
 	}
-)
 
-var (
 	PullRequestTitleTemplateCandidates = []string{
 		"PULL_REQUEST_TITLE.md",
 		".gogs/PULL_REQUEST_TITLE.md",

--- a/internal/route/repo/pull.go
+++ b/internal/route/repo/pull.go
@@ -652,8 +652,6 @@ func CompareAndPullRequest(c *context.Context) {
 		customTitle := c.Data[PULL_REQUEST_TITLE_TEMPLATE_KEY].(string)
 		r := strings.NewReplacer("{{headBranch}}", headBranch,"{{baseBranch}}", baseBranch)
 		c.Data["title"] = r.Replace(customTitle)
-	} else {
-		fmt.Sprintf("Merge %s into %s", headBranch, baseBranch)
 	}
 
 	c.Success(COMPARE_PULL)


### PR DESCRIPTION
Hello.
I migrate from bitbacket to gogs, and in PR i want to be able auto fill PR title field.
So i write some simple code for this feature and my explanation how it works.

It works like `.gogs/PULL_REQUEST.md`
But fills `pull request title field`.
And have some feature, like `branch placeholders`

For example init repository:
1. Init repo with `PULL_REQUEST_TITLE.md`
```bash
$ ... git init etc...
$ echo 'Merge {{headBranch}} into {{baseBranch}}' > .gogs/PULL_REQUEST_TITLE.md
$ git add . && git commit -m "custom pr title for gogs" && git push origin master
```
2. Then create new branch for test compare web form
```bash
$ git checkout -b test-1
$ echo 'changes in readme' > README.md
$ git add && git commit -m "changes in readme" && git push origin test-1
```
3. Go to link `http://localhost:3000/ivanb/test1/compare/master...ivanb:test-1`
And we will get some html code
```html
...
<div class="ui segment content">
<div class="field">
   <input name="title" placeholder="Заголовок" value="Merge test-1 into master" tabindex="3" autofocus="" required="">
</div>
...
```

Thanks for attention
