### PR TITLE
Adding '|' to the releases page 

### DIFF
--- a/templates/repo/release/list.tmpl
+++ b/templates/repo/release/list.tmpl
@@ -43,7 +43,7 @@
 									<a href="{{AppSubURL}}/{{.Publisher.Name}}">{{.Publisher.DisplayName}}</a>
 								</span>
 								{{if .Created}}<span class="time">{{TimeSince .Created $.Lang}}</span>{{end}}
-								<span class="ahead">{{$.i18n.Tr "repo.release.ahead" .NumCommitsBehind .Target | Str2HTML}}</span>
+								<span class="ahead">| {{$.i18n.Tr "repo.release.ahead" .NumCommitsBehind .Target | Str2HTML}}</span>
 							</p>
 							<div class="markdown desc">
 								{{Str2HTML .Note}}


### PR DESCRIPTION
## Adding '|' to the releases page 
a very simple change to the `templates/repo/release/list.tmpl` 

i changed this:
![2023-12-22_16-41_1](https://github.com/gogs/gogs/assets/78868991/3d0f8572-b4de-458d-8bf2-dcd030c67757)
to this:
![2023-12-22_16-41](https://github.com/gogs/gogs/assets/78868991/43e2fe58-1019-40f5-b2fb-d011d1145be4)
(yes)

## Checklist
- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
