### PR TITLE
db: skip ping when not available

### DIFF
--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -231,6 +231,9 @@ func GetStatistic() (stats Statistic) {
 }
 
 func Ping() error {
+	if x == nil {
+		return errors.New("database not available")
+	}
 	return x.Ping()
 }
 


### PR DESCRIPTION
### Describe the pull request

The healthcheck endpoint panics on pinging on a `*xorm.Engine` with `nil` value, and it doesn't make sense to ping in such cases.

Link to the issue: https://github.com/gogs/gogs/discussions/6672#discussioncomment-1845476

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/contributing.md).
- [x] I have added test cases to cover the new code.
