### PR TITLE
chore: fix dead link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The Gogs (`/gɑgz/`) project aims to build a simple, stable and extensible self-
 - Want to try it before doing anything else? Do it [online](https://try.gogs.io/gogs/gogs)!
 - Having trouble? Help yourself with [troubleshooting](https://gogs.io/docs/intro/troubleshooting.html) or ask questions in [Discussions](https://github.com/gogs/gogs/discussions).
 - Want to help with localization? Check out the [localization documentation](https://gogs.io/docs/features/i18n.html).
-- Ready to get hands dirty? Read our [contributing guide](.github/contributing.md).
+- Ready to get hands dirty? Read our [contributing guide](.github/CONTRIBUTING.md).
 - Hmm... What about APIs? We have experimental support with [documentation](https://github.com/gogs/docs-api).
 
 ## 💌 Features


### PR DESCRIPTION
### Describe the pull request

GitHub URLs are case sensitive. Update 'contributing.md' link to 'CONTRIBUTING.md' so that the link is no longer dead.

In the current state of the repository, if you click on the 'contributing guide' link in README.md, you get a 404 page.

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/contributing.md).
- N/A I have added test cases to cover the new code.
