### PR TITLE
Add fuzzer

### DIFF
--- a/internal/db/fuzzer.go
+++ b/internal/db/fuzzer.go
@@ -1,0 +1,14 @@
+// Copyright 2021 The Gogs Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+// +build gofuzz
+
+package db
+
+func Fuzz(data []byte) int {
+	_, err := CheckPublicKeyString(string(data))
+	if err != nil {
+		return 0
+	}
+	return 1
+}


### PR DESCRIPTION
This PR adds a fuzzer implemented by way of [go-fuzz](https://github.com/dvyukov/go-fuzz)

Fuzzing is a way of testing programs whereby pseudo-random data is passed to a target function with the goal of finding bugs and vulnerabilities.

I have been working on running this fuzzer continuously on OSS-fuzz's platform, and I will be happy to integrate gogs into the project so that this fuzzer can run continuously. OSS-fuzz is a free service for open source projects, and if bugs are found an email with a link to a detailed bug report is sent out to the maintainers on the mailing list. The mailing list is public and can be changed at any time, and there is a public disclosure policy of 90 days.

Continuous fuzzing of Gogs has previously been proposed here: https://github.com/gogs/gogs/issues/5783

Signed-off-by: AdamKorcz <adam@adalogics.com>
