### PR TITLE
docker: remove healthcheck against the SSH port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,6 @@ RUN ./docker/finalize.sh
 # Configure Docker Container
 VOLUME ["/data", "/backup"]
 EXPOSE 22 3000
-HEALTHCHECK CMD (nc -z -w 3 localhost 22 && curl -o /dev/null -sS http://localhost:3000/healthcheck) || exit 1
+HEALTHCHECK CMD (curl -o /dev/null -sS http://localhost:3000/healthcheck) || exit 1
 ENTRYPOINT ["/app/gogs/docker/start.sh"]
 CMD ["/bin/s6-svscan", "/app/gogs/docker/s6/"]


### PR DESCRIPTION
### Describe the pull request

Checking against SSH port involves complex issue like setting up proper private keys, it does not feel worth the effort to keep it as long as we are still checking against the HTTP endpoint.

Link to the issue: https://github.com/gogs/gogs/issues/6727

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/contributing.md).
- [x] I have added test cases to cover the new code.
