### PR TITLE
Fix ~git/.ssh/environment file owner problem using in docker.

### DIFF
--- a/docker/s6/gogs/setup
+++ b/docker/s6/gogs/setup
@@ -6,6 +6,7 @@ if ! test -d ~git/.ssh; then
 fi
 
 if ! test -f ~git/.ssh/environment; then
+    gosu "$USER" touch ~git/.ssh/environment
     gosu "$USER" echo "GOGS_CUSTOM=${GOGS_CUSTOM}" > ~git/.ssh/environment
     chmod 600 ~git/.ssh/environment
 fi


### PR DESCRIPTION
## Describe the pull request

I thought that you want to use `gosu "$USER" echo "GOGS_CUSTOM=${GOGS_CUSTOM}" > ~git/.ssh/environment` to create a ~git/.ssh/environment file owned by $USER and then write something to it when the s6 boots gogs service in a docker container. [This gosu command is located in here.](https://github.com/gogs/gogs/blob/61940ca879d2599e446d302f0134dac2d08ce2fe/docker/s6/gogs/setup#L9C67-L9C67)

But this command will actually create a ~git/.ssh/environment file owned by root:root. Because on the right side of the pip, the ~git/.ssh/environment is actually created by the current user (root), not $USER.

To have it the right owner (maybe git:git) the file should be `touch` (created) by $USER before use it. That is what I do.

Link to the issue: n/a

## Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [x] I have added test cases to cover the new code or have provided the test plan.

## Test plan

You can test the code inside a gogs docker container by running these bash commands:

```bash
USER=git
gosu "$USER" touch ~git/.ssh/environment_test
gosu "$USER" echo "GOGS_CUSTOM=${GOGS_CUSTOM}" > ~git/.ssh/environment_test
``` 

Below is what I tested:

```plaintext
ba2e12b10e0f:/data/git# USER=git
ba2e12b10e0f:/data/git# gosu "$USER" touch ~git/.ssh/environment_test
ba2e12b10e0f:/data/git# gosu "$USER" echo "GOGS_CUSTOM=${GOGS_CUSTOM}" > ~git/.ssh/environment_test
ba2e12b10e0f:/data/git# ls -l ~git/.ssh/environment_test 
-rw-r--r--    1 git      git             23 Nov 11 16:09 /data/git/.ssh/environment_test
```

Besides, inside the same container, you can find the ~git/.ssh/environment file is owned by root:root `ls -l ~git/.ssh/environment`.