### PR TITLE
docker: fix the bug of using root to create /data/ directory

### DIFF
--- a/docker/s6/gogs/run
+++ b/docker/s6/gogs/run
@@ -4,5 +4,4 @@ if test -f ./setup; then
     source ./setup
 fi
 
-export USER=git
 exec gosu $USER /app/gogs/gogs web

--- a/docker/s6/gogs/setup
+++ b/docker/s6/gogs/setup
@@ -1,12 +1,12 @@
 #!/bin/sh
 
 if ! test -d ~git/.ssh; then
-    mkdir -p ~git/.ssh
+    gosu $USER mkdir -p ~git/.ssh
     chmod 700 ~git/.ssh
 fi
 
 if ! test -f ~git/.ssh/environment; then
-    echo "GOGS_CUSTOM=${GOGS_CUSTOM}" > ~git/.ssh/environment
+    gosu $USER echo "GOGS_CUSTOM=${GOGS_CUSTOM}" > ~git/.ssh/environment
     chmod 600 ~git/.ssh/environment
 fi
 
@@ -18,16 +18,5 @@ ln -sfn /data/gogs/data ./data
 
 # Backward Compatibility with Gogs Container v0.6.15
 ln -sfn /data/git /home/git
-
-# Only chown for the first time, owner of '/data' is 'git' inside Docker after installation
-if [ $(stat -c '%U' /data) != 'git' ]; then
-    chown -R git:git /data ~git/
-fi
-
-# Check ownership of '/app/gogs' in case the image changed and '/data' is persistent
-if [ $(stat -c '%U' /app/gogs) != 'git' ]; then
-    chown -R git:git /app/gogs
-fi
-
 
 chmod 0755 /data /data/gogs ~git/

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -33,16 +33,17 @@ create_volume_subfolder() {
     # Create VOLUME subfolder
     for f in /data/gogs/data /data/gogs/conf /data/gogs/log /data/git /data/ssh; do
         if ! test -d $f; then
-            mkdir -p $f
+            gosu $USER mkdir -p $f
         fi
     done
 }
 
 setids() {
+    export USER=git
     PUID=${PUID:-1000}
     PGID=${PGID:-1000}
-    groupmod -o -g "$PGID" git
-    usermod -o -u "$PUID" git
+    groupmod -o -g "$PGID" $USER
+    usermod -o -u "$PUID" $USER
 }
 
 setids


### PR DESCRIPTION
Resubmit: 

Fixes [#6067 ](https://github.com/gogs/gogs/issues/6067) : Create /data/* directory with git user.

The old commit [#6068 ] has a BUG(comments in https://github.com/gogs/gogs/commit/f3b05961aae82fa3e19c47f03c78974cf793fda3) : [`exec gosu $USER mkdir -p $f`](https://github.com/gogs/gogs/pull/6068/commits/e38c130c2d4f63014522276768cd5fe8d95ea0f3#diff-bdc913edcb71ddadcdcb8860a18f4527R36) will interrupt the execution of subsequent commands.

> The  exec() family of functions replaces the current process image with a new process image. 

### Verify result
 **Install** and **Add ssh key** passed the test in docker run & docker-compose.


