### PR TITLE
docker: update default port to be exposed on the host

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -18,7 +18,7 @@ $ docker pull gogs/gogs
 $ mkdir -p /var/gogs
 
 # Use `docker run` for the first time.
-$ docker run --name=gogs -p 10022:22 -p 10080:3000 -v /var/gogs:/data gogs/gogs
+$ docker run --name=gogs -p 10022:22 -p 10880:3000 -v /var/gogs:/data gogs/gogs
 
 # Use `docker start` if you have stopped it.
 $ docker start gogs
@@ -53,7 +53,7 @@ If you're more comfortable with mounting data to a data container, the commands 
 docker run --name=gogs-data --entrypoint /bin/true gogs/gogs
 
 # Use `docker run` for the first time.
-docker run --name=gogs --volumes-from gogs-data -p 10022:22 -p 10080:3000 gogs/gogs
+docker run --name=gogs --volumes-from gogs-data -p 10022:22 -p 10880:3000 gogs/gogs
 ```
 
 #### Using Docker 1.9 Volume Command
@@ -63,7 +63,7 @@ docker run --name=gogs --volumes-from gogs-data -p 10022:22 -p 10080:3000 gogs/g
 $ docker volume create --name gogs-data
 
 # Use `docker run` for the first time.
-$ docker run --name=gogs -p 10022:22 -p 10080:3000 -v gogs-data:/data gogs/gogs
+$ docker run --name=gogs -p 10022:22 -p 10880:3000 -v gogs-data:/data gogs/gogs
 ```
 
 ## Settings
@@ -76,8 +76,8 @@ Most of settings are obvious and easy to understand, but there are some settings
 - **Run User**: keep it as default value `git` because `finalize.sh` already setup a user with name `git`.
 - **Domain**: fill in with Docker container IP (e.g. `192.168.99.100`). But if you want to access your Gogs instance from a different physical machine, please fill in with the hostname or IP address of the Docker host machine.
 - **SSH Port**: Use the exposed port from Docker container. For example, your SSH server listens on `22` inside Docker, **but** you expose it by `10022:22`, then use `10022` for this value. **Builtin SSH server is not recommended inside Docker Container**
-- **HTTP Port**: Use port you want Gogs to listen on inside Docker container. For example, your Gogs listens on `3000` inside Docker, **and** you expose it by `10080:3000`, but you still use `3000` for this value.
-- **Application URL**: Use combination of **Domain** and **exposed HTTP Port** values (e.g. `http://192.168.99.100:10080/`).
+- **HTTP Port**: Use port you want Gogs to listen on inside Docker container. For example, your Gogs listens on `3000` inside Docker, **and** you expose it by `10880:3000`, but you still use `3000` for this value.
+- **Application URL**: Use combination of **Domain** and **exposed HTTP Port** values (e.g. `http://192.168.99.100:10880/`).
 
 Full documentation of application settings can be found [here](https://github.com/gogs/gogs/blob/main/conf/app.ini).
 


### PR DESCRIPTION
As Described in #6572 Port 10080 has being blocked default by modern Browsers, i suggest changing the default port.