### PR TITLE
web: correctly handle go-get pages for repository roots

### DIFF
--- a/internal/cmd/web.go
+++ b/internal/cmd/web.go
@@ -611,10 +611,10 @@ func runWeb(c *cli.Context) error {
 			m.Get("/compare/:before([a-z0-9]{40})\\.\\.\\.:after([a-z0-9]{40})", repo.MustBeNotBare, context.RepoRef(), repo.CompareDiff)
 		}, ignSignIn, context.RepoAssignment())
 		m.Group("/:username/:reponame", func() {
-			m.Get("", context.ServeGoGet(), repo.Home)
+			m.Get("", repo.Home)
 			m.Get("/stars", repo.Stars)
 			m.Get("/watchers", repo.Watchers)
-		}, ignSignIn, context.RepoAssignment(), context.RepoRef())
+		}, context.ServeGoGet(), ignSignIn, context.RepoAssignment(), context.RepoRef())
 		// ***** END: Repository *****
 
 		// **********************


### PR DESCRIPTION
#6318 caused `?go-get=1` handling to be broken for repository roots (e.g. `https://git.example.com/James/project?go-get=1`) when user was not logged in. This is due to the handlers for the group running before the `context.ServeGoGet` handler, producing 404s or redirects and the `ServeGoGet` handler not being run.

This moves the `ServeGoGet` handler to the group level before any other handler. This makes it more similar to the previous behaviour where `?go-get=1` handling was done before almost any other handler.