### PR TITLE
Enable use of %p wildcard in "Bind Password"

### DIFF
--- a/internal/auth/ldap/config.go
+++ b/internal/auth/ldap/config.go
@@ -108,12 +108,13 @@ func (c *Config) sanitizedGroupDN(groupDn string) (string, bool) {
 	return groupDn, true
 }
 
-func (c *Config) findUserDN(l *ldap.Conn, name string) (string, bool) {
+func (c *Config) findUserDN(l *ldap.Conn, name string, passwd string) (string, bool) {
 	log.Trace("Search for LDAP user: %s", name)
 	if len(c.BindDN) > 0 && len(c.BindPassword) > 0 {
 		// Replace placeholders with username
 		bindDN := strings.Replace(c.BindDN, "%s", name, -1)
-		err := l.Bind(bindDN, c.BindPassword)
+		bindPW := strings.Replace(c.BindPassword, "%p", passwd, -1)
+		err := l.Bind(bindDN, bindPW)
 		if err != nil {
 			log.Trace("LDAP: Failed to bind as BindDN '%s': %v", bindDN, err)
 			return "", false
@@ -217,7 +218,7 @@ func (c *Config) searchEntry(name, passwd string, directBind bool) (string, stri
 		log.Trace("LDAP will use BindDN")
 
 		var found bool
-		userDN, found = c.findUserDN(l, name)
+		userDN, found = c.findUserDN(l, name, passwd)
 		if !found {
 			return "", "", "", "", false, false
 		}


### PR DESCRIPTION
Enable use of %p wildcard in "Bind Password" field in BindDN to allow user to bind to LDAP with user's credentials, for situations where neither anonymous bind allowed nor a dedicated LDAP bind user is available.

