### PR TITLE
workflow: add shellcheck as a linter

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -1,5 +1,5 @@
 on: push
-name: "Trigger: Push"
+name: "Shellcheck"
 jobs:
   shellcheck:
     name: Shellcheck

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -1,0 +1,11 @@
+on: push
+name: "Trigger: Push"
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -1,5 +1,8 @@
-on: push
-name: "Shellcheck"
+name: Shell
+on:
+  push:
+    branches: [master]
+  pull_request:
 jobs:
   shellcheck:
     name: Shellcheck
@@ -8,4 +11,3 @@ jobs:
       - uses: actions/checkout@master
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
-

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,11 +1,13 @@
+#!/bin/bash
+
 outPath=./output
 
 rm -rf $outPath
 mkdir $outPath
 
 go build ../gogs.go
-PLATFORM=`uname | cut -d _ -f 1`
-if [ $PLATFORM = "MINGW32" ] || [ $PLATFORM = "MINGW64" ] || [ $PLATFORM = "CYGWIN" ]; then
+PLATFORM=$(uname | cut -d _ -f 1)
+if [ "$PLATFORM" = "MINGW32" ] || [ "$PLATFORM" = "MINGW64" ] || [ "$PLATFORM" = "CYGWIN" ]; then
 	GOGS_EXE=gogs.exe
 else
 	GOGS_EXE=gogs


### PR DESCRIPTION
This pull request adds Shellcheck as a github work flow to provide linting for shell scripts. In addition to adding the workflow I have made some small changes to one shell script to ensure that it successfully passed that file.

There are quite a number of recommendations being made by shell check, I can make those adjustments as well but I wanted to keep this commit small.