### PR TITLE
fix "fatal: git cat-file: could not get object info" when viewing diff of commit deleting submodule

### DIFF
--- a/templates/repo/diff/box.tmpl
+++ b/templates/repo/diff/box.tmpl
@@ -77,10 +77,12 @@
 				</h4>
 				<div class="ui unstackable attached table segment">
 					{{$isImage := false}}
-					{{if $file.IsDeleted}}
-						{{$isImage = (call $.IsImageFileByIndex $file.Index)}}
-					{{else}}
-						{{$isImage = (call $.IsImageFile $file.Name)}}
+					{{if not $file.IsSubmodule}}
+						{{if $file.IsDeleted}}
+							{{$isImage = (call $.IsImageFileByIndex $file.Index)}}
+						{{else}}
+							{{$isImage = (call $.IsImageFile $file.Name)}}
+						{{end}}
 					{{end}}
 
 					{{if $isImage}}


### PR DESCRIPTION
fixes bug described in https://github.com/gogs/gogs/issues/6525