### PR TITLE
repo: disallow urlencoded new lines in git protocol paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to Gogs are documented in this file.
 ### Fixed
 
 - Add `X-Frame-Options` header to prevent Clickjacking. [#6409](https://github.com/gogs/gogs/issues/6409) 
+- [Security] Potential SSRF attack by CRLF injection via repository migration. [#6413](https://github.com/gogs/gogs/issues/6413)
+
 
 ### Removed
 

--- a/internal/form/repo.go
+++ b/internal/form/repo.go
@@ -72,6 +72,7 @@ func (f MigrateRepo) ParseRemoteAddr(user *db.User) (string, error) {
 		if len(f.AuthUsername)+len(f.AuthPassword) > 0 {
 			u.User = url.UserPassword(f.AuthUsername, f.AuthPassword)
 		}
+		// To prevent CRLF injection in git protocol, see https://github.com/gogs/gogs/issues/6413
 		if u.Scheme == "git" && (strings.Contains(remoteAddr, "%0d") || strings.Contains(remoteAddr, "%0a")) {
 			return "", db.ErrInvalidCloneAddr{IsURLError: true}
 		}

--- a/internal/form/repo.go
+++ b/internal/form/repo.go
@@ -72,6 +72,9 @@ func (f MigrateRepo) ParseRemoteAddr(user *db.User) (string, error) {
 		if len(f.AuthUsername)+len(f.AuthPassword) > 0 {
 			u.User = url.UserPassword(f.AuthUsername, f.AuthPassword)
 		}
+		if u.Scheme == "git" && u.Port() != "" && (strings.Contains(remoteAddr, "%0d") || strings.Contains(remoteAddr, "%0a")) {
+			return "", db.ErrInvalidCloneAddr{IsURLError: true}
+		}
 		remoteAddr = u.String()
 	} else if !user.CanImportLocal() {
 		return "", db.ErrInvalidCloneAddr{IsPermissionDenied: true}

--- a/internal/form/repo.go
+++ b/internal/form/repo.go
@@ -72,7 +72,7 @@ func (f MigrateRepo) ParseRemoteAddr(user *db.User) (string, error) {
 		if len(f.AuthUsername)+len(f.AuthPassword) > 0 {
 			u.User = url.UserPassword(f.AuthUsername, f.AuthPassword)
 		}
-		if u.Scheme == "git" && u.Port() != "" && (strings.Contains(remoteAddr, "%0d") || strings.Contains(remoteAddr, "%0a")) {
+		if u.Scheme == "git" && (strings.Contains(remoteAddr, "%0d") || strings.Contains(remoteAddr, "%0a")) {
 			return "", db.ErrInvalidCloneAddr{IsURLError: true}
 		}
 		remoteAddr = u.String()


### PR DESCRIPTION
This will fix the issue of #6413 

Related reference: https://github.com/go-gitea/gitea/pull/13525