### PR TITLE
webhook: add missing `%s` URL value for webhook description

### DIFF
--- a/internal/route/repo/webhook.go
+++ b/internal/route/repo/webhook.go
@@ -81,10 +81,10 @@ func Webhooks(c *context.Context, orCtx *orgRepoContext) {
 	var err error
 	var ws []*db.Webhook
 	if orCtx.RepoID > 0 {
-		c.Data["Description"] = c.Tr("repo.settings.hooks_desc")
+		c.Data["Description"] = c.Tr("repo.settings.hooks_desc", "https://gogs.io/docs/features/webhook.html")
 		ws, err = db.GetWebhooksByRepoID(orCtx.RepoID)
 	} else {
-		c.Data["Description"] = c.Tr("org.settings.hooks_desc")
+		c.Data["Description"] = c.Tr("org.settings.hooks_desc", "https://gogs.io/docs/features/webhook.html")
 		ws, err = db.GetWebhooksByOrgID(orCtx.OrgID)
 	}
 	if err != nil {

--- a/internal/route/repo/webhook.go
+++ b/internal/route/repo/webhook.go
@@ -84,7 +84,7 @@ func Webhooks(c *context.Context, orCtx *orgRepoContext) {
 		c.Data["Description"] = c.Tr("repo.settings.hooks_desc", "https://gogs.io/docs/features/webhook.html")
 		ws, err = db.GetWebhooksByRepoID(orCtx.RepoID)
 	} else {
-		c.Data["Description"] = c.Tr("org.settings.hooks_desc", "https://gogs.io/docs/features/webhook.html")
+		c.Data["Description"] = c.Tr("org.settings.hooks_desc")
 		ws, err = db.GetWebhooksByOrgID(orCtx.OrgID)
 	}
 	if err != nil {


### PR DESCRIPTION
"Webhooks Guide" URL is empty. "hooks_desc" has a %s which is not filled in code. With this patch it is.

![image](https://user-images.githubusercontent.com/2914051/105614371-43aaaa80-5dc9-11eb-83cc-2ffcb3a7e5c4.png)
