### PR TITLE
db: use `context` and go-mockgen for `ReposStore`

### DIFF
--- a/internal/context/go_get.go
+++ b/internal/context/go_get.go
@@ -28,7 +28,7 @@ func ServeGoGet() macaron.Handler {
 
 		owner, err := db.Users.GetByUsername(c.Req.Context(), ownerName)
 		if err == nil {
-			repo, err := db.Repos.GetByName(owner.ID, repoName)
+			repo, err := db.Repos.GetByName(c.Req.Context(), owner.ID, repoName)
 			if err == nil && repo.DefaultBranch != "" {
 				branchName = repo.DefaultBranch
 			}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -73,7 +73,7 @@ func newDSN(opts conf.DatabaseOpts) (dsn string, err error) {
 
 	case "postgres":
 		host, port := parsePostgreSQLHostPort(opts.Host)
-		dsn = fmt.Sprintf("user='%s' password='%s' host='%s' port='%s' dbname='%s' sslmode='%s' search_path='%s'",
+		dsn = fmt.Sprintf("user='%s' password='%s' host='%s' port='%s' dbname='%s' sslmode='%s' search_path='%s' application_name='gogs'",
 			opts.User, opts.Password, host, port, opts.Name, opts.SSLMode, opts.Schema)
 
 	case "mssql":

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -63,9 +63,9 @@ func Test_parseDSN(t *testing.T) {
 	})
 
 	tests := []struct {
-		name   string
-		opts   conf.DatabaseOpts
-		expDSN string
+		name    string
+		opts    conf.DatabaseOpts
+		wantDSN string
 	}{
 		{
 			name: "mysql: unix",
@@ -76,7 +76,7 @@ func Test_parseDSN(t *testing.T) {
 				User:     "gogs",
 				Password: "pa$$word",
 			},
-			expDSN: "gogs:pa$$word@unix(/tmp/mysql.sock)/gogs?charset=utf8mb4&parseTime=true",
+			wantDSN: "gogs:pa$$word@unix(/tmp/mysql.sock)/gogs?charset=utf8mb4&parseTime=true",
 		},
 		{
 			name: "mysql: tcp",
@@ -87,7 +87,7 @@ func Test_parseDSN(t *testing.T) {
 				User:     "gogs",
 				Password: "pa$$word",
 			},
-			expDSN: "gogs:pa$$word@tcp(localhost:3306)/gogs?charset=utf8mb4&parseTime=true",
+			wantDSN: "gogs:pa$$word@tcp(localhost:3306)/gogs?charset=utf8mb4&parseTime=true",
 		},
 
 		{
@@ -101,7 +101,7 @@ func Test_parseDSN(t *testing.T) {
 				Password: "pa$$word",
 				SSLMode:  "disable",
 			},
-			expDSN: "user='gogs@local' password='pa$$word' host='/tmp/pg.sock' port='5432' dbname='gogs' sslmode='disable' search_path='test'",
+			wantDSN: "user='gogs@local' password='pa$$word' host='/tmp/pg.sock' port='5432' dbname='gogs' sslmode='disable' search_path='test' application_name='gogs'",
 		},
 		{
 			name: "postgres: tcp",
@@ -114,7 +114,7 @@ func Test_parseDSN(t *testing.T) {
 				Password: "pa$$word",
 				SSLMode:  "disable",
 			},
-			expDSN: "user='gogs@local' password='pa$$word' host='127.0.0.1' port='5432' dbname='gogs' sslmode='disable' search_path='test'",
+			wantDSN: "user='gogs@local' password='pa$$word' host='127.0.0.1' port='5432' dbname='gogs' sslmode='disable' search_path='test' application_name='gogs'",
 		},
 
 		{
@@ -126,7 +126,7 @@ func Test_parseDSN(t *testing.T) {
 				User:     "gogs@local",
 				Password: "pa$$word",
 			},
-			expDSN: "server=127.0.0.1; port=1433; database=gogs; user id=gogs@local; password=pa$$word;",
+			wantDSN: "server=127.0.0.1; port=1433; database=gogs; user id=gogs@local; password=pa$$word;",
 		},
 
 		{
@@ -135,7 +135,7 @@ func Test_parseDSN(t *testing.T) {
 				Type: "sqlite3",
 				Path: "/tmp/gogs.db",
 			},
-			expDSN: "file:/tmp/gogs.db?cache=shared&mode=rwc",
+			wantDSN: "file:/tmp/gogs.db?cache=shared&mode=rwc",
 		},
 	}
 	for _, test := range tests {
@@ -144,7 +144,7 @@ func Test_parseDSN(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			assert.Equal(t, test.expDSN, dsn)
+			assert.Equal(t, test.wantDSN, dsn)
 		})
 	}
 }

--- a/internal/db/mock_gen.go
+++ b/internal/db/mock_gen.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-//go:generate go-mockgen -f gogs.io/gogs/internal/db -i AccessTokensStore -i LFSStore -i LoginSourcesStore -i LoginSourceFilesStore -i loginSourceFileStore -i PermsStore -i TwoFactorsStore -i UsersStore -o mocks.go
+//go:generate go-mockgen -f gogs.io/gogs/internal/db -i AccessTokensStore -i LFSStore -i LoginSourcesStore -i LoginSourceFilesStore -i loginSourceFileStore -i PermsStore -i ReposStore -i TwoFactorsStore -i UsersStore -o mocks.go
 
 func SetMockAccessTokensStore(t *testing.T, mock AccessTokensStore) {
 	before := AccessTokens
@@ -40,16 +40,6 @@ func SetMockPermsStore(t *testing.T, mock PermsStore) {
 	t.Cleanup(func() {
 		Perms = before
 	})
-}
-
-var _ ReposStore = (*MockReposStore)(nil)
-
-type MockReposStore struct {
-	MockGetByName func(ownerID int64, name string) (*Repository, error)
-}
-
-func (m *MockReposStore) GetByName(ownerID int64, name string) (*Repository, error) {
-	return m.MockGetByName(ownerID, name)
 }
 
 func SetMockReposStore(t *testing.T, mock ReposStore) {

--- a/internal/route/api/v1/api.go
+++ b/internal/route/api/v1/api.go
@@ -45,7 +45,7 @@ func repoAssignment() macaron.Handler {
 		}
 		c.Repo.Owner = owner
 
-		repo, err := db.Repos.GetByName(owner.ID, reponame)
+		repo, err := db.Repos.GetByName(c.Req.Context(), owner.ID, reponame)
 		if err != nil {
 			c.NotFoundOrError(err, "get repository by name")
 			return

--- a/internal/route/lfs/route.go
+++ b/internal/route/lfs/route.go
@@ -119,7 +119,7 @@ func authorize(mode db.AccessMode) macaron.Handler {
 			return
 		}
 
-		repo, err := db.Repos.GetByName(owner.ID, reponame)
+		repo, err := db.Repos.GetByName(c.Req.Context(), owner.ID, reponame)
 		if err != nil {
 			if db.IsErrRepoNotExist(err) {
 				c.Status(http.StatusNotFound)

--- a/internal/route/repo/http.go
+++ b/internal/route/repo/http.go
@@ -76,7 +76,7 @@ func HTTPContexter() macaron.Handler {
 			return
 		}
 
-		repo, err := db.Repos.GetByName(owner.ID, repoName)
+		repo, err := db.Repos.GetByName(c.Req.Context(), owner.ID, repoName)
 		if err != nil {
 			if db.IsErrRepoNotExist(err) {
 				c.Status(http.StatusNotFound)

--- a/internal/route/repo/tasks.go
+++ b/internal/route/repo/tasks.go
@@ -44,7 +44,7 @@ func TriggerTask(c *macaron.Context) {
 		return
 	}
 
-	repo, err := db.Repos.GetByName(owner.ID, reponame)
+	repo, err := db.Repos.GetByName(c.Req.Context(), owner.ID, reponame)
 	if err != nil {
 		if db.IsErrRepoNotExist(err) {
 			c.Error(http.StatusBadRequest, "Repository does not exist")


### PR DESCRIPTION
### Describe the pull request

1. Make all methods accept `context.Context`
2. Use go-mockgen to auto-generate mocks
3. Specify the application name when connecting to Postgres

Link to the issue: n/a

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [x] I have added test cases to cover the new code.
