### PR TITLE
netutil: allow using `*` to match any hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to Gogs are documented in this file.
 - Use [Task](https://github.com/go-task/task) as the build tool. [#6297](https://github.com/gogs/gogs/pull/6297)
 - The required Go version to compile source code changed to 1.16.
 - Access tokens are now stored using their SHA256 hashes instead of raw values. [#7008](https://github.com/gogs/gogs/pull/7008)
-- Support using `[security] LOCAL_NETWORK_ALLOWLIST = *` to allow all hostnames. [#?](https://github.com/gogs/gogs/pull/?)
+- Support using `[security] LOCAL_NETWORK_ALLOWLIST = *` to allow all hostnames. [#7111](https://github.com/gogs/gogs/pull/7111)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to Gogs are documented in this file.
 - Use [Task](https://github.com/go-task/task) as the build tool. [#6297](https://github.com/gogs/gogs/pull/6297)
 - The required Go version to compile source code changed to 1.16.
 - Access tokens are now stored using their SHA256 hashes instead of raw values. [#7008](https://github.com/gogs/gogs/pull/7008)
+- Support using `[security] LOCAL_NETWORK_ALLOWLIST = *` to allow all hostnames. [#?](https://github.com/gogs/gogs/pull/?)
 
 ### Fixed
 

--- a/conf/app.ini
+++ b/conf/app.ini
@@ -174,6 +174,7 @@ ENABLE_LOGIN_STATUS_COOKIE = false
 ; The cookie name to store user login status.
 LOGIN_STATUS_COOKIE_NAME = login_status
 ; A comma separated list of hostnames that are explicitly allowed to be accessed within the local network.
+; Use "*" to allow all hostnames.
 LOCAL_NETWORK_ALLOWLIST =
 
 [email]

--- a/internal/netutil/netutil.go
+++ b/internal/netutil/netutil.go
@@ -52,7 +52,7 @@ func init() {
 // allowlist).
 func IsBlockedLocalHostname(hostname string, allowlist []string) bool {
 	for _, allow := range allowlist {
-		if hostname == allow {
+		if hostname == allow || allow == "*" {
 			return false
 		}
 	}

--- a/internal/netutil/netutil_test.go
+++ b/internal/netutil/netutil_test.go
@@ -31,6 +31,8 @@ func TestIsLocalHostname(t *testing.T) {
 
 		{hostname: "192.168.123.45", allowlist: []string{"10.0.0.17"}, want: true}, // #11
 		{hostname: "gogs.local", allowlist: []string{"gogs.local"}, want: false},   // #12
+
+		{hostname: "192.168.123.45", allowlist: []string{"*"}, want: false}, // #13
 	}
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {


### PR DESCRIPTION
### Describe the pull request

Allow using `*` as an escape hatch for all local network address.

Link to the issue: https://github.com/gogs/gogs/discussions/7048#discussioncomment-2930780

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [x] I have added test cases to cover the new code.
