### PR TITLE
public: fix jquery3.x syntax error

### DIFF
--- a/public/js/gogs.js
+++ b/public/js/gogs.js
@@ -425,7 +425,7 @@ function initRepository() {
             if (confirm($this.data('locale'))) {
                 $.post($this.data('url'), {
                     "_csrf": csrf
-                }).success(function () {
+                }).done(function () {
                     $('#' + $this.data('comment-id')).remove();
                 });
             }
@@ -1310,7 +1310,7 @@ $(document).ready(function () {
                 $.post($this.data('url'), {
                     "_csrf": csrf,
                     "id": $this.data("id")
-                }).success(function (data) {
+                }).done(function (data) {
                     window.location.href = data.redirect;
                 });
             }


### PR DESCRIPTION
`$.post().success -> $.post().done`

The jqXHR.success(), jqXHR.error(), and jqXHR.complete() callback methods are removed as of jQuery 3.0. Need to use jqXHR.done(), jqXHR.fail(), and jqXHR.always() instead.