### PR TITLE
conf: fallback time layout to RFC 3339 when misconfigured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ All notable changes to Gogs are documented in this file.
 - Enable Federated Avatar Lookup could cause server to crash. [#5848](https://github.com/gogs/gogs/issues/5848)
 - Private repositories are hidden in the organization's view. [#5869](https://github.com/gogs/gogs/issues/5869)
 - Server error when changing email address in user settings page. [#5899](https://github.com/gogs/gogs/issues/5899)
+- Fall back to use RFC 3339 as time layout when misconfigured. [#6098](https://github.com/gogs/gogs/issues/6098)
 - Webhooks are not fired after push when `[service] REQUIRE_SIGNIN_VIEW = true`.
 
 ### Removed

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -294,7 +294,7 @@ func Init(customConf string) error {
 		"StampNano":   time.StampNano,
 	}[Time.Format]
 	if Time.FormatLayout == "" {
-		return fmt.Errorf("unrecognized '[time] FORMAT': %s", Time.Format)
+		Time.FormatLayout = time.RFC3339
 	}
 
 	// ****************************


### PR DESCRIPTION
Scope:
* If the configuration file has wrong time format then use a default time format. 
