### PR TITLE
Make __debug_bin work on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ public/img/avatar/
 *.exe
 *.exe~
 /gogs
+/__debug_bin
 profile/
 *.pem
 output*

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -7,6 +7,7 @@ package conf
 import (
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -34,9 +35,17 @@ var (
 func AppPath() string {
 	appPathOnce.Do(func() {
 		var err error
-		appPath, err = exec.LookPath(os.Args[0])
-		if err != nil {
-			panic("look executable path: " + err.Error())
+		lookPath := true
+		if os.PathSeparator == '\\' {
+			appPath = strings.ReplaceAll(os.Args[0], "\\", "/")
+			file := path.Base(appPath)
+			lookPath = file != "__debug_bin"
+		}
+		if lookPath {
+			appPath, err = exec.LookPath(os.Args[0])
+			if err != nil {
+				panic("look executable path: " + err.Error())
+			}
 		}
 
 		appPath, err = filepath.Abs(appPath)


### PR DESCRIPTION
Make `__debug_bin` work on Windows when using debugger.

This is because `__debug_bin` does not end with `.exe`