### PR TITLE
db: use `context` and go-mockgen for `PermsStore`

### DIFF
--- a/internal/cmd/serv.go
+++ b/internal/cmd/serv.go
@@ -5,6 +5,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -208,7 +209,7 @@ func runServ(c *cli.Context) error {
 				fail("Internal error", "Failed to get user by key ID '%d': %v", key.ID, err)
 			}
 
-			mode := db.Perms.AccessMode(user.ID, repo.ID,
+			mode := db.Perms.AccessMode(context.Background(), user.ID, repo.ID,
 				db.AccessModeOptions{
 					OwnerID: repo.OwnerID,
 					Private: repo.IsPrivate,

--- a/internal/context/repo.go
+++ b/internal/context/repo.go
@@ -170,7 +170,7 @@ func RepoAssignment(pages ...bool) macaron.Handler {
 		if c.IsLogged && c.User.IsAdmin {
 			c.Repo.AccessMode = db.AccessModeOwner
 		} else {
-			c.Repo.AccessMode = db.Perms.AccessMode(c.UserID(), repo.ID,
+			c.Repo.AccessMode = db.Perms.AccessMode(c.Req.Context(), c.UserID(), repo.ID,
 				db.AccessModeOptions{
 					OwnerID: repo.OwnerID,
 					Private: repo.IsPrivate,
@@ -181,7 +181,7 @@ func RepoAssignment(pages ...bool) macaron.Handler {
 		// If the authenticated user has no direct access, see if the repository is a fork
 		// and whether the user has access to the base repository.
 		if c.Repo.AccessMode == db.AccessModeNone && repo.BaseRepo != nil {
-			mode := db.Perms.AccessMode(c.UserID(), repo.BaseRepo.ID,
+			mode := db.Perms.AccessMode(c.Req.Context(), c.UserID(), repo.BaseRepo.ID,
 				db.AccessModeOptions{
 					OwnerID: repo.BaseRepo.OwnerID,
 					Private: repo.BaseRepo.IsPrivate,

--- a/internal/db/access_tokens_test.go
+++ b/internal/db/access_tokens_test.go
@@ -66,9 +66,7 @@ func TestAccessTokens(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Cleanup(func() {
 				err := clearTables(t, db.DB, tables...)
-				if err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, err)
 			})
 			tc.test(t, db)
 		})
@@ -123,8 +121,8 @@ func accessTokensDeleteByID(t *testing.T, db *accessTokens) {
 
 	// We should get token not found error
 	_, err = db.GetBySHA1(ctx, token.Sha1)
-	expErr := ErrAccessTokenNotExist{args: errutil.Args{"sha": token.Sha1}}
-	assert.Equal(t, expErr, err)
+	wantErr := ErrAccessTokenNotExist{args: errutil.Args{"sha": token.Sha1}}
+	assert.Equal(t, wantErr, err)
 }
 
 func accessTokensGetBySHA(t *testing.T, db *accessTokens) {
@@ -140,8 +138,8 @@ func accessTokensGetBySHA(t *testing.T, db *accessTokens) {
 
 	// Try to get a non-existent token
 	_, err = db.GetBySHA1(ctx, "bad_sha")
-	expErr := ErrAccessTokenNotExist{args: errutil.Args{"sha": "bad_sha"}}
-	assert.Equal(t, expErr, err)
+	wantErr := ErrAccessTokenNotExist{args: errutil.Args{"sha": "bad_sha"}}
+	assert.Equal(t, wantErr, err)
 }
 
 func accessTokensList(t *testing.T, db *accessTokens) {

--- a/internal/db/mock_gen.go
+++ b/internal/db/mock_gen.go
@@ -10,7 +10,7 @@ import (
 	"gogs.io/gogs/internal/lfsutil"
 )
 
-//go:generate go-mockgen -f gogs.io/gogs/internal/db -i AccessTokensStore -o mocks.go
+//go:generate go-mockgen -f gogs.io/gogs/internal/db -i AccessTokensStore -i PermsStore -o mocks.go
 
 func SetMockAccessTokensStore(t *testing.T, mock AccessTokensStore) {
 	before := AccessTokens
@@ -99,26 +99,6 @@ func (m *mockLoginSourceFileStore) SetConfig(cfg interface{}) error {
 
 func (m *mockLoginSourceFileStore) Save() error {
 	return m.MockSave()
-}
-
-var _ PermsStore = (*MockPermsStore)(nil)
-
-type MockPermsStore struct {
-	MockAccessMode   func(userID, repoID int64, opts AccessModeOptions) AccessMode
-	MockAuthorize    func(userID, repoID int64, desired AccessMode, opts AccessModeOptions) bool
-	MockSetRepoPerms func(repoID int64, accessMap map[int64]AccessMode) error
-}
-
-func (m *MockPermsStore) AccessMode(userID, repoID int64, opts AccessModeOptions) AccessMode {
-	return m.MockAccessMode(userID, repoID, opts)
-}
-
-func (m *MockPermsStore) Authorize(userID, repoID int64, desired AccessMode, opts AccessModeOptions) bool {
-	return m.MockAuthorize(userID, repoID, desired, opts)
-}
-
-func (m *MockPermsStore) SetRepoPerms(repoID int64, accessMap map[int64]AccessMode) error {
-	return m.MockSetRepoPerms(repoID, accessMap)
 }
 
 func SetMockPermsStore(t *testing.T, mock PermsStore) {

--- a/internal/db/perms_test.go
+++ b/internal/db/perms_test.go
@@ -5,12 +5,14 @@
 package db
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func Test_perms(t *testing.T) {
+func TestPerms(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -26,16 +28,14 @@ func Test_perms(t *testing.T) {
 		name string
 		test func(*testing.T, *perms)
 	}{
-		{"AccessMode", test_perms_AccessMode},
-		{"Authorize", test_perms_Authorize},
-		{"SetRepoPerms", test_perms_SetRepoPerms},
+		{"AccessMode", permsAccessMode},
+		{"Authorize", permsAuthorize},
+		{"SetRepoPerms", permsSetRepoPerms},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Cleanup(func() {
 				err := clearTables(t, db.DB, tables...)
-				if err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, err)
 			})
 			tc.test(t, db)
 		})
@@ -45,21 +45,23 @@ func Test_perms(t *testing.T) {
 	}
 }
 
-func test_perms_AccessMode(t *testing.T, db *perms) {
+func permsAccessMode(t *testing.T, db *perms) {
+	ctx := context.Background()
+
 	// Set up permissions
-	err := db.SetRepoPerms(1, map[int64]AccessMode{
-		2: AccessModeWrite,
-		3: AccessModeAdmin,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = db.SetRepoPerms(2, map[int64]AccessMode{
-		1: AccessModeRead,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	err := db.SetRepoPerms(ctx, 1,
+		map[int64]AccessMode{
+			2: AccessModeWrite,
+			3: AccessModeAdmin,
+		},
+	)
+	require.NoError(t, err)
+	err = db.SetRepoPerms(ctx, 2,
+		map[int64]AccessMode{
+			1: AccessModeRead,
+		},
+	)
+	require.NoError(t, err)
 
 	publicRepoID := int64(1)
 	publicRepoOpts := AccessModeOptions{
@@ -73,99 +75,101 @@ func test_perms_AccessMode(t *testing.T, db *perms) {
 	}
 
 	tests := []struct {
-		name          string
-		userID        int64
-		repoID        int64
-		opts          AccessModeOptions
-		expAccessMode AccessMode
+		name           string
+		userID         int64
+		repoID         int64
+		opts           AccessModeOptions
+		wantAccessMode AccessMode
 	}{
 		{
-			name:          "nil repository",
-			expAccessMode: AccessModeNone,
+			name:           "nil repository",
+			wantAccessMode: AccessModeNone,
 		},
 
 		{
-			name:          "anonymous user has read access to public repository",
-			repoID:        publicRepoID,
-			opts:          publicRepoOpts,
-			expAccessMode: AccessModeRead,
+			name:           "anonymous user has read access to public repository",
+			repoID:         publicRepoID,
+			opts:           publicRepoOpts,
+			wantAccessMode: AccessModeRead,
 		},
 		{
-			name:          "anonymous user has no access to private repository",
-			repoID:        privateRepoID,
-			opts:          privateRepoOpts,
-			expAccessMode: AccessModeNone,
-		},
-
-		{
-			name:          "user is the owner",
-			userID:        98,
-			repoID:        publicRepoID,
-			opts:          publicRepoOpts,
-			expAccessMode: AccessModeOwner,
-		},
-		{
-			name:          "user 1 has read access to public repo",
-			userID:        1,
-			repoID:        publicRepoID,
-			opts:          publicRepoOpts,
-			expAccessMode: AccessModeRead,
-		},
-		{
-			name:          "user 2 has write access to public repo",
-			userID:        2,
-			repoID:        publicRepoID,
-			opts:          publicRepoOpts,
-			expAccessMode: AccessModeWrite,
-		},
-		{
-			name:          "user 3 has admin access to public repo",
-			userID:        3,
-			repoID:        publicRepoID,
-			opts:          publicRepoOpts,
-			expAccessMode: AccessModeAdmin,
+			name:           "anonymous user has no access to private repository",
+			repoID:         privateRepoID,
+			opts:           privateRepoOpts,
+			wantAccessMode: AccessModeNone,
 		},
 
 		{
-			name:          "user 1 has read access to private repo",
-			userID:        1,
-			repoID:        privateRepoID,
-			opts:          privateRepoOpts,
-			expAccessMode: AccessModeRead,
+			name:           "user is the owner",
+			userID:         98,
+			repoID:         publicRepoID,
+			opts:           publicRepoOpts,
+			wantAccessMode: AccessModeOwner,
 		},
 		{
-			name:          "user 2 has no access to private repo",
-			userID:        2,
-			repoID:        privateRepoID,
-			opts:          privateRepoOpts,
-			expAccessMode: AccessModeNone,
+			name:           "user 1 has read access to public repo",
+			userID:         1,
+			repoID:         publicRepoID,
+			opts:           publicRepoOpts,
+			wantAccessMode: AccessModeRead,
 		},
 		{
-			name:          "user 3 has no access to private repo",
-			userID:        3,
-			repoID:        privateRepoID,
-			opts:          privateRepoOpts,
-			expAccessMode: AccessModeNone,
+			name:           "user 2 has write access to public repo",
+			userID:         2,
+			repoID:         publicRepoID,
+			opts:           publicRepoOpts,
+			wantAccessMode: AccessModeWrite,
+		},
+		{
+			name:           "user 3 has admin access to public repo",
+			userID:         3,
+			repoID:         publicRepoID,
+			opts:           publicRepoOpts,
+			wantAccessMode: AccessModeAdmin,
+		},
+
+		{
+			name:           "user 1 has read access to private repo",
+			userID:         1,
+			repoID:         privateRepoID,
+			opts:           privateRepoOpts,
+			wantAccessMode: AccessModeRead,
+		},
+		{
+			name:           "user 2 has no access to private repo",
+			userID:         2,
+			repoID:         privateRepoID,
+			opts:           privateRepoOpts,
+			wantAccessMode: AccessModeNone,
+		},
+		{
+			name:           "user 3 has no access to private repo",
+			userID:         3,
+			repoID:         privateRepoID,
+			opts:           privateRepoOpts,
+			wantAccessMode: AccessModeNone,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			mode := db.AccessMode(test.userID, test.repoID, test.opts)
-			assert.Equal(t, test.expAccessMode, mode)
+			mode := db.AccessMode(ctx, test.userID, test.repoID, test.opts)
+			assert.Equal(t, test.wantAccessMode, mode)
 		})
 	}
 }
 
-func test_perms_Authorize(t *testing.T, db *perms) {
+func permsAuthorize(t *testing.T, db *perms) {
+	ctx := context.Background()
+
 	// Set up permissions
-	err := db.SetRepoPerms(1, map[int64]AccessMode{
-		1: AccessModeRead,
-		2: AccessModeWrite,
-		3: AccessModeAdmin,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	err := db.SetRepoPerms(ctx, 1,
+		map[int64]AccessMode{
+			1: AccessModeRead,
+			2: AccessModeWrite,
+			3: AccessModeAdmin,
+		},
+	)
+	require.NoError(t, err)
 
 	repo := &Repository{
 		ID:      1,
@@ -173,74 +177,78 @@ func test_perms_Authorize(t *testing.T, db *perms) {
 	}
 
 	tests := []struct {
-		name          string
-		userID        int64
-		desired       AccessMode
-		expAuthorized bool
+		name           string
+		userID         int64
+		desired        AccessMode
+		wantAuthorized bool
 	}{
 		{
-			name:          "user 1 has read and wants read",
-			userID:        1,
-			desired:       AccessModeRead,
-			expAuthorized: true,
+			name:           "user 1 has read and wants read",
+			userID:         1,
+			desired:        AccessModeRead,
+			wantAuthorized: true,
 		},
 		{
-			name:          "user 1 has read and wants write",
-			userID:        1,
-			desired:       AccessModeWrite,
-			expAuthorized: false,
-		},
-
-		{
-			name:          "user 2 has write and wants read",
-			userID:        2,
-			desired:       AccessModeRead,
-			expAuthorized: true,
-		},
-		{
-			name:          "user 2 has write and wants write",
-			userID:        2,
-			desired:       AccessModeWrite,
-			expAuthorized: true,
-		},
-		{
-			name:          "user 2 has write and wants admin",
-			userID:        2,
-			desired:       AccessModeAdmin,
-			expAuthorized: false,
+			name:           "user 1 has read and wants write",
+			userID:         1,
+			desired:        AccessModeWrite,
+			wantAuthorized: false,
 		},
 
 		{
-			name:          "user 3 has admin and wants read",
-			userID:        3,
-			desired:       AccessModeRead,
-			expAuthorized: true,
+			name:           "user 2 has write and wants read",
+			userID:         2,
+			desired:        AccessModeRead,
+			wantAuthorized: true,
 		},
 		{
-			name:          "user 3 has admin and wants write",
-			userID:        3,
-			desired:       AccessModeWrite,
-			expAuthorized: true,
+			name:           "user 2 has write and wants write",
+			userID:         2,
+			desired:        AccessModeWrite,
+			wantAuthorized: true,
 		},
 		{
-			name:          "user 3 has admin and wants admin",
-			userID:        3,
-			desired:       AccessModeAdmin,
-			expAuthorized: true,
+			name:           "user 2 has write and wants admin",
+			userID:         2,
+			desired:        AccessModeAdmin,
+			wantAuthorized: false,
+		},
+
+		{
+			name:           "user 3 has admin and wants read",
+			userID:         3,
+			desired:        AccessModeRead,
+			wantAuthorized: true,
+		},
+		{
+			name:           "user 3 has admin and wants write",
+			userID:         3,
+			desired:        AccessModeWrite,
+			wantAuthorized: true,
+		},
+		{
+			name:           "user 3 has admin and wants admin",
+			userID:         3,
+			desired:        AccessModeAdmin,
+			wantAuthorized: true,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			authorized := db.Authorize(test.userID, repo.ID, test.desired, AccessModeOptions{
-				OwnerID: repo.OwnerID,
-				Private: repo.IsPrivate,
-			})
-			assert.Equal(t, test.expAuthorized, authorized)
+			authorized := db.Authorize(ctx, test.userID, repo.ID, test.desired,
+				AccessModeOptions{
+					OwnerID: repo.OwnerID,
+					Private: repo.IsPrivate,
+				},
+			)
+			assert.Equal(t, test.wantAuthorized, authorized)
 		})
 	}
 }
 
-func test_perms_SetRepoPerms(t *testing.T, db *perms) {
+func permsSetRepoPerms(t *testing.T, db *perms) {
+	ctx := context.Background()
+
 	for _, update := range []struct {
 		repoID    int64
 		accessMap map[int64]AccessMode
@@ -279,7 +287,7 @@ func test_perms_SetRepoPerms(t *testing.T, db *perms) {
 			},
 		},
 	} {
-		err := db.SetRepoPerms(update.repoID, update.accessMap)
+		err := db.SetRepoPerms(ctx, update.repoID, update.accessMap)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -287,21 +295,19 @@ func test_perms_SetRepoPerms(t *testing.T, db *perms) {
 
 	var accesses []*Access
 	err := db.Order("user_id, repo_id").Find(&accesses).Error
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// Ignore ID fields
 	for _, a := range accesses {
 		a.ID = 0
 	}
 
-	expAccesses := []*Access{
+	wantAccesses := []*Access{
 		{UserID: 1, RepoID: 2, Mode: AccessModeWrite},
 		{UserID: 2, RepoID: 1, Mode: AccessModeWrite},
 		{UserID: 2, RepoID: 2, Mode: AccessModeRead},
 		{UserID: 3, RepoID: 1, Mode: AccessModeAdmin},
 		{UserID: 5, RepoID: 2, Mode: AccessModeWrite},
 	}
-	assert.Equal(t, expAccesses, accesses)
+	assert.Equal(t, wantAccesses, accesses)
 }

--- a/internal/db/repo.go
+++ b/internal/db/repo.go
@@ -6,6 +6,7 @@ package db
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"image"
 	_ "image/jpeg"
@@ -557,7 +558,7 @@ func (repo *Repository) ComposeCompareURL(oldCommitID, newCommitID string) strin
 }
 
 func (repo *Repository) HasAccess(userID int64) bool {
-	return Perms.Authorize(userID, repo.ID, AccessModeRead,
+	return Perms.Authorize(context.TODO(), userID, repo.ID, AccessModeRead,
 		AccessModeOptions{
 			OwnerID: repo.OwnerID,
 			Private: repo.IsPrivate,

--- a/internal/db/repo_branch.go
+++ b/internal/db/repo_branch.go
@@ -5,6 +5,7 @@
 package db
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -175,7 +176,7 @@ func UpdateOrgProtectBranch(repo *Repository, protectBranch *ProtectBranch, whit
 		userIDs := tool.StringsToInt64s(strings.Split(whitelistUserIDs, ","))
 		validUserIDs = make([]int64, 0, len(userIDs))
 		for _, userID := range userIDs {
-			if !Perms.Authorize(userID, repo.ID, AccessModeWrite,
+			if !Perms.Authorize(context.TODO(), userID, repo.ID, AccessModeWrite,
 				AccessModeOptions{
 					OwnerID: repo.OwnerID,
 					Private: repo.IsPrivate,

--- a/internal/db/ssh_key.go
+++ b/internal/db/ssh_key.go
@@ -5,6 +5,7 @@
 package db
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/binary"
 	"errors"
@@ -752,7 +753,7 @@ func DeleteDeployKey(doer *User, id int64) error {
 		if err != nil {
 			return fmt.Errorf("GetRepositoryByID: %v", err)
 		}
-		if !Perms.Authorize(doer.ID, repo.ID, AccessModeAdmin,
+		if !Perms.Authorize(context.TODO(), doer.ID, repo.ID, AccessModeAdmin,
 			AccessModeOptions{
 				OwnerID: repo.OwnerID,
 				Private: repo.IsPrivate,

--- a/internal/db/user.go
+++ b/internal/db/user.go
@@ -6,6 +6,7 @@ package db
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/hex"
@@ -369,7 +370,7 @@ func (u *User) DeleteAvatar() error {
 
 // IsAdminOfRepo returns true if user has admin or higher access of repository.
 func (u *User) IsAdminOfRepo(repo *Repository) bool {
-	return Perms.Authorize(u.ID, repo.ID, AccessModeAdmin,
+	return Perms.Authorize(context.TODO(), u.ID, repo.ID, AccessModeAdmin,
 		AccessModeOptions{
 			OwnerID: repo.OwnerID,
 			Private: repo.IsPrivate,
@@ -379,7 +380,7 @@ func (u *User) IsAdminOfRepo(repo *Repository) bool {
 
 // IsWriterOfRepo returns true if user has write access to given repository.
 func (u *User) IsWriterOfRepo(repo *Repository) bool {
-	return Perms.Authorize(u.ID, repo.ID, AccessModeWrite,
+	return Perms.Authorize(context.TODO(), u.ID, repo.ID, AccessModeWrite,
 		AccessModeOptions{
 			OwnerID: repo.OwnerID,
 			Private: repo.IsPrivate,
@@ -941,7 +942,7 @@ func GetUserByID(id int64) (*User, error) {
 
 // GetAssigneeByID returns the user with read access of repository by given ID.
 func GetAssigneeByID(repo *Repository, userID int64) (*User, error) {
-	if !Perms.Authorize(userID, repo.ID, AccessModeRead,
+	if !Perms.Authorize(context.TODO(), userID, repo.ID, AccessModeRead,
 		AccessModeOptions{
 			OwnerID: repo.OwnerID,
 			Private: repo.IsPrivate,

--- a/internal/route/api/v1/api.go
+++ b/internal/route/api/v1/api.go
@@ -57,7 +57,7 @@ func repoAssignment() macaron.Handler {
 		if c.IsTokenAuth && c.User.IsAdmin {
 			c.Repo.AccessMode = db.AccessModeOwner
 		} else {
-			c.Repo.AccessMode = db.Perms.AccessMode(c.UserID(), repo.ID,
+			c.Repo.AccessMode = db.Perms.AccessMode(c.Req.Context(), c.UserID(), repo.ID,
 				db.AccessModeOptions{
 					OwnerID: repo.OwnerID,
 					Private: repo.IsPrivate,

--- a/internal/route/lfs/route.go
+++ b/internal/route/lfs/route.go
@@ -130,7 +130,7 @@ func authorize(mode db.AccessMode) macaron.Handler {
 			return
 		}
 
-		if !db.Perms.Authorize(actor.ID, repo.ID, mode,
+		if !db.Perms.Authorize(c.Req.Context(), actor.ID, repo.ID, mode,
 			db.AccessModeOptions{
 				OwnerID: repo.OwnerID,
 				Private: repo.IsPrivate,

--- a/internal/route/repo/http.go
+++ b/internal/route/repo/http.go
@@ -166,7 +166,7 @@ Please create and use personal access token on user settings page`)
 		if isPull {
 			mode = db.AccessModeRead
 		}
-		if !db.Perms.Authorize(authUser.ID, repo.ID, mode,
+		if !db.Perms.Authorize(c.Req.Context(), authUser.ID, repo.ID, mode,
 			db.AccessModeOptions{
 				OwnerID: repo.OwnerID,
 				Private: repo.IsPrivate,


### PR DESCRIPTION
### Describe the pull request

1. Make all methods accept `context.Context`
2. Use go-mockgen to auto-generate mocks

Link to the issue: n/a

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [x] I have added test cases to cover the new code.
