### PR TITLE
Example ports change to 9022 and 9080

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -18,13 +18,13 @@ $ docker pull gogs/gogs
 $ mkdir -p /var/gogs
 
 # Use `docker run` for the first time.
-$ docker run --name=gogs -p 10022:22 -p 10080:3000 -v /var/gogs:/data gogs/gogs
+$ docker run --name=gogs -p 9022:22 -p 9080:3000 -v /var/gogs:/data gogs/gogs
 
 # Use `docker start` if you have stopped it.
 $ docker start gogs
 ```
 
-Note: It is important to map the Gogs ssh service from the container to the host and set the appropriate SSH Port and URI settings when setting up Gogs for the first time. To access and clone Gogs Git repositories with the above configuration you would use: `git clone ssh://git@hostname:10022/username/myrepo.git` for example.
+Note: It is important to map the Gogs ssh service from the container to the host and set the appropriate SSH Port and URI settings when setting up Gogs for the first time. To access and clone Gogs Git repositories with the above configuration you would use: `git clone ssh://git@hostname:9022/username/myrepo.git` for example.
 
 Files will be store in local path `/var/gogs` in my case.
 
@@ -53,7 +53,7 @@ If you're more comfortable with mounting data to a data container, the commands 
 docker run --name=gogs-data --entrypoint /bin/true gogs/gogs
 
 # Use `docker run` for the first time.
-docker run --name=gogs --volumes-from gogs-data -p 10022:22 -p 10080:3000 gogs/gogs
+docker run --name=gogs --volumes-from gogs-data -p 9022:22 -p 9080:3000 gogs/gogs
 ```
 
 #### Using Docker 1.9 Volume Command
@@ -63,7 +63,7 @@ docker run --name=gogs --volumes-from gogs-data -p 10022:22 -p 10080:3000 gogs/g
 $ docker volume create --name gogs-data
 
 # Use `docker run` for the first time.
-$ docker run --name=gogs -p 10022:22 -p 10080:3000 -v gogs-data:/data gogs/gogs
+$ docker run --name=gogs -p 9022:22 -p 9080:3000 -v gogs-data:/data gogs/gogs
 ```
 
 ## Settings
@@ -75,9 +75,9 @@ Most of settings are obvious and easy to understand, but there are some settings
 - **Repository Root Path**: keep it as default value `/home/git/gogs-repositories` because `start.sh` already made a symbolic link for you.
 - **Run User**: keep it as default value `git` because `finalize.sh` already setup a user with name `git`.
 - **Domain**: fill in with Docker container IP (e.g. `192.168.99.100`). But if you want to access your Gogs instance from a different physical machine, please fill in with the hostname or IP address of the Docker host machine.
-- **SSH Port**: Use the exposed port from Docker container. For example, your SSH server listens on `22` inside Docker, **but** you expose it by `10022:22`, then use `10022` for this value. **Builtin SSH server is not recommended inside Docker Container**
-- **HTTP Port**: Use port you want Gogs to listen on inside Docker container. For example, your Gogs listens on `3000` inside Docker, **and** you expose it by `10080:3000`, but you still use `3000` for this value.
-- **Application URL**: Use combination of **Domain** and **exposed HTTP Port** values (e.g. `http://192.168.99.100:10080/`).
+- **SSH Port**: Use the exposed port from Docker container. For example, your SSH server listens on `22` inside Docker, **but** you expose it by `9022:22`, then use `9022` for this value. **Builtin SSH server is not recommended inside Docker Container**
+- **HTTP Port**: Use port you want Gogs to listen on inside Docker container. For example, your Gogs listens on `3000` inside Docker, **and** you expose it by `9080:3000`, but you still use `3000` for this value.
+- **Application URL**: Use combination of **Domain** and **exposed HTTP Port** values (e.g. `http://192.168.99.100:9080/`).
 
 Full documentation of application settings can be found [here](https://github.com/gogs/gogs/blob/main/conf/app.ini).
 


### PR DESCRIPTION
Chrome blocks traffic through port 10080 as of Chrome 91. See the release notes for Chrome 91: https://support.google.com/chrome/a/answer/7679408#91&zippy=%2Cchrome

By using port 9080, for example, instead of port 10080 as the container's exposed HTTP port used in this README, Chrome (as well as Firefox) will not block traffic when the user tries to reach the container's exposed port 9080.

Also suggested is changing the container's port 10022 to port 9022, simply to be consistent with the container's exposed 9080 port.