### PR TITLE
Read ROOT_URL from HTTP header dynamically(gogs#5518)

### DIFF
--- a/internal/context/repo.go
+++ b/internal/context/repo.go
@@ -260,6 +260,15 @@ func RepoAssignment(pages ...bool) macaron.Handler {
 
 		c.Data["DisableSSH"] = conf.SSH.Disabled
 		c.Data["DisableHTTP"] = conf.Repository.DisableHTTPGit
+
+		HostSplits := strings.Split(c.Req.Host, ":")
+		conf.SSH.Domain = HostSplits[0]
+		if conf.Server.Protocol == "unix" {
+			conf.Server.ExternalURL = c.Req.Host
+		} else {
+			conf.Server.ExternalURL = fmt.Sprintf("%s://%s", conf.Server.Protocol, c.Req.Host)
+		}
+
 		c.Data["CloneLink"] = repo.CloneLink()
 		c.Data["WikiCloneLink"] = repo.WikiCloneLink()
 


### PR DESCRIPTION
modify `conf.Server.ExternalURL` and `conf.SSH.Domain` for each HTTP request, hence no need to pass `url` into function `CloneLink()` and `WikiCloneLInk()`