### PR TITLE
scripts: fix MySQL script for MariaDB >= 10.3.1

### DIFF
--- a/scripts/mysql.sql
+++ b/scripts/mysql.sql
@@ -1,11 +1,10 @@
-SET @s = IF(version() < 8 OR version() LIKE '%MariaDB%', 
-            'SET GLOBAL innodb_file_per_table = ON, 
-                        innodb_file_format = Barracuda, 
-                        innodb_large_prefix = ON;', 
+SET @s = IF(version() < 8 OR (version() LIKE '%MariaDB%' AND version() < 10.3),
+            'SET GLOBAL innodb_file_per_table = ON,
+                        innodb_file_format = Barracuda,
+                        innodb_large_prefix = ON;',
             'SET GLOBAL innodb_file_per_table = ON;');
 PREPARE stmt1 FROM @s;
-EXECUTE stmt1; 
+EXECUTE stmt1;
 
 DROP DATABASE IF EXISTS gogs;
 CREATE DATABASE IF NOT EXISTS gogs CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
-


### PR DESCRIPTION
`innodb_file_format` and `innodb_large_prefix` have been deprecated with MariaDB v10.2 and removed with v10.3.1. They have been reintroduced with v10.4.3 but remain deprecated and unused:
- https://mariadb.com/kb/en/innodb-system-variables/#innodb_file_format
- https://mariadb.com/kb/en/innodb-system-variables/#innodb_large_prefix

Setting those variables on MariaDB >=10.3.1 leads to the following error:
```
ERROR 1238 (HY000) at line 7: Variable 'innodb_file_format' is a read only variable
```

Since semantic versioning patch versions cannot be compared via numeric operators, only the major + minor versions are compared against 10.3. Since v10.2.2 the defaults match the desired values, so there is only the single patch version 10.3.0 where, when explicitly set differently via MariaDB configs, this commit could lead to an unwanted database format. In favour of a simple SQL change, this case is ignored.

This commit additionally removes trailing spaces and the doubled trailing empty line.