### PR TITLE
Show private repos to admin users

### DIFF
--- a/internal/route/api/v1/repo/repo.go
+++ b/internal/route/api/v1/repo/repo.go
@@ -91,7 +91,7 @@ func listUserRepositories(c *context.APIContext, username string) {
 	} else {
 		ownRepos, err = db.GetUserRepositories(&db.UserRepoOptions{
 			UserID:   user.ID,
-			Private:  c.User.ID == user.ID,
+			Private:  c.User.ID == user.ID || c.User.IsAdmin,
 			Page:     1,
 			PageSize: user.NumRepos,
 		})


### PR DESCRIPTION
I found a small problem in the REST API.

When I try to list user's repositories with admin's token, I don't see private repos. 
I can create private repos, I can delete them, but I can't list them.
It looks weird. 

This small change improves this situation. It allows listing user's private repos with admin's token.