### PR TITLE
Remove restriction for repository website url length

### DIFF
--- a/internal/form/repo.go
+++ b/internal/form/repo.go
@@ -89,7 +89,7 @@ func (f MigrateRepo) ParseRemoteAddr(user *db.User) (string, error) {
 type RepoSetting struct {
 	RepoName      string `binding:"Required;AlphaDashDot;MaxSize(100)"`
 	Description   string `binding:"MaxSize(512)"`
-	Website       string `binding:"Url;MaxSize(100)"`
+	Website       string `binding:"Url"`
 	Branch        string
 	Interval      int
 	MirrorAddress string


### PR DESCRIPTION
I checked github maximum length for repository website url and I understood it doesn't have any restriction, so I remove maximum length for repository website url due to #4820