### PR TITLE
lsif: don't upload indexes for forks

### DIFF
--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -2,6 +2,7 @@ name: LSIF
 on: [push]
 jobs:
   lsif-go:
+    if: github.repository == 'gogs/gogs'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
Sourcegraph's original published LSIF indexing CI guidelines had an error where the default setting on GitHub workflows would be for forks of the indexed repository to also build and upload LSIF indexes to Sourcegraph.com. The docs have been updated accordingly, and this PR contains the fix.