### PR TITLE
Update Dockerfiles for ARM to use alpine golang

### DIFF
--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM arm64v8/golang:1.14 AS binarybuilder
+FROM arm64v8/golang:1.14-alpine3.11 AS binarybuilder
 RUN apk --no-cache --no-progress add --virtual \
   build-deps \
   build-base \

--- a/docker/Dockerfile.rpi
+++ b/docker/Dockerfile.rpi
@@ -1,4 +1,4 @@
-FROM arm32v7/golang:1.14 AS binarybuilder
+FROM arm32v7/golang:1.14-alpine3.11 AS binarybuilder
 RUN apk --no-cache --no-progress add --virtual \
   build-deps \
   build-base \


### PR DESCRIPTION
Dockerfiles for arm do not work currently. They don't use the correct base image for golang.
The 1.14 tag is based on a debian image. The gogs Dockerfiles are written to work with alpine.

This pull request just updates the Dockerfiles to include the alpine tag for golang. I used alpine 3.11 as this is what the main Dockerfile uses.

Fixes #6182.
