### PR TITLE
db: create new session for MySQL after changing attribute

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -187,7 +187,10 @@ func Init() (*gorm.DB, error) {
 		conf.UsePostgreSQL = true
 	case "mysql":
 		conf.UseMySQL = true
-		db = db.Set("gorm:table_options", "ENGINE=InnoDB")
+		db = db.Set("gorm:table_options", "ENGINE=InnoDB").
+			Session(&gorm.Session{
+				WithConditions: true,
+			})
 	case "sqlite3":
 		conf.UseSQLite3 = true
 	case "mssql":


### PR DESCRIPTION
After changing the connection attribute, a new session is required for thread-safe sharing in GORM v2.

Fixes https://github.com/gogs/gogs/issues/6334