### PR TITLE
chore: remove usages of the deprecated `ioutil`

### DIFF
--- a/internal/cmd/backup.go
+++ b/internal/cmd/backup.go
@@ -7,7 +7,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -66,7 +65,7 @@ func runBackup(c *cli.Context) error {
 	if !com.IsExist(tmpDir) {
 		log.Fatal("'--tempdir' does not exist: %s", tmpDir)
 	}
-	rootDir, err := ioutil.TempDir(tmpDir, "gogs-backup-")
+	rootDir, err := os.MkdirTemp(tmpDir, "gogs-backup-")
 	if err != nil {
 		log.Fatal("Failed to create backup root directory '%s': %v", rootDir, err)
 	}

--- a/internal/db/ssh_key.go
+++ b/internal/db/ssh_key.go
@@ -10,7 +10,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"path"
@@ -181,7 +180,7 @@ func parseKeyString(content string) (string, error) {
 // writeTmpKeyFile writes key content to a temporary file
 // and returns the name of that file, along with any possible errors.
 func writeTmpKeyFile(content string) (string, error) {
-	tmpFile, err := ioutil.TempFile(conf.SSH.KeyTestPath, "gogs_keytest")
+	tmpFile, err := os.CreateTemp(conf.SSH.KeyTestPath, "gogs_keytest")
 	if err != nil {
 		return "", fmt.Errorf("TempFile: %v", err)
 	}
@@ -377,7 +376,7 @@ func addKey(e Engine, key *PublicKey) (err error) {
 	// Calculate fingerprint.
 	tmpPath := strings.ReplaceAll(path.Join(os.TempDir(), fmt.Sprintf("%d", time.Now().Nanosecond()), "id_rsa.pub"), "\\", "/")
 	_ = os.MkdirAll(path.Dir(tmpPath), os.ModePerm)
-	if err = ioutil.WriteFile(tmpPath, []byte(key.Content), 0644); err != nil {
+	if err = os.WriteFile(tmpPath, []byte(key.Content), 0644); err != nil {
 		return err
 	}
 

--- a/internal/db/wiki.go
+++ b/internal/db/wiki.go
@@ -6,7 +6,6 @@ package db
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path"
@@ -122,7 +121,7 @@ func (repo *Repository) updateWikiPage(doer *User, oldTitle, title, content, mes
 	// The new file we created will be in normal text format.
 	os.Remove(filename)
 
-	if err = ioutil.WriteFile(filename, []byte(content), 0666); err != nil {
+	if err = os.WriteFile(filename, []byte(content), 0666); err != nil {
 		return fmt.Errorf("WriteFile: %v", err)
 	}
 

--- a/internal/lfsutil/storage_test.go
+++ b/internal/lfsutil/storage_test.go
@@ -6,7 +6,7 @@ package lfsutil
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -79,7 +79,7 @@ func TestLocalStorage_Upload(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			written, err := s.Upload(test.oid, ioutil.NopCloser(strings.NewReader(test.content)))
+			written, err := s.Upload(test.oid, io.NopCloser(strings.NewReader(test.content)))
 			assert.Equal(t, test.expWritten, written)
 			assert.Equal(t, test.expErr, err)
 		})
@@ -100,7 +100,7 @@ func TestLocalStorage_Download(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = ioutil.WriteFile(fpath, []byte("Hello world!"), os.ModePerm)
+	err = os.WriteFile(fpath, []byte("Hello world!"), os.ModePerm)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/route/lfs/basic.go
+++ b/internal/route/lfs/basic.go
@@ -7,7 +7,6 @@ package lfs
 import (
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 
@@ -82,7 +81,7 @@ func (h *basicHandler) serveUpload(c *macaron.Context, repo *db.Repository, oid 
 	_, err := db.LFS.GetObjectByOID(c.Req.Context(), repo.ID, oid)
 	if err == nil {
 		// Object exists, drain the request body and we're good.
-		_, _ = io.Copy(ioutil.Discard, c.Req.Request.Body)
+		_, _ = io.Copy(io.Discard, c.Req.Request.Body)
 		c.Req.Request.Body.Close()
 		c.Status(http.StatusOK)
 		return

--- a/internal/route/lfs/basic.go
+++ b/internal/route/lfs/basic.go
@@ -122,16 +122,7 @@ func (h *basicHandler) serveUpload(c *macaron.Context, repo *db.Repository, oid 
 // POST /{owner}/{repo}.git/info/lfs/object/basic/verify
 func (*basicHandler) serveVerify(c *macaron.Context, repo *db.Repository) {
 	var request basicVerifyRequest
-	
-	defer func() {
-		err := c.Req.Request.Body.Close()
-		if err != nil {
-			responseJSON(c.Resp, http.StatusBadRequest, responseError{
-				Message: strutil.ToUpperFirst(err.Error()),
-			})
-			return
-		}
-	}()
+	defer func() { _ = c.Req.Request.Body.Close() }()
 
 	err := json.NewDecoder(c.Req.Request.Body).Decode(&request)
 	if err != nil {

--- a/internal/route/lfs/basic.go
+++ b/internal/route/lfs/basic.go
@@ -122,7 +122,17 @@ func (h *basicHandler) serveUpload(c *macaron.Context, repo *db.Repository, oid 
 // POST /{owner}/{repo}.git/info/lfs/object/basic/verify
 func (*basicHandler) serveVerify(c *macaron.Context, repo *db.Repository) {
 	var request basicVerifyRequest
-	defer c.Req.Request.Body.Close()
+	
+	defer func() {
+		err := c.Req.Request.Body.Close()
+		if err != nil {
+			responseJSON(c.Resp, http.StatusBadRequest, responseError{
+				Message: strutil.ToUpperFirst(err.Error()),
+			})
+			return
+		}
+	}()
+
 	err := json.NewDecoder(c.Req.Request.Body).Decode(&request)
 	if err != nil {
 		responseJSON(c.Resp, http.StatusBadRequest, responseError{

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -7,7 +7,6 @@ package ssh
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -190,7 +189,7 @@ func Listen(host string, port int, ciphers, macs []string) {
 		log.Trace("SSH: New private key is generateed: %s", keyPath)
 	}
 
-	privateBytes, err := ioutil.ReadFile(keyPath)
+	privateBytes, err := os.ReadFile(keyPath)
 	if err != nil {
 		panic("SSH: Failed to load private key: " + err.Error())
 	}

--- a/internal/testutil/golden.go
+++ b/internal/testutil/golden.go
@@ -7,7 +7,6 @@ package testutil
 import (
 	"encoding/json"
 	"flag"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -45,13 +44,13 @@ func AssertGolden(t testing.TB, path string, update bool, got any) {
 			t.Fatalf("create directories for golden file %q: %v", path, err)
 		}
 
-		err = ioutil.WriteFile(path, data, 0640)
+		err = os.WriteFile(path, data, 0640)
 		if err != nil {
 			t.Fatalf("update golden file %q: %v", path, err)
 		}
 	}
 
-	golden, err := ioutil.ReadFile(path)
+	golden, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("read golden file %q: %v", path, err)
 	}

--- a/templates/embed.go
+++ b/templates/embed.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 
@@ -73,7 +73,7 @@ func NewTemplateFileSystem(dir, customDir string) macaron.TemplateFileSystem {
 		var data []byte
 		fpath := path.Join(customDir, name)
 		if osutil.IsFile(fpath) {
-			data, err = ioutil.ReadFile(fpath)
+			data, err = os.ReadFile(fpath)
 		} else {
 			data, err = files.ReadFile(name)
 		}


### PR DESCRIPTION
### Describe the pull request

The ioutil package has been deprecated as of Go v1.16: https://go.dev/doc/go1.16#ioutil This commit replaces ioutil functions with their respective io/os functions.

Link to the issue: n/a

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [x] I have added test cases to cover the new code.
