### PR TITLE
db: use `context` and go-mockgen for `LFSStore`

### DIFF
--- a/internal/db/lfs_test.go
+++ b/internal/db/lfs_test.go
@@ -5,16 +5,18 @@
 package db
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"gogs.io/gogs/internal/errutil"
 	"gogs.io/gogs/internal/lfsutil"
 )
 
-func Test_lfs(t *testing.T) {
+func TestLFS(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -30,16 +32,14 @@ func Test_lfs(t *testing.T) {
 		name string
 		test func(*testing.T, *lfs)
 	}{
-		{"CreateObject", test_lfs_CreateObject},
-		{"GetObjectByOID", test_lfs_GetObjectByOID},
-		{"GetObjectsByOIDs", test_lfs_GetObjectsByOIDs},
+		{"CreateObject", lfsCreateObject},
+		{"GetObjectByOID", lfsGetObjectByOID},
+		{"GetObjectsByOIDs", lfsGetObjectsByOIDs},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Cleanup(func() {
 				err := clearTables(t, db.DB, tables...)
-				if err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, err)
 			})
 			tc.test(t, db)
 		})
@@ -49,67 +49,59 @@ func Test_lfs(t *testing.T) {
 	}
 }
 
-func test_lfs_CreateObject(t *testing.T, db *lfs) {
+func lfsCreateObject(t *testing.T, db *lfs) {
+	ctx := context.Background()
+
 	// Create first LFS object
 	repoID := int64(1)
 	oid := lfsutil.OID("ef797c8118f02dfb649607dd5d3f8c7623048c9c063d532cc95c5ed7a898a64f")
-	err := db.CreateObject(repoID, oid, 12, lfsutil.StorageLocal)
-	if err != nil {
-		t.Fatal(err)
-	}
+	err := db.CreateObject(ctx, repoID, oid, 12, lfsutil.StorageLocal)
+	require.NoError(t, err)
 
 	// Get it back and check the CreatedAt field
-	object, err := db.GetObjectByOID(repoID, oid)
-	if err != nil {
-		t.Fatal(err)
-	}
+	object, err := db.GetObjectByOID(ctx, repoID, oid)
+	require.NoError(t, err)
 	assert.Equal(t, db.NowFunc().Format(time.RFC3339), object.CreatedAt.UTC().Format(time.RFC3339))
 
 	// Try create second LFS object with same oid should fail
-	err = db.CreateObject(repoID, oid, 12, lfsutil.StorageLocal)
+	err = db.CreateObject(ctx, repoID, oid, 12, lfsutil.StorageLocal)
 	assert.Error(t, err)
 }
 
-func test_lfs_GetObjectByOID(t *testing.T, db *lfs) {
+func lfsGetObjectByOID(t *testing.T, db *lfs) {
+	ctx := context.Background()
+
 	// Create a LFS object
 	repoID := int64(1)
 	oid := lfsutil.OID("ef797c8118f02dfb649607dd5d3f8c7623048c9c063d532cc95c5ed7a898a64f")
-	err := db.CreateObject(repoID, oid, 12, lfsutil.StorageLocal)
-	if err != nil {
-		t.Fatal(err)
-	}
+	err := db.CreateObject(ctx, repoID, oid, 12, lfsutil.StorageLocal)
+	require.NoError(t, err)
 
 	// We should be able to get it back
-	_, err = db.GetObjectByOID(repoID, oid)
-	if err != nil {
-		t.Fatal(err)
-	}
+	_, err = db.GetObjectByOID(ctx, repoID, oid)
+	require.NoError(t, err)
 
 	// Try to get a non-existent object
-	_, err = db.GetObjectByOID(repoID, "bad_oid")
+	_, err = db.GetObjectByOID(ctx, repoID, "bad_oid")
 	expErr := ErrLFSObjectNotExist{args: errutil.Args{"repoID": repoID, "oid": lfsutil.OID("bad_oid")}}
 	assert.Equal(t, expErr, err)
 }
 
-func test_lfs_GetObjectsByOIDs(t *testing.T, db *lfs) {
+func lfsGetObjectsByOIDs(t *testing.T, db *lfs) {
+	ctx := context.Background()
+
 	// Create two LFS objects
 	repoID := int64(1)
 	oid1 := lfsutil.OID("ef797c8118f02dfb649607dd5d3f8c7623048c9c063d532cc95c5ed7a898a64f")
 	oid2 := lfsutil.OID("ef797c8118f02dfb649607dd5d3f8c7623048c9c063d532cc95c5ed7a898a64g")
-	err := db.CreateObject(repoID, oid1, 12, lfsutil.StorageLocal)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = db.CreateObject(repoID, oid2, 12, lfsutil.StorageLocal)
-	if err != nil {
-		t.Fatal(err)
-	}
+	err := db.CreateObject(ctx, repoID, oid1, 12, lfsutil.StorageLocal)
+	require.NoError(t, err)
+	err = db.CreateObject(ctx, repoID, oid2, 12, lfsutil.StorageLocal)
+	require.NoError(t, err)
 
 	// We should be able to get them back and ignore non-existent ones
-	objects, err := db.GetObjectsByOIDs(repoID, oid1, oid2, "bad_oid")
-	if err != nil {
-		t.Fatal(err)
-	}
+	objects, err := db.GetObjectsByOIDs(ctx, repoID, oid1, oid2, "bad_oid")
+	require.NoError(t, err)
 	assert.Equal(t, 2, len(objects), "number of objects")
 
 	assert.Equal(t, repoID, objects[0].RepoID)

--- a/internal/db/mock_gen.go
+++ b/internal/db/mock_gen.go
@@ -6,11 +6,9 @@ package db
 
 import (
 	"testing"
-
-	"gogs.io/gogs/internal/lfsutil"
 )
 
-//go:generate go-mockgen -f gogs.io/gogs/internal/db -i AccessTokensStore -i PermsStore -o mocks.go
+//go:generate go-mockgen -f gogs.io/gogs/internal/db -i AccessTokensStore -i LFSStore -i PermsStore -o mocks.go
 
 func SetMockAccessTokensStore(t *testing.T, mock AccessTokensStore) {
 	before := AccessTokens
@@ -18,26 +16,6 @@ func SetMockAccessTokensStore(t *testing.T, mock AccessTokensStore) {
 	t.Cleanup(func() {
 		AccessTokens = before
 	})
-}
-
-var _ LFSStore = (*MockLFSStore)(nil)
-
-type MockLFSStore struct {
-	MockCreateObject     func(repoID int64, oid lfsutil.OID, size int64, storage lfsutil.Storage) error
-	MockGetObjectByOID   func(repoID int64, oid lfsutil.OID) (*LFSObject, error)
-	MockGetObjectsByOIDs func(repoID int64, oids ...lfsutil.OID) ([]*LFSObject, error)
-}
-
-func (m *MockLFSStore) CreateObject(repoID int64, oid lfsutil.OID, size int64, storage lfsutil.Storage) error {
-	return m.MockCreateObject(repoID, oid, size, storage)
-}
-
-func (m *MockLFSStore) GetObjectByOID(repoID int64, oid lfsutil.OID) (*LFSObject, error) {
-	return m.MockGetObjectByOID(repoID, oid)
-}
-
-func (m *MockLFSStore) GetObjectsByOIDs(repoID int64, oids ...lfsutil.OID) ([]*LFSObject, error) {
-	return m.MockGetObjectsByOIDs(repoID, oids...)
 }
 
 func SetMockLFSStore(t *testing.T, mock LFSStore) {

--- a/internal/route/lfs/basic_test.go
+++ b/internal/route/lfs/basic_test.go
@@ -70,7 +70,7 @@ func Test_basicHandler_serveDownload(t *testing.T) {
 			name: "object does not exist",
 			mockLFSStore: func() db.LFSStore {
 				mock := db.NewMockLFSStore()
-				mock.GetObjectsByOIDsFunc.SetDefaultReturn(nil, db.ErrLFSObjectNotExist{})
+				mock.GetObjectByOIDFunc.SetDefaultReturn(nil, db.ErrLFSObjectNotExist{})
 				return mock
 			},
 			expStatusCode: http.StatusNotFound,

--- a/internal/route/lfs/basic_test.go
+++ b/internal/route/lfs/basic_test.go
@@ -61,17 +61,17 @@ func Test_basicHandler_serveDownload(t *testing.T) {
 	tests := []struct {
 		name          string
 		content       string
-		mockLFSStore  *db.MockLFSStore
+		mockLFSStore  func() db.LFSStore
 		expStatusCode int
 		expHeader     http.Header
 		expBody       string
 	}{
 		{
 			name: "object does not exist",
-			mockLFSStore: &db.MockLFSStore{
-				MockGetObjectByOID: func(repoID int64, oid lfsutil.OID) (*db.LFSObject, error) {
-					return nil, db.ErrLFSObjectNotExist{}
-				},
+			mockLFSStore: func() db.LFSStore {
+				mock := db.NewMockLFSStore()
+				mock.GetObjectsByOIDsFunc.SetDefaultReturn(nil, db.ErrLFSObjectNotExist{})
+				return mock
 			},
 			expStatusCode: http.StatusNotFound,
 			expHeader: http.Header{
@@ -81,10 +81,10 @@ func Test_basicHandler_serveDownload(t *testing.T) {
 		},
 		{
 			name: "storage not found",
-			mockLFSStore: &db.MockLFSStore{
-				MockGetObjectByOID: func(repoID int64, oid lfsutil.OID) (*db.LFSObject, error) {
-					return &db.LFSObject{Storage: "bad_storage"}, nil
-				},
+			mockLFSStore: func() db.LFSStore {
+				mock := db.NewMockLFSStore()
+				mock.GetObjectByOIDFunc.SetDefaultReturn(&db.LFSObject{Storage: "bad_storage"}, nil)
+				return mock
 			},
 			expStatusCode: http.StatusInternalServerError,
 			expHeader: http.Header{
@@ -96,13 +96,16 @@ func Test_basicHandler_serveDownload(t *testing.T) {
 		{
 			name:    "object exists",
 			content: "Hello world!",
-			mockLFSStore: &db.MockLFSStore{
-				MockGetObjectByOID: func(repoID int64, oid lfsutil.OID) (*db.LFSObject, error) {
-					return &db.LFSObject{
+			mockLFSStore: func() db.LFSStore {
+				mock := db.NewMockLFSStore()
+				mock.GetObjectByOIDFunc.SetDefaultReturn(
+					&db.LFSObject{
 						Size:    12,
 						Storage: s.Storage(),
-					}, nil
-				},
+					},
+					nil,
+				)
+				return mock
 			},
 			expStatusCode: http.StatusOK,
 			expHeader: http.Header{
@@ -114,7 +117,7 @@ func Test_basicHandler_serveDownload(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			db.SetMockLFSStore(t, test.mockLFSStore)
+			db.SetMockLFSStore(t, test.mockLFSStore())
 
 			s.buf = bytes.NewBufferString(test.content)
 
@@ -158,35 +161,32 @@ func Test_basicHandler_serveUpload(t *testing.T) {
 
 	tests := []struct {
 		name          string
-		mockLFSStore  *db.MockLFSStore
+		mockLFSStore  func() db.LFSStore
 		expStatusCode int
 		expBody       string
 	}{
 		{
 			name: "object already exists",
-			mockLFSStore: &db.MockLFSStore{
-				MockGetObjectByOID: func(repoID int64, oid lfsutil.OID) (*db.LFSObject, error) {
-					return &db.LFSObject{}, nil
-				},
+			mockLFSStore: func() db.LFSStore {
+				mock := db.NewMockLFSStore()
+				mock.GetObjectByOIDFunc.SetDefaultReturn(&db.LFSObject{}, nil)
+				return mock
 			},
 			expStatusCode: http.StatusOK,
 		},
 		{
 			name: "new object",
-			mockLFSStore: &db.MockLFSStore{
-				MockGetObjectByOID: func(repoID int64, oid lfsutil.OID) (*db.LFSObject, error) {
-					return nil, db.ErrLFSObjectNotExist{}
-				},
-				MockCreateObject: func(repoID int64, oid lfsutil.OID, size int64, storage lfsutil.Storage) error {
-					return nil
-				},
+			mockLFSStore: func() db.LFSStore {
+				mock := db.NewMockLFSStore()
+				mock.GetObjectByOIDFunc.SetDefaultReturn(nil, db.ErrLFSObjectNotExist{})
+				return mock
 			},
 			expStatusCode: http.StatusOK,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			db.SetMockLFSStore(t, test.mockLFSStore)
+			db.SetMockLFSStore(t, test.mockLFSStore())
 
 			r, err := http.NewRequest("PUT", "/", strings.NewReader("Hello world!"))
 			if err != nil {
@@ -219,7 +219,7 @@ func Test_basicHandler_serveVerify(t *testing.T) {
 	tests := []struct {
 		name          string
 		body          string
-		mockLFSStore  *db.MockLFSStore
+		mockLFSStore  func() db.LFSStore
 		expStatusCode int
 		expBody       string
 	}{
@@ -232,10 +232,10 @@ func Test_basicHandler_serveVerify(t *testing.T) {
 		{
 			name: "object does not exist",
 			body: `{"oid":"ef797c8118f02dfb649607dd5d3f8c7623048c9c063d532cc95c5ed7a898a64f"}`,
-			mockLFSStore: &db.MockLFSStore{
-				MockGetObjectByOID: func(repoID int64, oid lfsutil.OID) (*db.LFSObject, error) {
-					return nil, db.ErrLFSObjectNotExist{}
-				},
+			mockLFSStore: func() db.LFSStore {
+				mock := db.NewMockLFSStore()
+				mock.GetObjectByOIDFunc.SetDefaultReturn(nil, db.ErrLFSObjectNotExist{})
+				return mock
 			},
 			expStatusCode: http.StatusNotFound,
 			expBody:       `{"message":"Object does not exist"}` + "\n",
@@ -243,10 +243,10 @@ func Test_basicHandler_serveVerify(t *testing.T) {
 		{
 			name: "object size mismatch",
 			body: `{"oid":"ef797c8118f02dfb649607dd5d3f8c7623048c9c063d532cc95c5ed7a898a64f"}`,
-			mockLFSStore: &db.MockLFSStore{
-				MockGetObjectByOID: func(repoID int64, oid lfsutil.OID) (*db.LFSObject, error) {
-					return &db.LFSObject{Size: 12}, nil
-				},
+			mockLFSStore: func() db.LFSStore {
+				mock := db.NewMockLFSStore()
+				mock.GetObjectByOIDFunc.SetDefaultReturn(&db.LFSObject{Size: 12}, nil)
+				return mock
 			},
 			expStatusCode: http.StatusBadRequest,
 			expBody:       `{"message":"Object size mismatch"}` + "\n",
@@ -255,17 +255,17 @@ func Test_basicHandler_serveVerify(t *testing.T) {
 		{
 			name: "object exists",
 			body: `{"oid":"ef797c8118f02dfb649607dd5d3f8c7623048c9c063d532cc95c5ed7a898a64f", "size":12}`,
-			mockLFSStore: &db.MockLFSStore{
-				MockGetObjectByOID: func(repoID int64, oid lfsutil.OID) (*db.LFSObject, error) {
-					return &db.LFSObject{Size: 12}, nil
-				},
+			mockLFSStore: func() db.LFSStore {
+				mock := db.NewMockLFSStore()
+				mock.GetObjectByOIDFunc.SetDefaultReturn(&db.LFSObject{Size: 12}, nil)
+				return mock
 			},
 			expStatusCode: http.StatusOK,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			db.SetMockLFSStore(t, test.mockLFSStore)
+			db.SetMockLFSStore(t, test.mockLFSStore())
 
 			r, err := http.NewRequest("POST", "/", strings.NewReader(test.body))
 			if err != nil {

--- a/internal/route/lfs/basic_test.go
+++ b/internal/route/lfs/basic_test.go
@@ -265,7 +265,9 @@ func Test_basicHandler_serveVerify(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			db.SetMockLFSStore(t, test.mockLFSStore())
+			if test.mockLFSStore != nil {
+				db.SetMockLFSStore(t, test.mockLFSStore())
+			}
 
 			r, err := http.NewRequest("POST", "/", strings.NewReader(test.body))
 			if err != nil {

--- a/internal/route/lfs/batch.go
+++ b/internal/route/lfs/batch.go
@@ -75,7 +75,7 @@ func serveBatch(c *macaron.Context, owner *db.User, repo *db.Repository) {
 		for _, obj := range request.Objects {
 			oids = append(oids, obj.Oid)
 		}
-		stored, err := db.LFS.GetObjectsByOIDs(repo.ID, oids...)
+		stored, err := db.LFS.GetObjectsByOIDs(c.Req.Context(), repo.ID, oids...)
 		if err != nil {
 			internalServerError(c.Resp)
 			log.Error("Failed to get objects [repo_id: %d, oids: %v]: %v", repo.ID, oids, err)


### PR DESCRIPTION
### Describe the pull request

1. Make all methods accept `context.Context`
2. Use go-mockgen to auto-generate mocks

Link to the issue: n/a

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [x] I have added test cases to cover the new code.
