### PR TITLE
systemd: add `mysql.service` to "After"

### DIFF
--- a/scripts/systemd/gogs.service
+++ b/scripts/systemd/gogs.service
@@ -2,7 +2,7 @@
 Description=Gogs
 After=syslog.target
 After=network.target
-After=mariadb.service mysqld.service postgresql.service memcached.service redis.service
+After=mariadb.service mysql.service mysqld.service postgresql.service memcached.service redis.service
 
 [Service]
 # Modify these two values and uncomment them if you have


### PR DESCRIPTION
### Describe the pull request

解决Ubuntu22.04下mysqld.service为mysql.service时自启失败问题
Ubuntu22.04通过apt安装mysql时没有mysqld.service文件，只有mysql.service。
所以gogs.service会在mysql启动前启动，导致[...o/gogs/internal/route/install.go:75 GlobalInit()] Failed to initialize ORM engine: open database: dial tcp 127.0.0.1:3306: connect: connection refused

### Checklist

- [✅ ] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [✅ ] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [✅] I have added test cases to cover the new code.
