### PR TITLE
web: print accessible URL on startup

### DIFF
--- a/internal/cmd/web.go
+++ b/internal/cmd/web.go
@@ -707,6 +707,7 @@ func runWeb(c *cli.Context) error {
 		listenAddr = fmt.Sprintf("%s:%s", conf.Server.HTTPAddr, conf.Server.HTTPPort)
 		log.Info("Listen on %v://%s%s", conf.Server.Protocol, listenAddr, conf.Server.Subpath)
 	}
+	log.Info("Available on %s", conf.Server.ExternalURL)
 
 	switch conf.Server.Protocol {
 	case "http":

--- a/internal/cmd/web.go
+++ b/internal/cmd/web.go
@@ -702,10 +702,8 @@ func runWeb(c *cli.Context) error {
 	var listenAddr string
 	if conf.Server.Protocol == "unix" {
 		listenAddr = conf.Server.HTTPAddr
-		log.Info("Listen on %v://%s", conf.Server.Protocol, listenAddr)
 	} else {
 		listenAddr = fmt.Sprintf("%s:%s", conf.Server.HTTPAddr, conf.Server.HTTPPort)
-		log.Info("Listen on %v://%s%s", conf.Server.Protocol, listenAddr, conf.Server.Subpath)
 	}
 	log.Info("Available on %s", conf.Server.ExternalURL)
 


### PR DESCRIPTION
### Describe the pull request

It is more useful to print the user-defined external URL than the server listening address.

Link to the issue: n/a

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [ ] I have added test cases to cover the new code.
