### PR TITLE
osutil: use system API to get the username when env vars are empty

### DIFF
--- a/internal/osutil/osutil.go
+++ b/internal/osutil/osutil.go
@@ -6,6 +6,7 @@ package osutil
 
 import (
 	"os"
+	"os/user"
 )
 
 // IsFile returns true if given path exists as a file (i.e. not a directory).
@@ -33,12 +34,20 @@ func IsExist(path string) bool {
 	return err == nil || os.IsExist(err)
 }
 
-// CurrentUsername returns the current system user via environment variables.
+// CurrentUsername returns the current system user
 func CurrentUsername() string {
 	username := os.Getenv("USER")
 	if len(username) > 0 {
 		return username
 	}
 
-	return os.Getenv("USERNAME")
+	username = os.Getenv("USERNAME")
+	if len(username) > 0 {
+		return username
+	}
+
+	if user, err := user.Current(); err == nil {
+		username = user.Username
+	}
+	return username
 }

--- a/internal/osutil/osutil_test.go
+++ b/internal/osutil/osutil_test.go
@@ -5,6 +5,7 @@
 package osutil
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -82,4 +83,18 @@ func TestIsExist(t *testing.T) {
 func TestCurrentUsername(t *testing.T) {
 	// Make sure it does not blow up
 	CurrentUsername()
+}
+
+func TestCurrentUsernamePrefersEnvironmentVariable(t *testing.T) {
+	// Some users/scripts expect that they can change the current username via environment variables
+	if userBak, ok := os.LookupEnv("USER"); ok {
+		defer os.Setenv("USER", userBak)
+	} else {
+		defer os.Unsetenv("USER")
+	}
+
+	if err := os.Setenv("USER", "__TESTING::USERNAME"); err != nil {
+		t.Skip("Could not set the USER environment variable:", err)
+	}
+	assert.Equal(t, "__TESTING::USERNAME", CurrentUsername())
 }


### PR DESCRIPTION
Previously Gogs got the current user via environment variables.
As Golang supports this via the standard library, this function is
now used instead and environment variables are only used if it fails.

Fixes #6219 