### PR TITLE
fix(db): correctly check Git path on case-insensitive file system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to Gogs are documented in this file.
 ### Fixed
 
 - _Security:_ Stored XSS for issue assignees. [#7145](https://github.com/gogs/gogs/issues/7145)
+- _Security:_ OS Command Injection in repo editor on case-insensitive file systems. [#7030](https://github.com/gogs/gogs/issues/7030)
 - Unable to use LDAP authentication on ARM machines. [#6761](https://github.com/gogs/gogs/issues/6761)
 - Unable to choose "Lookup Avatar by mail" in user settings without deleting custom avatar. [#7267](https://github.com/gogs/gogs/pull/7267)
 - Mistakenly include the "data" directory under the custom directory in the Docker setup. [#7343](https://github.com/gogs/gogs/pull/7343)

--- a/internal/db/repo_editor.go
+++ b/internal/db/repo_editor.go
@@ -485,7 +485,10 @@ type UploadRepoFileOptions struct {
 
 // isRepositoryGitPath returns true if given path is or resides inside ".git"
 // path of the repository.
+//
+// TODO(unknwon): Move to repoutil during refactoring for this file.
 func isRepositoryGitPath(path string) bool {
+	path = strings.ToLower(path)
 	return strings.HasSuffix(path, ".git") ||
 		strings.Contains(path, ".git/") ||
 		strings.Contains(path, `.git\`) ||

--- a/internal/db/repo_editor_test.go
+++ b/internal/db/repo_editor_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_isRepositoryGitPath(t *testing.T) {
+func TestIsRepositoryGitPath(t *testing.T) {
 	tests := []struct {
 		path    string
 		wantVal bool
@@ -20,6 +20,13 @@ func Test_isRepositoryGitPath(t *testing.T) {
 		{path: ".git/hooks/pre-commit", wantVal: true},
 		{path: ".git/hooks", wantVal: true},
 		{path: "dir/.git", wantVal: true},
+
+		// Case-insensitive file system
+		{path: ".Git", wantVal: true},
+		{path: "./.Git", wantVal: true},
+		{path: ".Git/hooks/pre-commit", wantVal: true},
+		{path: ".Git/hooks", wantVal: true},
+		{path: "dir/.Git", wantVal: true},
 
 		{path: ".gitignore", wantVal: false},
 		{path: "dir/.gitkeep", wantVal: false},


### PR DESCRIPTION
## Describe the pull request

On case-insensitive file system, `.Git` is treated as `.git` so we need to be able to handle mixed cases.

Link to the issue: fixes https://github.com/gogs/gogs/issues/7030

## Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [x] I have added test cases to cover the new code.
