### PR TITLE
api: support get releases endpoint

### DIFF
--- a/internal/db/release.go
+++ b/internal/db/release.go
@@ -267,6 +267,12 @@ func GetPublishedReleasesByRepoID(repoID int64, matches ...string) ([]*Release, 
 	return releases, sess.Find(&releases, new(Release))
 }
 
+// GetReleasesByRepoID returns a list of all releases (including drafts) of given repository.
+func GetReleasesByRepoID(repoID int64) ([]*Release, error) {
+	releases := make([]*Release, 0)
+	return releases, x.Where("repo_id = ?", repoID).Find(&releases)
+}
+
 // GetDraftReleasesByRepoID returns all draft releases of repository.
 func GetDraftReleasesByRepoID(repoID int64) ([]*Release, error) {
 	releases := make([]*Release, 0)

--- a/internal/route/api/v1/api.go
+++ b/internal/route/api/v1/api.go
@@ -245,6 +245,7 @@ func RegisterRoutes(m *macaron.Macaron) {
 			m.Get("/search", repo.Search)
 
 			m.Get("/:username/:reponame", repoAssignment(), repo.Get)
+			m.Get("/:username/:reponame/releases", repoAssignment(), repo.Releases)
 		})
 
 		m.Group("/repos", func() {


### PR DESCRIPTION
Fixes #6012

Added the releases endpoint at `/repos/:user/:repo/releases`

https://developer.github.com/v3/repos/releases/#list-releases-for-a-repository