### PR TITLE
markup: use default link formation when no format in metas

### DIFF
--- a/internal/markup/markup.go
+++ b/internal/markup/markup.go
@@ -101,7 +101,7 @@ func RenderIssueIndexPattern(rawBytes []byte, urlPrefix string, metas map[string
 			m = m[1:]
 		}
 		var link string
-		if metas == nil {
+		if metas == nil || metas["format"] == "" {
 			link = fmt.Sprintf(`<a href="%s/issues/%s">%s</a>`, urlPrefix, m[1:], m)
 		} else {
 			// Support for external issue tracker


### PR DESCRIPTION
### Describe the pull request

We should render issue links using default link formation when `metas["format"]` is not present.

Link to the issue: https://github.com/gogs/gogs/issues/6506

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/contributing.md).
- [x] I have added test cases to cover the new code.
