### PR TITLE
api: group "/contents" with "" and "/*" #5985

### DIFF
--- a/internal/route/api/v1/api.go
+++ b/internal/route/api/v1/api.go
@@ -271,7 +271,10 @@ func RegisterRoutes(m *macaron.Macaron) {
 				}, reqRepoAdmin())
 
 				m.Get("/raw/*", context.RepoRef(), repo.GetRawFile)
-				m.Get("/contents/*", repo.GetContents)
+				m.Group("/contents", func() {
+					m.Get("", repo.GetContents)
+					m.Get("/*", repo.GetContents)
+				})
 				m.Get("/archive/*", repo.GetArchive)
 				m.Group("/git/trees", func() {
 					m.Get("/:sha", repo.GetRepoGitTree)


### PR DESCRIPTION
This PR groups the contents api endpoint with both `""` and `/*` as
valid URL patterns.

When `""` is the URL pattern, this means that no repo path has'nt been
provided, in which case the path would be the default repo path.

When  `"/*"` is the URL pattern, then this would return the contents at
the specified path if it's valid.

Github API v3 is conformant to this behavior and have verified it
locally.
