### PR TITLE
API user search now allows searching based on Email

### DIFF
--- a/internal/route/api/v1/user/user.go
+++ b/internal/route/api/v1/user/user.go
@@ -20,13 +20,19 @@ func Search(c *context.APIContext) {
 	opts := &db.SearchUserOptions{
 		Keyword:  c.Query("q"),
 		Type:     db.UserIndividual,
+		Field:    c.Query("field"),
 		PageSize: com.StrTo(c.Query("limit")).MustInt(),
 	}
 	if opts.PageSize == 0 {
 		opts.PageSize = 10
 	}
 
-	users, _, err := db.SearchUserByName(opts)
+	// Default to searching based on the name
+	if opts.Field == "" {
+		opts.Field = "name"
+	}
+
+	users, _, err := db.SearchUser(opts)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, map[string]interface{}{
 			"ok":    false,
@@ -43,6 +49,8 @@ func Search(c *context.APIContext) {
 			AvatarUrl: users[i].AvatarLink(),
 			FullName:  markup.Sanitize(users[i].FullName),
 		}
+
+		// We allow searching based on email regardless of whether you are logged in, but only display emails if you are
 		if c.IsLogged {
 			results[i].Email = users[i].Email
 		}


### PR DESCRIPTION
There are several tradeoffs with this code, such as the more generic search call with an allowlist of fields. This could be abused in the future if care is not taken, but allows generic code for now.
There is also the decision to hide emails from users that are not logged in, even though it is possible to search based on them.

This change implements #6470.