### PR TITLE
docker: reduce additional image layer for the not executable gosu binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ COPY . .
 RUN make build TAGS="cert pam"
 
 FROM alpine:3.11
-ADD https://github.com/tianon/gosu/releases/download/1.11/gosu-amd64 /usr/sbin/gosu
-RUN chmod +x /usr/sbin/gosu \
+RUN wget https://github.com/tianon/gosu/releases/download/1.11/gosu-amd64 -O /usr/sbin/gosu \
+  && chmod +x /usr/sbin/gosu \
   && echo http://dl-2.alpinelinux.org/alpine/edge/community/ >> /etc/apk/repositories \
   && apk --no-cache --no-progress add \
   bash \

--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -10,8 +10,8 @@ COPY . .
 RUN make build TAGS="cert pam"
 
 FROM arm64v8/alpine:3.11
-ADD https://github.com/tianon/gosu/releases/download/1.11/gosu-arm64 /usr/sbin/gosu
-RUN chmod +x /usr/sbin/gosu \
+RUN wget https://github.com/tianon/gosu/releases/download/1.11/gosu-arm64 -O /usr/sbin/gosu \
+  && chmod +x /usr/sbin/gosu \
   && echo http://dl-2.alpinelinux.org/alpine/edge/community/ >> /etc/apk/repositories \
   && apk --no-cache --no-progress add \
   bash \

--- a/docker/Dockerfile.rpi
+++ b/docker/Dockerfile.rpi
@@ -10,8 +10,8 @@ COPY . .
 RUN make build TAGS="cert pam"
 
 FROM arm32v7/alpine:3.12
-ADD https://github.com/tianon/gosu/releases/download/1.12/gosu-armhf /usr/sbin/gosu
-RUN chmod +x /usr/sbin/gosu \
+RUN wget https://github.com/tianon/gosu/releases/download/1.12/gosu-armhf -O /usr/sbin/gosu \
+  && chmod +x /usr/sbin/gosu \
   && echo http://dl-2.alpinelinux.org/alpine/edge/community/ >> /etc/apk/repositories \
   && apk --no-cache --no-progress add \
   bash \


### PR DESCRIPTION
This is a Dockerfile refactor, which will help reduce the image size and image layers. So I don't think it will need an issue opened first, hopefully it's acceptable, please let me know, if it's not, before directly close this PR, I could open an issue for it if it's required! Thanks!