### PR TITLE
templates: fix copypaste of email verification in reset_passwd

### DIFF
--- a/templates/mail/auth/reset_passwd.tmpl
+++ b/templates/mail/auth/reset_passwd.tmpl
@@ -7,7 +7,7 @@
 
 <body>
 	<p>Hi <b>{{.Username}}</b>,</p>
-	<p>Please click the following link to verify your email address within <b>{{.ResetPwdCodeLives}} hours</b>:</p>
+	<p>Please click the following link to reset your password within <b>{{.ResetPwdCodeLives}} hours</b>:</p>
 	<p><a href="{{AppURL}}user/reset_password?code={{.Code}}">{{AppURL}}user/reset_password?code={{.Code}}</a></p>
 	<p>Not working? Try copying and pasting it to your browser.</p>
 	<p>© {{Year}} <a target="_blank" rel="noopener noreferrer" href="{{AppURL}}">{{AppName}}</a></p>


### PR DESCRIPTION
Reset password email template contained a copypaste caused typo: it was telling about email address verification instead of password reset. This PR fixes that typo.