### PR TITLE
change clone link dynamically(gogs#5518)

### DIFF
--- a/internal/context/repo.go
+++ b/internal/context/repo.go
@@ -260,6 +260,15 @@ func RepoAssignment(pages ...bool) macaron.Handler {
 
 		c.Data["DisableSSH"] = conf.SSH.Disabled
 		c.Data["DisableHTTP"] = conf.Repository.DisableHTTPGit
+
+		HostSplits := strings.Split(c.Req.Host, ":")
+		conf.SSH.Domain = HostSplits[0]
+		if conf.Server.Protocol == "unix" {
+			conf.Server.ExternalURL = c.Req.Host
+		} else {
+			conf.Server.ExternalURL = fmt.Sprintf("%s://%s/", conf.Server.Protocol, c.Req.Host)
+		}
+
 		c.Data["CloneLink"] = repo.CloneLink()
 		c.Data["WikiCloneLink"] = repo.WikiCloneLink()
 


### PR DESCRIPTION
change the clone link by modifying the `conf.Server.ExternalURL`/`conf.SSH.Domain` for each request. 
Not pass `c.Req.Host` to `repo.CloneLink()` can avoid a lot of code changes.