### PR TITLE
docker: add Healthcheck support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,5 +40,6 @@ RUN ./docker/finalize.sh
 # Configure Docker Container
 VOLUME ["/data", "/backup"]
 EXPOSE 22 3000
+HEALTHCHECK CMD (nc -z -w 3 localhost:22 && curl -o /dev/null -sS http://localhost:3000) || exit 1
 ENTRYPOINT ["/app/gogs/docker/start.sh"]
 CMD ["/bin/s6-svscan", "/app/gogs/docker/s6/"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,6 @@ RUN ./docker/finalize.sh
 # Configure Docker Container
 VOLUME ["/data", "/backup"]
 EXPOSE 22 3000
-HEALTHCHECK CMD (nc -z -w 3 localhost:22 && curl -o /dev/null -sS http://localhost:3000) || exit 1
+HEALTHCHECK CMD (nc -z -w 3 localhost:22 && curl -o /dev/null -sS http://localhost:3000/healthcheck) || exit 1
 ENTRYPOINT ["/app/gogs/docker/start.sh"]
 CMD ["/bin/s6-svscan", "/app/gogs/docker/s6/"]

--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -40,5 +40,6 @@ RUN ./docker/finalize.sh
 # Configure Docker Container
 VOLUME ["/data", "/backup"]
 EXPOSE 22 3000
+HEALTHCHECK CMD (nc -z -w 3 localhost:22 && curl -o /dev/null -sS http://localhost:3000) || exit 1
 ENTRYPOINT ["/app/gogs/docker/start.sh"]
 CMD ["/bin/s6-svscan", "/app/gogs/docker/s6/"]

--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -40,6 +40,6 @@ RUN ./docker/finalize.sh
 # Configure Docker Container
 VOLUME ["/data", "/backup"]
 EXPOSE 22 3000
-HEALTHCHECK CMD (nc -z -w 3 localhost:22 && curl -o /dev/null -sS http://localhost:3000) || exit 1
+HEALTHCHECK CMD (nc -z -w 3 localhost:22 && curl -o /dev/null -sS http://localhost:3000/healthcheck) || exit 1
 ENTRYPOINT ["/app/gogs/docker/start.sh"]
 CMD ["/bin/s6-svscan", "/app/gogs/docker/s6/"]

--- a/docker/Dockerfile.rpi
+++ b/docker/Dockerfile.rpi
@@ -40,5 +40,6 @@ RUN ./docker/finalize.sh
 # Configure Docker Container
 VOLUME ["/data", "/backup"]
 EXPOSE 22 3000
+HEALTHCHECK CMD (nc -z -w 3 localhost:22 && curl -o /dev/null -sS http://localhost:3000) || exit 1
 ENTRYPOINT ["/app/gogs/docker/start.sh"]
 CMD ["/bin/s6-svscan", "/app/gogs/docker/s6/"]

--- a/docker/Dockerfile.rpi
+++ b/docker/Dockerfile.rpi
@@ -40,6 +40,6 @@ RUN ./docker/finalize.sh
 # Configure Docker Container
 VOLUME ["/data", "/backup"]
 EXPOSE 22 3000
-HEALTHCHECK CMD (nc -z -w 3 localhost:22 && curl -o /dev/null -sS http://localhost:3000) || exit 1
+HEALTHCHECK CMD (nc -z -w 3 localhost:22 && curl -o /dev/null -sS http://localhost:3000/healthcheck) || exit 1
 ENTRYPOINT ["/app/gogs/docker/start.sh"]
 CMD ["/bin/s6-svscan", "/app/gogs/docker/s6/"]


### PR DESCRIPTION
This pull request provides the required updates to the 3 dockerfiles which enables support for dockers built-in healthchecks.

The healthcheck shows a containers status as healthy if both:

* SSH (TCP 22) can be connected to via a TCP Port open request
* The Web Portal (TCP 3000) home page returns a HTTP 200 code response

Fixes #5935