### PR TITLE
Avatars use external url if present

### DIFF
--- a/internal/db/user.go
+++ b/internal/db/user.go
@@ -261,7 +261,11 @@ func (u *User) RelAvatarLink() string {
 		if !com.IsExist(u.CustomAvatarPath()) {
 			return defaultImgUrl
 		}
-		return fmt.Sprintf("%s/%s/%d", conf.Server.Subpath, USER_AVATAR_URL_PREFIX, u.ID)
+		if len(conf.Server.ExternalURL) == 0 {
+			return fmt.Sprintf("%s/%s/%d", conf.Server.Subpath, USER_AVATAR_URL_PREFIX, u.ID)
+		} else {
+			return fmt.Sprintf("%s/%s/%d", conf.Server.ExternalURL, USER_AVATAR_URL_PREFIX, u.ID)
+		}
 	case conf.Picture.DisableGravatar:
 		if !com.IsExist(u.CustomAvatarPath()) {
 			if err := u.GenerateRandomAvatar(); err != nil {

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -147,7 +147,11 @@ func AvatarLink(email string) (url string) {
 		url = conf.Picture.GravatarSource + HashEmail(email) + "?d=identicon"
 	}
 	if len(url) == 0 {
-		url = conf.Server.Subpath + "/img/avatar_default.png"
+		if len(conf.Server.ExternalURL) == 0 {
+			url = conf.Server.Subpath + "/img/avatar_default.png"
+		} else {
+			url = conf.Server.ExternalURL + "/img/avatar_default.png"
+		}
 	}
 	return url
 }


### PR DESCRIPTION
Thank you for this fantastic and simple to operate service. I have noticed one small issue

As a user when I upload my avatar for myself or an orga
I want to to show, when using a more complex hosting arrangement
So that the url it operates on may be different from the public url.

i.e.

localhost:3000 may be code.xxx.com:443

with an nginx proxy in-between

When setup in this format I noticed that custom avatars are not displayed (as per screenshot)

I hope this PR is useful.

<img width="1293" alt="01-broken-avatar" src="https://user-images.githubusercontent.com/397106/103176806-3acfc300-4875-11eb-9be9-6b96cfa56def.png">

<img width="590" alt="02-avatar-using-subpath-ref-bad" src="https://user-images.githubusercontent.com/397106/103176808-3dcab380-4875-11eb-91f5-7dd6e9caee04.png">

<img width="1423" alt="03-works" src="https://user-images.githubusercontent.com/397106/103176809-3e634a00-4875-11eb-9deb-1e3b4a821ed3.png">

