### PR TITLE
Add ability to set SameSite attribute of cookie

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -242,6 +242,8 @@ PROVIDER_CONFIG = data/sessions
 COOKIE_NAME = i_like_gogs
 ; Whether to set cookie in HTTPS only.
 COOKIE_SECURE = false
+; Whether to set SameSite on cookie to Lax (false) or Strict (true).
+COOKIE_SAME_SITE = false
 ; The GC interval in seconds for session data.
 GC_INTERVAL = 3600
 ; The maximum life time in seconds for a session.

--- a/go.mod
+++ b/go.mod
@@ -10,10 +10,10 @@ require (
 	github.com/go-macaron/binding v1.1.1
 	github.com/go-macaron/cache v0.0.0-20190810181446-10f7c57e2196
 	github.com/go-macaron/captcha v0.2.0
-	github.com/go-macaron/csrf v0.0.0-20190812063352-946f6d303a4c
+	github.com/go-macaron/csrf v0.0.0-20190812063352-946f6d303a4c //TODO: update once go-macaron/csrf#15 is merged
 	github.com/go-macaron/gzip v0.0.0-20160222043647-cad1c6580a07
 	github.com/go-macaron/i18n v0.5.0
-	github.com/go-macaron/session v0.0.0-20190805070824-1a3cdc6f5659
+	github.com/go-macaron/session v1.0.0
 	github.com/go-macaron/toolbox v0.0.0-20190813233741-94defb8383c6
 	github.com/gogs/chardet v0.0.0-20150115103509-2404f7772561
 	github.com/gogs/cron v0.0.0-20171120032916-9f6c956d3e14

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/go-macaron/inject v0.0.0-20160627170012-d8a0b8677191 h1:NjHlg70DuOkcA
 github.com/go-macaron/inject v0.0.0-20160627170012-d8a0b8677191/go.mod h1:VFI2o2q9kYsC4o7VP1HrEVosiZZTd+MVT3YZx4gqvJw=
 github.com/go-macaron/session v0.0.0-20190805070824-1a3cdc6f5659 h1:YXDFNK98PgKeBd+xM2Babdd6gyABG8H+SSAh5+hr0os=
 github.com/go-macaron/session v0.0.0-20190805070824-1a3cdc6f5659/go.mod h1:tLd0QEudXocQckwcpCq5pCuTCuYc24I0bRJDuRe9OuQ=
+github.com/go-macaron/session v1.0.0 h1:ixsWNPxg038ZuhaMBN64sqLRaueRwDUSbF6q+30WJic=
+github.com/go-macaron/session v1.0.0/go.mod h1:tLd0QEudXocQckwcpCq5pCuTCuYc24I0bRJDuRe9OuQ=
 github.com/go-macaron/toolbox v0.0.0-20190813233741-94defb8383c6 h1:x/v1iUWlqXTKVg17ulB0qCgcM2s+eysAbr/dseKLLss=
 github.com/go-macaron/toolbox v0.0.0-20190813233741-94defb8383c6/go.mod h1:YFNJ/JT4yLnpuIXTFef30SZkxGHUczjGZGFaZpPcdn0=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
@@ -361,8 +363,6 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
-github.com/unknwon/cae v1.0.1 h1:2sLCLKUntoV4xJ3lov9N+Nya6Z3AfToqJJ0cnao4O7U=
-github.com/unknwon/cae v1.0.1/go.mod h1:HqpmD2fVq9G1oGEXrXzbgIp51uJ29Hshv41n9ljm+AA=
 github.com/unknwon/cae v1.0.2 h1:3L8/RCN1ARvD5quyNjU30EdvYkFbxBfnRcIBXugpHlg=
 github.com/unknwon/cae v1.0.2/go.mod h1:HqpmD2fVq9G1oGEXrXzbgIp51uJ29Hshv41n9ljm+AA=
 github.com/unknwon/com v0.0.0-20190804042917-757f69c95f3e/go.mod h1:tOOxU81rwgoCLoOVVPHb6T/wt8HZygqH5id+GNnlCXM=
@@ -538,8 +538,6 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gorm.io/driver/mysql v1.0.1 h1:omJoilUzyrAp0xNoio88lGJCroGdIOen9hq2A/+3ifw=
 gorm.io/driver/mysql v1.0.1/go.mod h1:KtqSthtg55lFp3S5kUXqlGaelnWpKitn4k1xZTnoiPw=
-gorm.io/driver/postgres v1.0.0 h1:Yh4jyFQ0a7F+JPU0Gtiam/eKmpT/XFc1FKxotGqc6FM=
-gorm.io/driver/postgres v1.0.0/go.mod h1:wtMFcOzmuA5QigNsgEIb7O5lhvH1tHAF1RbWmLWV4to=
 gorm.io/driver/postgres v1.0.1 h1:jRfDNUxpxNrea/97kbcscAQGmiks4UCKAYXsvh4rhOQ=
 gorm.io/driver/postgres v1.0.1/go.mod h1:pv4dVhHvEVrP7k/UYqdBIllbdbpB5VTz89X1O0uOrCA=
 gorm.io/driver/sqlite v1.1.3 h1:BYfdVuZB5He/u9dt4qDpZqiqDJ6KhPqs5QUqsr/Eeuc=

--- a/internal/cmd/web.go
+++ b/internal/cmd/web.go
@@ -631,6 +631,7 @@ func runWeb(c *cli.Context) error {
 			ProviderConfig: conf.Session.ProviderConfig,
 			CookieName:     conf.Session.CookieName,
 			CookiePath:     conf.Server.Subpath,
+			CookieSameSite: conf.Session.CookieSameSite,
 			Gclifetime:     conf.Session.GCInterval,
 			Maxlifetime:    conf.Session.MaxLifeTime,
 			Secure:         conf.Session.CookieSecure,

--- a/internal/conf/static.go
+++ b/internal/conf/static.go
@@ -151,6 +151,7 @@ var (
 		ProviderConfig string
 		CookieName     string
 		CookieSecure   bool
+		CookieSameSite bool
 		GCInterval     int64 `ini:"GC_INTERVAL"`
 		MaxLifeTime    int64
 		CSRFCookieName string `ini:"CSRF_COOKIE_NAME"`


### PR DESCRIPTION
Hi,
this PR is somewhat related to #3525 and adds the ability to set the `SameSite` attribute for both the session cookies and the CSRF cookie.

This PR depends on go-macaron/csrf#15 and thus go-macaron/macaron#206 because the version in `go.mod` has to be lifted once those PRs are merged.

This implementation is using the same logic/style as go-macaron/session#38 where `false` is `Lax` and `true` is `Strict`. The default is again `false`.
