### PR TITLE
security: fix improper PAM authorization handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to Gogs are documented in this file.
 ### Fixed
 
 - _Security:_ Potential SSRF in repository migration. [#6754](https://github.com/gogs/gogs/issues/6754)
+- _Security:_ Improper PAM authorization handling. [#6810](https://github.com/gogs/gogs/issues/6810)
 - Unable to use LDAP authentication on ARM machines. [#6761](https://github.com/gogs/gogs/issues/6761)
 
 ### Removed

--- a/internal/auth/pam/pam.go
+++ b/internal/auth/pam/pam.go
@@ -25,6 +25,11 @@ func (c *Config) doAuth(login, password string) error {
 	if err != nil {
 		return err
 	}
-
-	return t.Authenticate(0)
+	
+	err = t.Authenticate(0)
+	if err != nil {
+		return err
+	}
+	
+	return t.AcctMgmt(0)
 }

--- a/internal/auth/pam/pam.go
+++ b/internal/auth/pam/pam.go
@@ -30,6 +30,5 @@ func (c *Config) doAuth(login, password string) error {
 	if err != nil {
 		return err
 	}
-	
 	return t.AcctMgmt(0)
 }


### PR DESCRIPTION
### Describe the pull request

Disallow expired accounts or accounts with expired passwords to login.

Link to the issue: https://github.com/gogs/gogs/issues/6810

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/contributing.md).
- [ ] I have added test cases to cover the new code.
