### PR TITLE
docker: fix mkdir subdir in /data failed when no mount volume

### DIFF
--- a/docker/start.sh
+++ b/docker/start.sh
@@ -30,6 +30,9 @@ cleanup() {
 }
 
 create_volume_subfolder() {
+    # Modify the owner of /data dir, make $USER(git) user have permission to create sub-dir in /data.
+    chown -R $USER:$USER /data
+
     # Create VOLUME subfolder
     for f in /data/gogs/data /data/gogs/conf /data/gogs/log /data/git /data/ssh; do
         if ! test -d $f; then


### PR DESCRIPTION
Fixed: mkdir sub-dir in /data failed when no mount volume.
> comments: https://github.com/gogs/gogs/pull/6106#issuecomment-614035480