### PR TITLE
commit: fix `matchUsersWithCommitEmails`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to Gogs are documented in this file.
 ### Fixed
 
 - Submodules using `ssh://` protocol and a port number are not rendered correctly. [#4941](https://github.com/gogs/gogs/issues/4941)
+- Missing link to user profile on the first commit in commits history page. [#7404](https://github.com/gogs/gogs/issues/7404)
 
 ## 0.13.0
 

--- a/internal/route/repo/commit.go
+++ b/internal/route/repo/commit.go
@@ -200,8 +200,8 @@ func matchUsersWithCommitEmails(ctx gocontext.Context, oldCommits []*git.Commit)
 	for i := range oldCommits {
 		var u *db.User
 		if v, ok := emailToUsers[oldCommits[i].Author.Email]; !ok {
-			emailToUsers[oldCommits[i].Author.Email], _ = db.Users.GetByEmail(ctx, oldCommits[i].Author.Email)
-			u = emailToUsers[oldCommits[i].Author.Email]
+			u _ = db.Users.GetByEmail(ctx, oldCommits[i].Author.Email)
+			emailToUsers[oldCommits[i].Author.Email] = u
 		} else {
 			u = v
 		}

--- a/internal/route/repo/commit.go
+++ b/internal/route/repo/commit.go
@@ -200,7 +200,7 @@ func matchUsersWithCommitEmails(ctx gocontext.Context, oldCommits []*git.Commit)
 	for i := range oldCommits {
 		var u *db.User
 		if v, ok := emailToUsers[oldCommits[i].Author.Email]; !ok {
-			u _ = db.Users.GetByEmail(ctx, oldCommits[i].Author.Email)
+			u, _ = db.Users.GetByEmail(ctx, oldCommits[i].Author.Email)
 			emailToUsers[oldCommits[i].Author.Email] = u
 		} else {
 			u = v

--- a/internal/route/repo/commit.go
+++ b/internal/route/repo/commit.go
@@ -201,6 +201,7 @@ func matchUsersWithCommitEmails(ctx gocontext.Context, oldCommits []*git.Commit)
 		var u *db.User
 		if v, ok := emailToUsers[oldCommits[i].Author.Email]; !ok {
 			emailToUsers[oldCommits[i].Author.Email], _ = db.Users.GetByEmail(ctx, oldCommits[i].Author.Email)
+			u = emailToUsers[oldCommits[i].Author.Email]
 		} else {
 			u = v
 		}


### PR DESCRIPTION
Set missing value on user variable, each time a new user is returned from db.

Fixes #7404

## Describe the pull request

This commit fixes the email to user properly handing the returned data from database.
Currently every time we are returning a new user from database, we are caching the value.
But we are not setting value to variable `u`, resulting in missing link for user in commit log.
Second commit from same user on the list shown as expected.

Link to the issue: #7404 

## Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).

