### PR TITLE
cmd/serv: improve hookMode handling

### DIFF
--- a/internal/cmd/serv.go
+++ b/internal/cmd/serv.go
@@ -35,14 +35,17 @@ var Serv = cli.Command{
 	},
 }
 
-func fail(userMessage, logMessage string, args ...interface{}) {
+// fail prints user message to the Git client (i.e. os.Stderr) and
+// logs error message on the server side. When not in "prod" mode,
+// error message is also printed to the client for easier debugging.
+func fail(userMessage, errMessage string, args ...interface{}) {
 	fmt.Fprintln(os.Stderr, "Gogs:", userMessage)
 
-	if len(logMessage) > 0 {
+	if len(errMessage) > 0 {
 		if !conf.IsProdMode() {
-			fmt.Fprintf(os.Stderr, logMessage+"\n", args...)
+			fmt.Fprintf(os.Stderr, errMessage+"\n", args...)
 		}
-		log.Fatal(logMessage, args...)
+		log.Error(errMessage, args...)
 	}
 
 	os.Exit(1)


### PR DESCRIPTION
- Allow remove primary logger at better location
- Use more appropriate log.Error to replace log.Fatal
