### PR TITLE
Fix some typos in comments (app.ini)

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -111,7 +111,7 @@ ENABLE_LOCAL_PATH_MIGRATION = false
 ENABLE_RAW_FILE_RENDER_MODE = false
 ; The maximum number of goroutines that can be run at the same time for a single
 ; fetch request. Usually, the value depend of how many CPU (cores) you have. If
-; the value is non-positive, it matchs the number of CPUs available to the application.
+; the value is non-positive, it matches the number of CPUs available to the application.
 COMMITS_FETCH_CONCURRENCY = 0
 
 [repository.editor]
@@ -159,9 +159,9 @@ INSTALL_LOCK = false
 SECRET_KEY = !#@FDEWREWR&*(
 ; The days remembered for auto-login.
 LOGIN_REMEMBER_DAYS = 7
-; The cookie name to stoed auto-login information.
+; The cookie name to store auto-login information.
 COOKIE_REMEMBER_NAME = gogs_incredible
-; The cookie name to stored logged in username.
+; The cookie name to store logged in username.
 COOKIE_USERNAME = gogs_awesome
 ; Whether to set secure cookie.
 COOKIE_SECURE = false
@@ -309,7 +309,7 @@ GRAVATAR_SOURCE = gravatar
 DISABLE_GRAVATAR = false
 ; Whether to enable federated avatar lookup uses DNS to discover avatar associated
 ; with emails, see https://www.libravatar.org for details.
-; This value will be forced to be false in offline mode or when Gravatar is disbaled.
+; This value will be forced to be false in offline mode or when Gravatar is disabled.
 ENABLE_FEDERATED_AVATAR = false
 
 [markdown]


### PR DESCRIPTION
### note
This PR supersedes #6110, as I could not revert a bad commit there.  
I have not run `make generate` before making this PR, per https://github.com/gogs/gogs/pull/6110#issuecomment-625156228.

### scope
- fixed some typos & misspellings
- minor grammar improvements

Sorry for the small PR! (again)