### PR TITLE
Option to init empty wiki Git remote repository upon repository creation

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -119,6 +119,8 @@ ENABLE_RAW_FILE_RENDER_MODE = false
 COMMITS_FETCH_CONCURRENCY = 0
 ; Default branch name when creating new repositories.
 DEFAULT_BRANCH = master
+; Wether to automatically create wiki repos if they do not exist, but are enabled
+AUTOCREATE_WIKI = true
 
 [repository.editor]
 ; List of file extensions that should have line wraps in the CodeMirror editor.

--- a/internal/conf/static.go
+++ b/internal/conf/static.go
@@ -323,6 +323,7 @@ type RepositoryOpts struct {
 	EnableRawFileRenderMode  bool
 	CommitsFetchConcurrency  int
 	DefaultBranch            string
+	AutocreateWiki           bool
 
 	// Repository editor settings
 	Editor struct {


### PR DESCRIPTION
## Describe the pull request

When the wiki for a repo is enabled, but doesn't have content yet, pushing to the wiki's git url will always fail.
This change provides a configuration option to automatically create an empty git repo, which can be pushed to.

Link to the issue: #7726

## Checklist

- [X] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [X] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [X] I have added test cases to cover the new code or have provided the test plan.

## Test plan

1. Enable `repository.AUTOCREATE_WIKI` in `app.ini`
2. create a new repo eg `owner/repo` and enable the wiki for that project
    * the wiki should now be empty and ask to create the first new page
    * no `repo.wiki.git` is yet available on the server
4. push to `git@gogs:owner/repo.wiki.git`
    * the `repo.wiki.git` is initialized
    * the content of the push is stored on the server
    * If there are Markdown-files in the wiki, the wiki-side displays them
