### PR TITLE
fix: wiki page delete issue

### DIFF
--- a/internal/route/repo/wiki.go
+++ b/internal/route/repo/wiki.go
@@ -56,7 +56,11 @@ func renderWikiPage(c *context.Context, isViewPage bool) (*git.Repository, strin
 
 	// Get page list.
 	if isViewPage {
-		entries, err := commit.Entries()
+		entries, err := commit.Entries(git.LsTreeOptions{
+			CommandOptions: git.CommandOptions{
+				Args: []string{"-z"},
+			},
+		})
 		if err != nil {
 			c.Error(err, "list entries")
 			return nil, ""
@@ -154,7 +158,11 @@ func WikiPages(c *context.Context) {
 		return
 	}
 
-	entries, err := commit.Entries()
+	entries, err := commit.Entries(git.LsTreeOptions{
+		CommandOptions: git.CommandOptions{
+			Args: []string{"-z"},
+		},
+	})
 	if err != nil {
 		c.Error(err, "list entries")
 		return


### PR DESCRIPTION
Fixes #7596 when [PR #103](https://github.com/gogs/git-module/pull/103) is merged.

## Describe the pull request

It seems there's an issue with the handling of special characters in wiki names, where Git internally escapes them. This creates a mismatch between the escaped filenames and the actual filenames, making it challenging to delete files accurately. As a result, the deletion process is not functioning as expected.

Including the `-z` option in the git ls-tree command results in filenames being presented without quotes.
Another pull request has been initiated to handle this specific case. Please check [git-module PR #103](https://github.com/gogs/git-module/pull/103) for details.

For example, I have created below test wikis:
![Test Wikis](https://github.com/gogs/gogs/assets/25850690/34ff266b-a4f4-4117-8208-461dc3624e56)
See the differences of using `-z`:
![Test Wikis with z](https://github.com/gogs/gogs/assets/25850690/534e2d4a-ada5-4e4c-919e-d4c1ebdc4e53)
Using `-z` the filename is output verbatim.

Link to the issue: #7596

## Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [x] I have added test cases to cover the new code or have provided the test plan.

## Test plan

Make sure [gogs/git-module](https://github.com/gogs/git-module) has [PR #103](https://github.com/gogs/git-module/pull/103) changes. And [gogs/gogs](https://github.com/gogs/gogs) has this PR changes.

Build(`go build -o gogs`) and start the gogs web server(`./gogs web`).
Create wiki pages(with characters like `"`, `\` etc,.) and test the fix.

https://github.com/gogs/gogs/assets/25850690/60607e1d-318c-4865-af28-d7a0e60790ce

<!-- Please provide concrete but concise steps to proof things are working as stated, see an example in https://github.com/gogs/gogs/pull/7345 -->
