### PR TITLE
pull: ignore PR status check if head repository is missing

### DIFF
--- a/internal/db/pull.go
+++ b/internal/db/pull.go
@@ -621,11 +621,6 @@ func (pr *PullRequest) UpdateCols(cols ...string) error {
 
 // UpdatePatch generates and saves a new patch.
 func (pr *PullRequest) UpdatePatch() (err error) {
-	if pr.HeadRepo == nil {
-		log.Trace("PullRequest[%d].UpdatePatch: ignored corrupted data", pr.ID)
-		return nil
-	}
-
 	headGitRepo, err := git.Open(pr.HeadRepo.RepoPath())
 	if err != nil {
 		return fmt.Errorf("open repository: %v", err)
@@ -759,6 +754,11 @@ func (prs PullRequestList) LoadAttributes() error {
 
 func addHeadRepoTasks(prs []*PullRequest) {
 	for _, pr := range prs {
+		if pr.HeadRepo == nil {
+			log.Trace("addHeadRepoTasks[%d]: missing head repository", pr.ID)
+			continue
+		}
+
 		log.Trace("addHeadRepoTasks[%d]: composing new test task", pr.ID)
 		if err := pr.UpdatePatch(); err != nil {
 			log.Error("UpdatePatch: %v", err)


### PR DESCRIPTION
### Describe the pull request

It does not make sense to proceed for either `UpdatePatch` or `PushToBaseRepo` if the head repository is missing. Previously was only checked for `UpdatePatch`, which would still cause panic for calls to `PushToBaseRepo`.

Link to the issue: https://github.com/gogs/gogs/issues/6963

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [ ] I have added test cases to cover the new code.
