### PR TITLE
http: always set header `X-Content-Type-Options` to `nosniff`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ All notable changes to Gogs are documented in this file.
 - [Security] Potential XSS attack via `.ipynb`. [#5170](https://github.com/gogs/gogs/issues/5170)
 - [Security] Potential SSRF attack via webhooks. [#5366](https://github.com/gogs/gogs/issues/5366)
 - [Security] Potential CSRF attack in admin panel. [#5367](https://github.com/gogs/gogs/issues/5367)
+- [Security] Potential stored XSS attack in some browsers. [#5397](https://github.com/gogs/gogs/issues/5397)
 - [Security] Potential RCE on mirror repositories. [#5767](https://github.com/gogs/gogs/issues/5767)
 - [Security] Potential XSS attack with raw markdown API. [#5907](https://github.com/gogs/gogs/pull/5907)
 - Open/close milestone redirects to a 404 page. [#5677](https://github.com/gogs/gogs/issues/5677)

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -335,6 +335,10 @@ func Contexter() macaron.Handler {
 
 		c.renderNoticeBanner()
 
+		// 🚨 SECURITY: Prevent MIME type sniffing in some browsers,
+		// see https://github.com/gogs/gogs/issues/5397 for details.
+		c.Header().Set("X-Content-Type-Options", "nosniff")
+
 		ctx.Map(c)
 	}
 }


### PR DESCRIPTION
Fixes #5397