### PR TITLE
git: explicitly disable debug in prod mode

### DIFF
--- a/internal/route/install.go
+++ b/internal/route/install.go
@@ -41,6 +41,7 @@ func checkRunMode() {
 	if conf.IsProdMode() {
 		macaron.Env = macaron.PROD
 		macaron.ColorLog = false
+		git.Debug = false
 	} else {
 		git.Debug = true
 	}


### PR DESCRIPTION
After first time running the application and went through the installation, the flag was always true until restarted.
