### PR TITLE
web: enable `ETag` to improve loading speed of static resources 

### DIFF
--- a/internal/cmd/web.go
+++ b/internal/cmd/web.go
@@ -89,6 +89,7 @@ func newMacaron() *macaron.Macaron {
 	m.Use(macaron.Static(
 		filepath.Join(conf.WorkDir(), "public"),
 		macaron.StaticOptions{
+			ETag:        true,
 			SkipLogging: conf.Server.DisableRouterLog,
 			FileSystem:  publicFs,
 		},
@@ -97,6 +98,7 @@ func newMacaron() *macaron.Macaron {
 	m.Use(macaron.Static(
 		conf.Picture.AvatarUploadPath,
 		macaron.StaticOptions{
+			ETag:        true,
 			Prefix:      db.USER_AVATAR_URL_PREFIX,
 			SkipLogging: conf.Server.DisableRouterLog,
 		},
@@ -104,6 +106,7 @@ func newMacaron() *macaron.Macaron {
 	m.Use(macaron.Static(
 		conf.Picture.RepositoryAvatarUploadPath,
 		macaron.StaticOptions{
+			ETag:        true,
 			Prefix:      db.REPO_AVATAR_URL_PREFIX,
 			SkipLogging: conf.Server.DisableRouterLog,
 		},


### PR DESCRIPTION
### Describe the pull request

enable etag header when serving static js&css file.  works well in my playground.

before:

<img width="1437" alt="截屏2022-06-08 18 22 55" src="https://user-images.githubusercontent.com/26156827/172604665-9a36018d-41be-4519-a5e7-c2ae43f095f0.png">

after:

<img width="1435" alt="截屏2022-06-08 18 52 30" src="https://user-images.githubusercontent.com/26156827/172604755-94cf7120-e30c-4a12-868d-2926094fed80.png">

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [ ] I have added test cases to cover the new code.
