### PR TITLE
http: fix non-sense `NotFound` call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to Gogs are documented in this file.
 
 - Unable to use LDAP authentication on ARM machines. [#6761](https://github.com/gogs/gogs/issues/6761)
 - Unable to init repository during creation on Windows. [#6967](https://github.com/gogs/gogs/issues/6967)
+- Mysterious panic on `Value not found for type *repo.HTTPContext`. [#6963](https://github.com/gogs/gogs/issues/6963)
 
 ### Removed
 

--- a/internal/route/repo/http.go
+++ b/internal/route/repo/http.go
@@ -100,7 +100,7 @@ func HTTPContexter() macaron.Handler {
 			!strings.Contains(action, "info/") &&
 			!strings.Contains(action, "HEAD") &&
 			!strings.Contains(action, "objects/") {
-			c.NotFound()
+			c.Error(http.StatusNotFound, fmt.Sprintf("Unrecognized action %q", action))
 			return
 		}
 

--- a/internal/route/repo/http.go
+++ b/internal/route/repo/http.go
@@ -100,7 +100,7 @@ func HTTPContexter() macaron.Handler {
 			!strings.Contains(action, "info/") &&
 			!strings.Contains(action, "HEAD") &&
 			!strings.Contains(action, "objects/") {
-			c.Error(http.StatusNotFound, fmt.Sprintf("Unrecognized action %q", action))
+			c.Error(http.StatusBadRequest, fmt.Sprintf("Unrecognized action %q", action))
 			return
 		}
 


### PR DESCRIPTION
### Describe the pull request

The meaning of `NotFound` method has been changed since https://github.com/gogs/gogs/commit/07818d5fa5aef7dd7dca1d556f59c7a146a9b00c, which doesn't response anything to the client but a utility method from the router.

Link to the issue: fixes #6963

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [ ] I have added test cases to cover the new code.
