### PR TITLE
db: include the Team ID in the error message

### DIFF
--- a/internal/db/error.go
+++ b/internal/db/error.go
@@ -400,6 +400,7 @@ func (err ErrLoginSourceInUse) Error() string {
 //              \/     \/      \/
 
 type ErrTeamAlreadyExist struct {
+	ID    int64
 	OrgID int64
 	Name  string
 }
@@ -410,7 +411,7 @@ func IsErrTeamAlreadyExist(err error) bool {
 }
 
 func (err ErrTeamAlreadyExist) Error() string {
-	return fmt.Sprintf("team already exists [org_id: %d, name: %s]", err.OrgID, err.Name)
+	return fmt.Sprintf("team already exists [id: %d, org_id: %d, name: %s]", err.ID, err.OrgID, err.Name)
 }
 
 //  ____ ___        .__                    .___

--- a/internal/db/org_team.go
+++ b/internal/db/org_team.go
@@ -241,11 +241,12 @@ func NewTeam(t *Team) error {
 	}
 
 	t.LowerName = strings.ToLower(t.Name)
-	has, err = x.Where("org_id=?", t.OrgID).And("lower_name=?", t.LowerName).Get(new(Team))
+	existingTeam := Team{}
+	has, err = x.Where("org_id=?", t.OrgID).And("lower_name=?", t.LowerName).Get(&existingTeam)
 	if err != nil {
 		return err
 	} else if has {
-		return ErrTeamAlreadyExist{t.OrgID, t.LowerName}
+		return ErrTeamAlreadyExist{existingTeam.ID, t.OrgID, t.LowerName}
 	}
 
 	sess := x.NewSession()
@@ -346,11 +347,12 @@ func UpdateTeam(t *Team, authChanged bool) (err error) {
 	}
 
 	t.LowerName = strings.ToLower(t.Name)
-	has, err := x.Where("org_id=?", t.OrgID).And("lower_name=?", t.LowerName).And("id!=?", t.ID).Get(new(Team))
+	existingTeam := new(Team)
+	has, err := x.Where("org_id=?", t.OrgID).And("lower_name=?", t.LowerName).And("id!=?", t.ID).Get(&existingTeam)
 	if err != nil {
 		return err
 	} else if has {
-		return ErrTeamAlreadyExist{t.OrgID, t.LowerName}
+		return ErrTeamAlreadyExist{existingTeam.ID, t.OrgID, t.LowerName}
 	}
 
 	if _, err = sess.ID(t.ID).AllCols().Update(t); err != nil {


### PR DESCRIPTION
This means that when using the API to create a new team, the output contains the existing team ID, not just the name.
While there may be the thought that this reveals sensitive information, it is never the case that a user can create or update a team without permission to view the teams in the first place.

One of the reasons for this change is without an existing API to get a list of Teams and their IDs using the API, it would be impossible for an administrator to add themselves to an Owners team (or introspect the Teams at all), as they never know the Teams ID. This is one way to get that functionality without another API call, though that would also be useful.