### PR TITLE
add ability to configure CSRF cookie secure flag

### DIFF
--- a/internal/cmd/web.go
+++ b/internal/cmd/web.go
@@ -643,7 +643,7 @@ func runWeb(c *cli.Context) error {
 			CookiePath:     conf.Server.Subpath,
 			CookieHttpOnly: true,
 			SetCookie:      true,
-			Secure:         conf.Server.URL.Scheme == "https",
+			Secure:         conf.Server.URL.Scheme == "https" || conf.Session.CookieSecure,
 		}),
 		context.Contexter(),
 	)


### PR DESCRIPTION
Hi,

this PR is somewhat related to #3525 and adds the ability to override the CSRF Cookie's `Secure` attribute.
If `conf.server.URL.scheme` is `http` and `COOKIE_SECURE` is set in config, the CSRF cookie will have the attribute.