### PR TITLE
internal/database: consistently use `Store` and `s` as receiver

### DIFF
--- a/internal/database/access_tokens_test.go
+++ b/internal/database/access_tokens_test.go
@@ -98,13 +98,13 @@ func TestAccessTokens(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	db := &accessTokens{
-		DB: newTestDB(t, "accessTokens"),
+	db := &accessTokensStore{
+		DB: newTestDB(t, "accessTokensStore"),
 	}
 
 	for _, tc := range []struct {
 		name string
-		test func(t *testing.T, ctx context.Context, db *accessTokens)
+		test func(t *testing.T, ctx context.Context, db *accessTokensStore)
 	}{
 		{"Create", accessTokensCreate},
 		{"DeleteByID", accessTokensDeleteByID},
@@ -125,7 +125,7 @@ func TestAccessTokens(t *testing.T) {
 	}
 }
 
-func accessTokensCreate(t *testing.T, ctx context.Context, db *accessTokens) {
+func accessTokensCreate(t *testing.T, ctx context.Context, db *accessTokensStore) {
 	// Create first access token with name "Test"
 	token, err := db.Create(ctx, 1, "Test")
 	require.NoError(t, err)
@@ -150,7 +150,7 @@ func accessTokensCreate(t *testing.T, ctx context.Context, db *accessTokens) {
 	assert.Equal(t, wantErr, err)
 }
 
-func accessTokensDeleteByID(t *testing.T, ctx context.Context, db *accessTokens) {
+func accessTokensDeleteByID(t *testing.T, ctx context.Context, db *accessTokensStore) {
 	// Create an access token with name "Test"
 	token, err := db.Create(ctx, 1, "Test")
 	require.NoError(t, err)
@@ -177,7 +177,7 @@ func accessTokensDeleteByID(t *testing.T, ctx context.Context, db *accessTokens)
 	assert.Equal(t, wantErr, err)
 }
 
-func accessTokensGetBySHA(t *testing.T, ctx context.Context, db *accessTokens) {
+func accessTokensGetBySHA(t *testing.T, ctx context.Context, db *accessTokensStore) {
 	// Create an access token with name "Test"
 	token, err := db.Create(ctx, 1, "Test")
 	require.NoError(t, err)
@@ -196,7 +196,7 @@ func accessTokensGetBySHA(t *testing.T, ctx context.Context, db *accessTokens) {
 	assert.Equal(t, wantErr, err)
 }
 
-func accessTokensList(t *testing.T, ctx context.Context, db *accessTokens) {
+func accessTokensList(t *testing.T, ctx context.Context, db *accessTokensStore) {
 	// Create two access tokens for user 1
 	_, err := db.Create(ctx, 1, "user1_1")
 	require.NoError(t, err)
@@ -219,7 +219,7 @@ func accessTokensList(t *testing.T, ctx context.Context, db *accessTokens) {
 	assert.Equal(t, "user1_2", tokens[1].Name)
 }
 
-func accessTokensTouch(t *testing.T, ctx context.Context, db *accessTokens) {
+func accessTokensTouch(t *testing.T, ctx context.Context, db *accessTokensStore) {
 	// Create an access token with name "Test"
 	token, err := db.Create(ctx, 1, "Test")
 	require.NoError(t, err)

--- a/internal/database/actions_test.go
+++ b/internal/database/actions_test.go
@@ -99,13 +99,13 @@ func TestActions(t *testing.T) {
 
 	ctx := context.Background()
 	t.Parallel()
-	db := &actions{
-		DB: newTestDB(t, "actions"),
+	db := &actionsStore{
+		DB: newTestDB(t, "actionsStore"),
 	}
 
 	for _, tc := range []struct {
 		name string
-		test func(t *testing.T, ctx context.Context, db *actions)
+		test func(t *testing.T, ctx context.Context, db *actionsStore)
 	}{
 		{"CommitRepo", actionsCommitRepo},
 		{"ListByOrganization", actionsListByOrganization},
@@ -132,7 +132,7 @@ func TestActions(t *testing.T) {
 	}
 }
 
-func actionsCommitRepo(t *testing.T, ctx context.Context, db *actions) {
+func actionsCommitRepo(t *testing.T, ctx context.Context, db *actionsStore) {
 	alice, err := NewUsersStore(db.DB).Create(ctx, "alice", "alice@example.com", CreateUserOptions{})
 	require.NoError(t, err)
 	repo, err := NewReposStore(db.DB).Create(ctx,
@@ -324,7 +324,7 @@ func actionsCommitRepo(t *testing.T, ctx context.Context, db *actions) {
 	})
 }
 
-func actionsListByOrganization(t *testing.T, ctx context.Context, db *actions) {
+func actionsListByOrganization(t *testing.T, ctx context.Context, db *actionsStore) {
 	if os.Getenv("GOGS_DATABASE_TYPE") != "postgres" {
 		t.Skip("Skipping testing with not using PostgreSQL")
 		return
@@ -363,14 +363,14 @@ func actionsListByOrganization(t *testing.T, ctx context.Context, db *actions) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			got := db.DB.ToSQL(func(tx *gorm.DB) *gorm.DB {
-				return NewActionsStore(tx).(*actions).listByOrganization(ctx, test.orgID, test.actorID, test.afterID).Find(new(Action))
+				return NewActionsStore(tx).(*actionsStore).listByOrganization(ctx, test.orgID, test.actorID, test.afterID).Find(new(Action))
 			})
 			assert.Equal(t, test.want, got)
 		})
 	}
 }
 
-func actionsListByUser(t *testing.T, ctx context.Context, db *actions) {
+func actionsListByUser(t *testing.T, ctx context.Context, db *actionsStore) {
 	if os.Getenv("GOGS_DATABASE_TYPE") != "postgres" {
 		t.Skip("Skipping testing with not using PostgreSQL")
 		return
@@ -428,14 +428,14 @@ func actionsListByUser(t *testing.T, ctx context.Context, db *actions) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			got := db.DB.ToSQL(func(tx *gorm.DB) *gorm.DB {
-				return NewActionsStore(tx).(*actions).listByUser(ctx, test.userID, test.actorID, test.afterID, test.isProfile).Find(new(Action))
+				return NewActionsStore(tx).(*actionsStore).listByUser(ctx, test.userID, test.actorID, test.afterID, test.isProfile).Find(new(Action))
 			})
 			assert.Equal(t, test.want, got)
 		})
 	}
 }
 
-func actionsMergePullRequest(t *testing.T, ctx context.Context, db *actions) {
+func actionsMergePullRequest(t *testing.T, ctx context.Context, db *actionsStore) {
 	alice, err := NewUsersStore(db.DB).Create(ctx, "alice", "alice@example.com", CreateUserOptions{})
 	require.NoError(t, err)
 	repo, err := NewReposStore(db.DB).Create(ctx,
@@ -480,7 +480,7 @@ func actionsMergePullRequest(t *testing.T, ctx context.Context, db *actions) {
 	assert.Equal(t, want, got)
 }
 
-func actionsMirrorSyncCreate(t *testing.T, ctx context.Context, db *actions) {
+func actionsMirrorSyncCreate(t *testing.T, ctx context.Context, db *actionsStore) {
 	alice, err := NewUsersStore(db.DB).Create(ctx, "alice", "alice@example.com", CreateUserOptions{})
 	require.NoError(t, err)
 	repo, err := NewReposStore(db.DB).Create(ctx,
@@ -521,7 +521,7 @@ func actionsMirrorSyncCreate(t *testing.T, ctx context.Context, db *actions) {
 	assert.Equal(t, want, got)
 }
 
-func actionsMirrorSyncDelete(t *testing.T, ctx context.Context, db *actions) {
+func actionsMirrorSyncDelete(t *testing.T, ctx context.Context, db *actionsStore) {
 	alice, err := NewUsersStore(db.DB).Create(ctx, "alice", "alice@example.com", CreateUserOptions{})
 	require.NoError(t, err)
 	repo, err := NewReposStore(db.DB).Create(ctx,
@@ -562,7 +562,7 @@ func actionsMirrorSyncDelete(t *testing.T, ctx context.Context, db *actions) {
 	assert.Equal(t, want, got)
 }
 
-func actionsMirrorSyncPush(t *testing.T, ctx context.Context, db *actions) {
+func actionsMirrorSyncPush(t *testing.T, ctx context.Context, db *actionsStore) {
 	alice, err := NewUsersStore(db.DB).Create(ctx, "alice", "alice@example.com", CreateUserOptions{})
 	require.NoError(t, err)
 	repo, err := NewReposStore(db.DB).Create(ctx,
@@ -627,7 +627,7 @@ func actionsMirrorSyncPush(t *testing.T, ctx context.Context, db *actions) {
 	assert.Equal(t, want, got)
 }
 
-func actionsNewRepo(t *testing.T, ctx context.Context, db *actions) {
+func actionsNewRepo(t *testing.T, ctx context.Context, db *actionsStore) {
 	alice, err := NewUsersStore(db.DB).Create(ctx, "alice", "alice@example.com", CreateUserOptions{})
 	require.NoError(t, err)
 	repo, err := NewReposStore(db.DB).Create(ctx,
@@ -702,7 +702,7 @@ func actionsNewRepo(t *testing.T, ctx context.Context, db *actions) {
 	})
 }
 
-func actionsPushTag(t *testing.T, ctx context.Context, db *actions) {
+func actionsPushTag(t *testing.T, ctx context.Context, db *actionsStore) {
 	// NOTE: We set a noop mock here to avoid data race with other tests that writes
 	// to the mock server because this function holds a lock.
 	conf.SetMockServer(t, conf.ServerOpts{})
@@ -798,7 +798,7 @@ func actionsPushTag(t *testing.T, ctx context.Context, db *actions) {
 	})
 }
 
-func actionsRenameRepo(t *testing.T, ctx context.Context, db *actions) {
+func actionsRenameRepo(t *testing.T, ctx context.Context, db *actionsStore) {
 	alice, err := NewUsersStore(db.DB).Create(ctx, "alice", "alice@example.com", CreateUserOptions{})
 	require.NoError(t, err)
 	repo, err := NewReposStore(db.DB).Create(ctx,
@@ -835,7 +835,7 @@ func actionsRenameRepo(t *testing.T, ctx context.Context, db *actions) {
 	assert.Equal(t, want, got)
 }
 
-func actionsTransferRepo(t *testing.T, ctx context.Context, db *actions) {
+func actionsTransferRepo(t *testing.T, ctx context.Context, db *actionsStore) {
 	alice, err := NewUsersStore(db.DB).Create(ctx, "alice", "alice@example.com", CreateUserOptions{})
 	require.NoError(t, err)
 	bob, err := NewUsersStore(db.DB).Create(ctx, "bob", "bob@example.com", CreateUserOptions{})

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -123,15 +123,15 @@ func Init(w logger.Writer) (*gorm.DB, error) {
 	}
 
 	// Initialize stores, sorted in alphabetical order.
-	AccessTokens = &accessTokens{DB: db}
+	AccessTokens = &accessTokensStore{DB: db}
 	Actions = NewActionsStore(db)
-	LoginSources = &loginSources{DB: db, files: sourceFiles}
-	LFS = &lfs{DB: db}
+	LoginSources = &loginSourcesStore{DB: db, files: sourceFiles}
+	LFS = &lfsStore{DB: db}
 	Notices = NewNoticesStore(db)
 	Orgs = NewOrgsStore(db)
 	Perms = NewPermsStore(db)
 	Repos = NewReposStore(db)
-	TwoFactors = &twoFactors{DB: db}
+	TwoFactors = &twoFactorsStore{DB: db}
 	Users = NewUsersStore(db)
 
 	return db, nil

--- a/internal/database/lfs_test.go
+++ b/internal/database/lfs_test.go
@@ -23,13 +23,13 @@ func TestLFS(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	db := &lfs{
-		DB: newTestDB(t, "lfs"),
+	db := &lfsStore{
+		DB: newTestDB(t, "lfsStore"),
 	}
 
 	for _, tc := range []struct {
 		name string
-		test func(t *testing.T, ctx context.Context, db *lfs)
+		test func(t *testing.T, ctx context.Context, db *lfsStore)
 	}{
 		{"CreateObject", lfsCreateObject},
 		{"GetObjectByOID", lfsGetObjectByOID},
@@ -48,7 +48,7 @@ func TestLFS(t *testing.T) {
 	}
 }
 
-func lfsCreateObject(t *testing.T, ctx context.Context, db *lfs) {
+func lfsCreateObject(t *testing.T, ctx context.Context, db *lfsStore) {
 	// Create first LFS object
 	repoID := int64(1)
 	oid := lfsutil.OID("ef797c8118f02dfb649607dd5d3f8c7623048c9c063d532cc95c5ed7a898a64f")
@@ -65,7 +65,7 @@ func lfsCreateObject(t *testing.T, ctx context.Context, db *lfs) {
 	assert.Error(t, err)
 }
 
-func lfsGetObjectByOID(t *testing.T, ctx context.Context, db *lfs) {
+func lfsGetObjectByOID(t *testing.T, ctx context.Context, db *lfsStore) {
 	// Create a LFS object
 	repoID := int64(1)
 	oid := lfsutil.OID("ef797c8118f02dfb649607dd5d3f8c7623048c9c063d532cc95c5ed7a898a64f")
@@ -82,7 +82,7 @@ func lfsGetObjectByOID(t *testing.T, ctx context.Context, db *lfs) {
 	assert.Equal(t, expErr, err)
 }
 
-func lfsGetObjectsByOIDs(t *testing.T, ctx context.Context, db *lfs) {
+func lfsGetObjectsByOIDs(t *testing.T, ctx context.Context, db *lfsStore) {
 	// Create two LFS objects
 	repoID := int64(1)
 	oid1 := lfsutil.OID("ef797c8118f02dfb649607dd5d3f8c7623048c9c063d532cc95c5ed7a898a64f")

--- a/internal/database/login_sources_test.go
+++ b/internal/database/login_sources_test.go
@@ -163,13 +163,13 @@ func TestLoginSources(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	db := &loginSources{
-		DB: newTestDB(t, "loginSources"),
+	db := &loginSourcesStore{
+		DB: newTestDB(t, "loginSourcesStore"),
 	}
 
 	for _, tc := range []struct {
 		name string
-		test func(t *testing.T, ctx context.Context, db *loginSources)
+		test func(t *testing.T, ctx context.Context, db *loginSourcesStore)
 	}{
 		{"Create", loginSourcesCreate},
 		{"Count", loginSourcesCount},
@@ -192,7 +192,7 @@ func TestLoginSources(t *testing.T) {
 	}
 }
 
-func loginSourcesCreate(t *testing.T, ctx context.Context, db *loginSources) {
+func loginSourcesCreate(t *testing.T, ctx context.Context, db *loginSourcesStore) {
 	// Create first login source with name "GitHub"
 	source, err := db.Create(ctx,
 		CreateLoginSourceOptions{
@@ -219,7 +219,7 @@ func loginSourcesCreate(t *testing.T, ctx context.Context, db *loginSources) {
 	assert.Equal(t, wantErr, err)
 }
 
-func loginSourcesCount(t *testing.T, ctx context.Context, db *loginSources) {
+func loginSourcesCount(t *testing.T, ctx context.Context, db *loginSourcesStore) {
 	// Create two login sources, one in database and one as source file.
 	_, err := db.Create(ctx,
 		CreateLoginSourceOptions{
@@ -241,7 +241,7 @@ func loginSourcesCount(t *testing.T, ctx context.Context, db *loginSources) {
 	assert.Equal(t, int64(3), db.Count(ctx))
 }
 
-func loginSourcesDeleteByID(t *testing.T, ctx context.Context, db *loginSources) {
+func loginSourcesDeleteByID(t *testing.T, ctx context.Context, db *loginSourcesStore) {
 	t.Run("delete but in used", func(t *testing.T) {
 		source, err := db.Create(ctx,
 			CreateLoginSourceOptions{
@@ -257,7 +257,7 @@ func loginSourcesDeleteByID(t *testing.T, ctx context.Context, db *loginSources)
 		require.NoError(t, err)
 
 		// Create a user that uses this login source
-		_, err = (&users{DB: db.DB}).Create(ctx, "alice", "",
+		_, err = (&usersStore{DB: db.DB}).Create(ctx, "alice", "",
 			CreateUserOptions{
 				LoginSource: source.ID,
 			},
@@ -308,7 +308,7 @@ func loginSourcesDeleteByID(t *testing.T, ctx context.Context, db *loginSources)
 	assert.Equal(t, wantErr, err)
 }
 
-func loginSourcesGetByID(t *testing.T, ctx context.Context, db *loginSources) {
+func loginSourcesGetByID(t *testing.T, ctx context.Context, db *loginSourcesStore) {
 	mock := NewMockLoginSourceFilesStore()
 	mock.GetByIDFunc.SetDefaultHook(func(id int64) (*LoginSource, error) {
 		if id != 101 {
@@ -344,7 +344,7 @@ func loginSourcesGetByID(t *testing.T, ctx context.Context, db *loginSources) {
 	require.NoError(t, err)
 }
 
-func loginSourcesList(t *testing.T, ctx context.Context, db *loginSources) {
+func loginSourcesList(t *testing.T, ctx context.Context, db *loginSourcesStore) {
 	mock := NewMockLoginSourceFilesStore()
 	mock.ListFunc.SetDefaultHook(func(opts ListLoginSourceOptions) []*LoginSource {
 		if opts.OnlyActivated {
@@ -393,7 +393,7 @@ func loginSourcesList(t *testing.T, ctx context.Context, db *loginSources) {
 	assert.Equal(t, 2, len(sources), "number of sources")
 }
 
-func loginSourcesResetNonDefault(t *testing.T, ctx context.Context, db *loginSources) {
+func loginSourcesResetNonDefault(t *testing.T, ctx context.Context, db *loginSourcesStore) {
 	mock := NewMockLoginSourceFilesStore()
 	mock.ListFunc.SetDefaultHook(func(opts ListLoginSourceOptions) []*LoginSource {
 		mockFile := NewMockLoginSourceFileStore()
@@ -448,7 +448,7 @@ func loginSourcesResetNonDefault(t *testing.T, ctx context.Context, db *loginSou
 	assert.False(t, source2.IsDefault)
 }
 
-func loginSourcesSave(t *testing.T, ctx context.Context, db *loginSources) {
+func loginSourcesSave(t *testing.T, ctx context.Context, db *loginSourcesStore) {
 	t.Run("save to database", func(t *testing.T) {
 		// Create a login source with name "GitHub"
 		source, err := db.Create(ctx,

--- a/internal/database/mocks.go
+++ b/internal/database/mocks.go
@@ -32,7 +32,7 @@ func setMockLoginSourcesStore(t *testing.T, mock LoginSourcesStore) {
 	})
 }
 
-func setMockLoginSourceFilesStore(t *testing.T, db *loginSources, mock loginSourceFilesStore) {
+func setMockLoginSourceFilesStore(t *testing.T, db *loginSourcesStore, mock loginSourceFilesStore) {
 	before := db.files
 	db.files = mock
 	t.Cleanup(func() {

--- a/internal/database/notices.go
+++ b/internal/database/notices.go
@@ -32,20 +32,20 @@ type NoticesStore interface {
 
 var Notices NoticesStore
 
-var _ NoticesStore = (*notices)(nil)
+var _ NoticesStore = (*noticesStore)(nil)
 
-type notices struct {
+type noticesStore struct {
 	*gorm.DB
 }
 
 // NewNoticesStore returns a persistent interface for system notices with given
 // database connection.
 func NewNoticesStore(db *gorm.DB) NoticesStore {
-	return &notices{DB: db}
+	return &noticesStore{DB: db}
 }
 
-func (db *notices) Create(ctx context.Context, typ NoticeType, desc string) error {
-	return db.WithContext(ctx).Create(
+func (s *noticesStore) Create(ctx context.Context, typ NoticeType, desc string) error {
+	return s.WithContext(ctx).Create(
 		&Notice{
 			Type:        typ,
 			Description: desc,
@@ -53,26 +53,26 @@ func (db *notices) Create(ctx context.Context, typ NoticeType, desc string) erro
 	).Error
 }
 
-func (db *notices) DeleteByIDs(ctx context.Context, ids ...int64) error {
-	return db.WithContext(ctx).Where("id IN (?)", ids).Delete(&Notice{}).Error
+func (s *noticesStore) DeleteByIDs(ctx context.Context, ids ...int64) error {
+	return s.WithContext(ctx).Where("id IN (?)", ids).Delete(&Notice{}).Error
 }
 
-func (db *notices) DeleteAll(ctx context.Context) error {
-	return db.WithContext(ctx).Where("TRUE").Delete(&Notice{}).Error
+func (s *noticesStore) DeleteAll(ctx context.Context) error {
+	return s.WithContext(ctx).Where("TRUE").Delete(&Notice{}).Error
 }
 
-func (db *notices) List(ctx context.Context, page, pageSize int) ([]*Notice, error) {
+func (s *noticesStore) List(ctx context.Context, page, pageSize int) ([]*Notice, error) {
 	notices := make([]*Notice, 0, pageSize)
-	return notices, db.WithContext(ctx).
+	return notices, s.WithContext(ctx).
 		Limit(pageSize).Offset((page - 1) * pageSize).
 		Order("id DESC").
 		Find(&notices).
 		Error
 }
 
-func (db *notices) Count(ctx context.Context) int64 {
+func (s *noticesStore) Count(ctx context.Context) int64 {
 	var count int64
-	db.WithContext(ctx).Model(&Notice{}).Count(&count)
+	s.WithContext(ctx).Model(&Notice{}).Count(&count)
 	return count
 }
 

--- a/internal/database/notices_test.go
+++ b/internal/database/notices_test.go
@@ -65,13 +65,13 @@ func TestNotices(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	db := &notices{
-		DB: newTestDB(t, "notices"),
+	db := &noticesStore{
+		DB: newTestDB(t, "noticesStore"),
 	}
 
 	for _, tc := range []struct {
 		name string
-		test func(t *testing.T, ctx context.Context, db *notices)
+		test func(t *testing.T, ctx context.Context, db *noticesStore)
 	}{
 		{"Create", noticesCreate},
 		{"DeleteByIDs", noticesDeleteByIDs},
@@ -92,7 +92,7 @@ func TestNotices(t *testing.T) {
 	}
 }
 
-func noticesCreate(t *testing.T, ctx context.Context, db *notices) {
+func noticesCreate(t *testing.T, ctx context.Context, db *noticesStore) {
 	err := db.Create(ctx, NoticeTypeRepository, "test")
 	require.NoError(t, err)
 
@@ -100,7 +100,7 @@ func noticesCreate(t *testing.T, ctx context.Context, db *notices) {
 	assert.Equal(t, int64(1), count)
 }
 
-func noticesDeleteByIDs(t *testing.T, ctx context.Context, db *notices) {
+func noticesDeleteByIDs(t *testing.T, ctx context.Context, db *noticesStore) {
 	err := db.Create(ctx, NoticeTypeRepository, "test")
 	require.NoError(t, err)
 
@@ -120,7 +120,7 @@ func noticesDeleteByIDs(t *testing.T, ctx context.Context, db *notices) {
 	assert.Equal(t, int64(0), count)
 }
 
-func noticesDeleteAll(t *testing.T, ctx context.Context, db *notices) {
+func noticesDeleteAll(t *testing.T, ctx context.Context, db *noticesStore) {
 	err := db.Create(ctx, NoticeTypeRepository, "test")
 	require.NoError(t, err)
 
@@ -131,7 +131,7 @@ func noticesDeleteAll(t *testing.T, ctx context.Context, db *notices) {
 	assert.Equal(t, int64(0), count)
 }
 
-func noticesList(t *testing.T, ctx context.Context, db *notices) {
+func noticesList(t *testing.T, ctx context.Context, db *noticesStore) {
 	err := db.Create(ctx, NoticeTypeRepository, "test 1")
 	require.NoError(t, err)
 	err = db.Create(ctx, NoticeTypeRepository, "test 2")
@@ -151,7 +151,7 @@ func noticesList(t *testing.T, ctx context.Context, db *notices) {
 	require.Len(t, got, 2)
 }
 
-func noticesCount(t *testing.T, ctx context.Context, db *notices) {
+func noticesCount(t *testing.T, ctx context.Context, db *noticesStore) {
 	count := db.Count(ctx)
 	assert.Equal(t, int64(0), count)
 

--- a/internal/database/orgs_test.go
+++ b/internal/database/orgs_test.go
@@ -21,13 +21,13 @@ func TestOrgs(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	db := &orgs{
-		DB: newTestDB(t, "orgs"),
+	db := &orgsStore{
+		DB: newTestDB(t, "orgsStore"),
 	}
 
 	for _, tc := range []struct {
 		name string
-		test func(t *testing.T, ctx context.Context, db *orgs)
+		test func(t *testing.T, ctx context.Context, db *orgsStore)
 	}{
 		{"List", orgsList},
 		{"SearchByName", orgsSearchByName},
@@ -46,7 +46,7 @@ func TestOrgs(t *testing.T) {
 	}
 }
 
-func orgsList(t *testing.T, ctx context.Context, db *orgs) {
+func orgsList(t *testing.T, ctx context.Context, db *orgsStore) {
 	usersStore := NewUsersStore(db.DB)
 	alice, err := usersStore.Create(ctx, "alice", "alice@example.com", CreateUserOptions{})
 	require.NoError(t, err)
@@ -116,7 +116,7 @@ func orgsList(t *testing.T, ctx context.Context, db *orgs) {
 	}
 }
 
-func orgsSearchByName(t *testing.T, ctx context.Context, db *orgs) {
+func orgsSearchByName(t *testing.T, ctx context.Context, db *orgsStore) {
 	// TODO: Use Orgs.Create to replace SQL hack when the method is available.
 	usersStore := NewUsersStore(db.DB)
 	org1, err := usersStore.Create(ctx, "org1", "org1@example.com", CreateUserOptions{FullName: "Acme Corp"})
@@ -161,7 +161,7 @@ func orgsSearchByName(t *testing.T, ctx context.Context, db *orgs) {
 	})
 }
 
-func orgsCountByUser(t *testing.T, ctx context.Context, db *orgs) {
+func orgsCountByUser(t *testing.T, ctx context.Context, db *orgsStore) {
 	// TODO: Use Orgs.Join to replace SQL hack when the method is available.
 	err := db.Exec(`INSERT INTO org_user (uid, org_id) VALUES (?, ?)`, 1, 1).Error
 	require.NoError(t, err)

--- a/internal/database/perms_test.go
+++ b/internal/database/perms_test.go
@@ -19,13 +19,13 @@ func TestPerms(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	db := &perms{
-		DB: newTestDB(t, "perms"),
+	db := &permsStore{
+		DB: newTestDB(t, "permsStore"),
 	}
 
 	for _, tc := range []struct {
 		name string
-		test func(t *testing.T, ctx context.Context, db *perms)
+		test func(t *testing.T, ctx context.Context, db *permsStore)
 	}{
 		{"AccessMode", permsAccessMode},
 		{"Authorize", permsAuthorize},
@@ -44,7 +44,7 @@ func TestPerms(t *testing.T) {
 	}
 }
 
-func permsAccessMode(t *testing.T, ctx context.Context, db *perms) {
+func permsAccessMode(t *testing.T, ctx context.Context, db *permsStore) {
 	// Set up permissions
 	err := db.SetRepoPerms(ctx, 1,
 		map[int64]AccessMode{
@@ -155,7 +155,7 @@ func permsAccessMode(t *testing.T, ctx context.Context, db *perms) {
 	}
 }
 
-func permsAuthorize(t *testing.T, ctx context.Context, db *perms) {
+func permsAuthorize(t *testing.T, ctx context.Context, db *permsStore) {
 	// Set up permissions
 	err := db.SetRepoPerms(ctx, 1,
 		map[int64]AccessMode{
@@ -241,7 +241,7 @@ func permsAuthorize(t *testing.T, ctx context.Context, db *perms) {
 	}
 }
 
-func permsSetRepoPerms(t *testing.T, ctx context.Context, db *perms) {
+func permsSetRepoPerms(t *testing.T, ctx context.Context, db *permsStore) {
 	for _, update := range []struct {
 		repoID    int64
 		accessMap map[int64]AccessMode

--- a/internal/database/public_keys_test.go
+++ b/internal/database/public_keys_test.go
@@ -24,13 +24,13 @@ func TestPublicKeys(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	db := &publicKeys{
-		DB: newTestDB(t, "publicKeys"),
+	db := &publicKeysStore{
+		DB: newTestDB(t, "publicKeysStore"),
 	}
 
 	for _, tc := range []struct {
 		name string
-		test func(t *testing.T, ctx context.Context, db *publicKeys)
+		test func(t *testing.T, ctx context.Context, db *publicKeysStore)
 	}{
 		{"RewriteAuthorizedKeys", publicKeysRewriteAuthorizedKeys},
 	} {
@@ -47,7 +47,7 @@ func TestPublicKeys(t *testing.T) {
 	}
 }
 
-func publicKeysRewriteAuthorizedKeys(t *testing.T, ctx context.Context, db *publicKeys) {
+func publicKeysRewriteAuthorizedKeys(t *testing.T, ctx context.Context, db *publicKeysStore) {
 	// TODO: Use PublicKeys.Add to replace SQL hack when the method is available.
 	publicKey := &PublicKey{
 		OwnerID:     1,

--- a/internal/database/repos_test.go
+++ b/internal/database/repos_test.go
@@ -85,13 +85,13 @@ func TestRepos(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	db := &repos{
+	db := &reposStore{
 		DB: newTestDB(t, "repos"),
 	}
 
 	for _, tc := range []struct {
 		name string
-		test func(t *testing.T, ctx context.Context, db *repos)
+		test func(t *testing.T, ctx context.Context, db *reposStore)
 	}{
 		{"Create", reposCreate},
 		{"GetByCollaboratorID", reposGetByCollaboratorID},
@@ -117,7 +117,7 @@ func TestRepos(t *testing.T) {
 	}
 }
 
-func reposCreate(t *testing.T, ctx context.Context, db *repos) {
+func reposCreate(t *testing.T, ctx context.Context, db *reposStore) {
 	t.Run("name not allowed", func(t *testing.T) {
 		_, err := db.Create(ctx,
 			1,
@@ -159,7 +159,7 @@ func reposCreate(t *testing.T, ctx context.Context, db *repos) {
 	assert.Equal(t, 1, repo.NumWatches) // The owner is watching the repo by default.
 }
 
-func reposGetByCollaboratorID(t *testing.T, ctx context.Context, db *repos) {
+func reposGetByCollaboratorID(t *testing.T, ctx context.Context, db *reposStore) {
 	repo1, err := db.Create(ctx, 1, CreateRepoOptions{Name: "repo1"})
 	require.NoError(t, err)
 	repo2, err := db.Create(ctx, 2, CreateRepoOptions{Name: "repo2"})
@@ -185,7 +185,7 @@ func reposGetByCollaboratorID(t *testing.T, ctx context.Context, db *repos) {
 	})
 }
 
-func reposGetByCollaboratorIDWithAccessMode(t *testing.T, ctx context.Context, db *repos) {
+func reposGetByCollaboratorIDWithAccessMode(t *testing.T, ctx context.Context, db *reposStore) {
 	repo1, err := db.Create(ctx, 1, CreateRepoOptions{Name: "repo1"})
 	require.NoError(t, err)
 	repo2, err := db.Create(ctx, 2, CreateRepoOptions{Name: "repo2"})
@@ -213,7 +213,7 @@ func reposGetByCollaboratorIDWithAccessMode(t *testing.T, ctx context.Context, d
 	assert.Equal(t, AccessModeAdmin, accessModes[repo2.ID])
 }
 
-func reposGetByID(t *testing.T, ctx context.Context, db *repos) {
+func reposGetByID(t *testing.T, ctx context.Context, db *reposStore) {
 	repo1, err := db.Create(ctx, 1, CreateRepoOptions{Name: "repo1"})
 	require.NoError(t, err)
 
@@ -226,7 +226,7 @@ func reposGetByID(t *testing.T, ctx context.Context, db *repos) {
 	assert.Equal(t, wantErr, err)
 }
 
-func reposGetByName(t *testing.T, ctx context.Context, db *repos) {
+func reposGetByName(t *testing.T, ctx context.Context, db *reposStore) {
 	repo, err := db.Create(ctx, 1,
 		CreateRepoOptions{
 			Name: "repo1",
@@ -242,7 +242,7 @@ func reposGetByName(t *testing.T, ctx context.Context, db *repos) {
 	assert.Equal(t, wantErr, err)
 }
 
-func reposStar(t *testing.T, ctx context.Context, db *repos) {
+func reposStar(t *testing.T, ctx context.Context, db *reposStore) {
 	repo1, err := db.Create(ctx, 1, CreateRepoOptions{Name: "repo1"})
 	require.NoError(t, err)
 	usersStore := NewUsersStore(db.DB)
@@ -261,7 +261,7 @@ func reposStar(t *testing.T, ctx context.Context, db *repos) {
 	assert.Equal(t, 1, alice.NumStars)
 }
 
-func reposTouch(t *testing.T, ctx context.Context, db *repos) {
+func reposTouch(t *testing.T, ctx context.Context, db *reposStore) {
 	repo, err := db.Create(ctx, 1,
 		CreateRepoOptions{
 			Name: "repo1",
@@ -287,7 +287,7 @@ func reposTouch(t *testing.T, ctx context.Context, db *repos) {
 	assert.False(t, got.IsBare)
 }
 
-func reposListWatches(t *testing.T, ctx context.Context, db *repos) {
+func reposListWatches(t *testing.T, ctx context.Context, db *reposStore) {
 	err := db.Watch(ctx, 1, 1)
 	require.NoError(t, err)
 	err = db.Watch(ctx, 2, 1)
@@ -308,7 +308,7 @@ func reposListWatches(t *testing.T, ctx context.Context, db *repos) {
 	assert.Equal(t, want, got)
 }
 
-func reposWatch(t *testing.T, ctx context.Context, db *repos) {
+func reposWatch(t *testing.T, ctx context.Context, db *reposStore) {
 	reposStore := NewReposStore(db.DB)
 	repo1, err := reposStore.Create(ctx, 1, CreateRepoOptions{Name: "repo1"})
 	require.NoError(t, err)
@@ -325,7 +325,7 @@ func reposWatch(t *testing.T, ctx context.Context, db *repos) {
 	assert.Equal(t, 2, repo1.NumWatches) // The owner is watching the repo by default.
 }
 
-func reposHasForkedBy(t *testing.T, ctx context.Context, db *repos) {
+func reposHasForkedBy(t *testing.T, ctx context.Context, db *reposStore) {
 	has := db.HasForkedBy(ctx, 1, 2)
 	assert.False(t, has)
 

--- a/internal/database/two_factors_test.go
+++ b/internal/database/two_factors_test.go
@@ -67,13 +67,13 @@ func TestTwoFactors(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	db := &twoFactors{
-		DB: newTestDB(t, "twoFactors"),
+	db := &twoFactorsStore{
+		DB: newTestDB(t, "twoFactorsStore"),
 	}
 
 	for _, tc := range []struct {
 		name string
-		test func(t *testing.T, ctx context.Context, db *twoFactors)
+		test func(t *testing.T, ctx context.Context, db *twoFactorsStore)
 	}{
 		{"Create", twoFactorsCreate},
 		{"GetByUserID", twoFactorsGetByUserID},
@@ -92,7 +92,7 @@ func TestTwoFactors(t *testing.T) {
 	}
 }
 
-func twoFactorsCreate(t *testing.T, ctx context.Context, db *twoFactors) {
+func twoFactorsCreate(t *testing.T, ctx context.Context, db *twoFactorsStore) {
 	// Create a 2FA token
 	err := db.Create(ctx, 1, "secure-key", "secure-secret")
 	require.NoError(t, err)
@@ -109,7 +109,7 @@ func twoFactorsCreate(t *testing.T, ctx context.Context, db *twoFactors) {
 	assert.Equal(t, int64(10), count)
 }
 
-func twoFactorsGetByUserID(t *testing.T, ctx context.Context, db *twoFactors) {
+func twoFactorsGetByUserID(t *testing.T, ctx context.Context, db *twoFactorsStore) {
 	// Create a 2FA token for user 1
 	err := db.Create(ctx, 1, "secure-key", "secure-secret")
 	require.NoError(t, err)
@@ -124,7 +124,7 @@ func twoFactorsGetByUserID(t *testing.T, ctx context.Context, db *twoFactors) {
 	assert.Equal(t, wantErr, err)
 }
 
-func twoFactorsIsEnabled(t *testing.T, ctx context.Context, db *twoFactors) {
+func twoFactorsIsEnabled(t *testing.T, ctx context.Context, db *twoFactorsStore) {
 	// Create a 2FA token for user 1
 	err := db.Create(ctx, 1, "secure-key", "secure-secret")
 	require.NoError(t, err)

--- a/internal/database/users_test.go
+++ b/internal/database/users_test.go
@@ -84,13 +84,13 @@ func TestUsers(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	db := &users{
-		DB: newTestDB(t, "users"),
+	db := &usersStore{
+		DB: newTestDB(t, "usersStore"),
 	}
 
 	for _, tc := range []struct {
 		name string
-		test func(t *testing.T, ctx context.Context, db *users)
+		test func(t *testing.T, ctx context.Context, db *usersStore)
 	}{
 		{"Authenticate", usersAuthenticate},
 		{"ChangeUsername", usersChangeUsername},
@@ -134,7 +134,7 @@ func TestUsers(t *testing.T) {
 	}
 }
 
-func usersAuthenticate(t *testing.T, ctx context.Context, db *users) {
+func usersAuthenticate(t *testing.T, ctx context.Context, db *usersStore) {
 	password := "pa$$word"
 	alice, err := db.Create(ctx, "alice", "alice@example.com",
 		CreateUserOptions{
@@ -229,7 +229,7 @@ func usersAuthenticate(t *testing.T, ctx context.Context, db *users) {
 	})
 }
 
-func usersChangeUsername(t *testing.T, ctx context.Context, db *users) {
+func usersChangeUsername(t *testing.T, ctx context.Context, db *usersStore) {
 	alice, err := db.Create(
 		ctx,
 		"alice",
@@ -359,7 +359,7 @@ func usersChangeUsername(t *testing.T, ctx context.Context, db *users) {
 	assert.Equal(t, strings.ToUpper(newUsername), alice.Name)
 }
 
-func usersCount(t *testing.T, ctx context.Context, db *users) {
+func usersCount(t *testing.T, ctx context.Context, db *usersStore) {
 	// Has no user initially
 	got := db.Count(ctx)
 	assert.Equal(t, int64(0), got)
@@ -382,7 +382,7 @@ func usersCount(t *testing.T, ctx context.Context, db *users) {
 	assert.Equal(t, int64(1), got)
 }
 
-func usersCreate(t *testing.T, ctx context.Context, db *users) {
+func usersCreate(t *testing.T, ctx context.Context, db *usersStore) {
 	alice, err := db.Create(
 		ctx,
 		"alice",
@@ -430,7 +430,7 @@ func usersCreate(t *testing.T, ctx context.Context, db *users) {
 	assert.Equal(t, db.NowFunc().Format(time.RFC3339), user.Updated.UTC().Format(time.RFC3339))
 }
 
-func usersDeleteCustomAvatar(t *testing.T, ctx context.Context, db *users) {
+func usersDeleteCustomAvatar(t *testing.T, ctx context.Context, db *usersStore) {
 	alice, err := db.Create(ctx, "alice", "alice@example.com", CreateUserOptions{})
 	require.NoError(t, err)
 
@@ -464,7 +464,7 @@ func usersDeleteCustomAvatar(t *testing.T, ctx context.Context, db *users) {
 	assert.False(t, alice.UseCustomAvatar)
 }
 
-func usersDeleteByID(t *testing.T, ctx context.Context, db *users) {
+func usersDeleteByID(t *testing.T, ctx context.Context, db *usersStore) {
 	reposStore := NewReposStore(db.DB)
 
 	t.Run("user still has repository ownership", func(t *testing.T) {
@@ -674,7 +674,7 @@ func usersDeleteByID(t *testing.T, ctx context.Context, db *users) {
 	assert.Equal(t, wantErr, err)
 }
 
-func usersDeleteInactivated(t *testing.T, ctx context.Context, db *users) {
+func usersDeleteInactivated(t *testing.T, ctx context.Context, db *usersStore) {
 	// User with repository ownership should be skipped
 	alice, err := db.Create(ctx, "alice", "alice@exmaple.com", CreateUserOptions{})
 	require.NoError(t, err)
@@ -720,7 +720,7 @@ func usersDeleteInactivated(t *testing.T, ctx context.Context, db *users) {
 	require.Len(t, users, 3)
 }
 
-func usersGetByEmail(t *testing.T, ctx context.Context, db *users) {
+func usersGetByEmail(t *testing.T, ctx context.Context, db *usersStore) {
 	t.Run("empty email", func(t *testing.T) {
 		_, err := db.GetByEmail(ctx, "")
 		wantErr := ErrUserNotExist{args: errutil.Args{"email": ""}}
@@ -781,7 +781,7 @@ func usersGetByEmail(t *testing.T, ctx context.Context, db *users) {
 	})
 }
 
-func usersGetByID(t *testing.T, ctx context.Context, db *users) {
+func usersGetByID(t *testing.T, ctx context.Context, db *usersStore) {
 	alice, err := db.Create(ctx, "alice", "alice@exmaple.com", CreateUserOptions{})
 	require.NoError(t, err)
 
@@ -794,7 +794,7 @@ func usersGetByID(t *testing.T, ctx context.Context, db *users) {
 	assert.Equal(t, wantErr, err)
 }
 
-func usersGetByUsername(t *testing.T, ctx context.Context, db *users) {
+func usersGetByUsername(t *testing.T, ctx context.Context, db *usersStore) {
 	alice, err := db.Create(ctx, "alice", "alice@exmaple.com", CreateUserOptions{})
 	require.NoError(t, err)
 
@@ -807,7 +807,7 @@ func usersGetByUsername(t *testing.T, ctx context.Context, db *users) {
 	assert.Equal(t, wantErr, err)
 }
 
-func usersGetByKeyID(t *testing.T, ctx context.Context, db *users) {
+func usersGetByKeyID(t *testing.T, ctx context.Context, db *usersStore) {
 	alice, err := db.Create(ctx, "alice", "alice@exmaple.com", CreateUserOptions{})
 	require.NoError(t, err)
 
@@ -832,7 +832,7 @@ func usersGetByKeyID(t *testing.T, ctx context.Context, db *users) {
 	assert.Equal(t, wantErr, err)
 }
 
-func usersGetMailableEmailsByUsernames(t *testing.T, ctx context.Context, db *users) {
+func usersGetMailableEmailsByUsernames(t *testing.T, ctx context.Context, db *usersStore) {
 	alice, err := db.Create(ctx, "alice", "alice@exmaple.com", CreateUserOptions{})
 	require.NoError(t, err)
 	bob, err := db.Create(ctx, "bob", "bob@exmaple.com", CreateUserOptions{Activated: true})
@@ -846,7 +846,7 @@ func usersGetMailableEmailsByUsernames(t *testing.T, ctx context.Context, db *us
 	assert.Equal(t, want, got)
 }
 
-func usersIsUsernameUsed(t *testing.T, ctx context.Context, db *users) {
+func usersIsUsernameUsed(t *testing.T, ctx context.Context, db *usersStore) {
 	alice, err := db.Create(ctx, "alice", "alice@example.com", CreateUserOptions{})
 	require.NoError(t, err)
 
@@ -896,7 +896,7 @@ func usersIsUsernameUsed(t *testing.T, ctx context.Context, db *users) {
 	}
 }
 
-func usersList(t *testing.T, ctx context.Context, db *users) {
+func usersList(t *testing.T, ctx context.Context, db *usersStore) {
 	alice, err := db.Create(ctx, "alice", "alice@example.com", CreateUserOptions{})
 	require.NoError(t, err)
 	bob, err := db.Create(ctx, "bob", "bob@example.com", CreateUserOptions{})
@@ -929,7 +929,7 @@ func usersList(t *testing.T, ctx context.Context, db *users) {
 	assert.Equal(t, bob.ID, got[1].ID)
 }
 
-func usersListFollowers(t *testing.T, ctx context.Context, db *users) {
+func usersListFollowers(t *testing.T, ctx context.Context, db *usersStore) {
 	john, err := db.Create(ctx, "john", "john@example.com", CreateUserOptions{})
 	require.NoError(t, err)
 
@@ -960,7 +960,7 @@ func usersListFollowers(t *testing.T, ctx context.Context, db *users) {
 	assert.Equal(t, alice.ID, got[0].ID)
 }
 
-func usersListFollowings(t *testing.T, ctx context.Context, db *users) {
+func usersListFollowings(t *testing.T, ctx context.Context, db *usersStore) {
 	john, err := db.Create(ctx, "john", "john@example.com", CreateUserOptions{})
 	require.NoError(t, err)
 
@@ -991,7 +991,7 @@ func usersListFollowings(t *testing.T, ctx context.Context, db *users) {
 	assert.Equal(t, alice.ID, got[0].ID)
 }
 
-func usersSearchByName(t *testing.T, ctx context.Context, db *users) {
+func usersSearchByName(t *testing.T, ctx context.Context, db *usersStore) {
 	alice, err := db.Create(ctx, "alice", "alice@example.com", CreateUserOptions{FullName: "Alice Jordan"})
 	require.NoError(t, err)
 	bob, err := db.Create(ctx, "bob", "bob@example.com", CreateUserOptions{FullName: "Bob Jordan"})
@@ -1029,7 +1029,7 @@ func usersSearchByName(t *testing.T, ctx context.Context, db *users) {
 	})
 }
 
-func usersUpdate(t *testing.T, ctx context.Context, db *users) {
+func usersUpdate(t *testing.T, ctx context.Context, db *usersStore) {
 	const oldPassword = "Password"
 	alice, err := db.Create(
 		ctx,
@@ -1142,7 +1142,7 @@ func usersUpdate(t *testing.T, ctx context.Context, db *users) {
 	assertValues()
 }
 
-func usersUseCustomAvatar(t *testing.T, ctx context.Context, db *users) {
+func usersUseCustomAvatar(t *testing.T, ctx context.Context, db *usersStore) {
 	alice, err := db.Create(ctx, "alice", "alice@example.com", CreateUserOptions{})
 	require.NoError(t, err)
 
@@ -1180,7 +1180,7 @@ func TestIsUsernameAllowed(t *testing.T) {
 	}
 }
 
-func usersAddEmail(t *testing.T, ctx context.Context, db *users) {
+func usersAddEmail(t *testing.T, ctx context.Context, db *usersStore) {
 	t.Run("multiple users can add the same unverified email", func(t *testing.T) {
 		alice, err := db.Create(ctx, "alice", "unverified@example.com", CreateUserOptions{})
 		require.NoError(t, err)
@@ -1197,7 +1197,7 @@ func usersAddEmail(t *testing.T, ctx context.Context, db *users) {
 	})
 }
 
-func usersGetEmail(t *testing.T, ctx context.Context, db *users) {
+func usersGetEmail(t *testing.T, ctx context.Context, db *usersStore) {
 	const testUserID = 1
 	const testEmail = "alice@example.com"
 	_, err := db.GetEmail(ctx, testUserID, testEmail, false)
@@ -1229,7 +1229,7 @@ func usersGetEmail(t *testing.T, ctx context.Context, db *users) {
 	assert.Equal(t, testEmail, got.Email)
 }
 
-func usersListEmails(t *testing.T, ctx context.Context, db *users) {
+func usersListEmails(t *testing.T, ctx context.Context, db *usersStore) {
 	t.Run("list emails with primary email", func(t *testing.T) {
 		alice, err := db.Create(ctx, "alice", "alice@example.com", CreateUserOptions{})
 		require.NoError(t, err)
@@ -1265,7 +1265,7 @@ func usersListEmails(t *testing.T, ctx context.Context, db *users) {
 	})
 }
 
-func usersMarkEmailActivated(t *testing.T, ctx context.Context, db *users) {
+func usersMarkEmailActivated(t *testing.T, ctx context.Context, db *usersStore) {
 	alice, err := db.Create(ctx, "alice", "alice@example.com", CreateUserOptions{})
 	require.NoError(t, err)
 
@@ -1283,7 +1283,7 @@ func usersMarkEmailActivated(t *testing.T, ctx context.Context, db *users) {
 	assert.NotEqual(t, alice.Rands, gotAlice.Rands)
 }
 
-func usersMarkEmailPrimary(t *testing.T, ctx context.Context, db *users) {
+func usersMarkEmailPrimary(t *testing.T, ctx context.Context, db *usersStore) {
 	alice, err := db.Create(ctx, "alice", "alice@example.com", CreateUserOptions{})
 	require.NoError(t, err)
 	err = db.AddEmail(ctx, alice.ID, "alice2@example.com", false)
@@ -1309,7 +1309,7 @@ func usersMarkEmailPrimary(t *testing.T, ctx context.Context, db *users) {
 	assert.False(t, gotEmail.IsActivated)
 }
 
-func usersDeleteEmail(t *testing.T, ctx context.Context, db *users) {
+func usersDeleteEmail(t *testing.T, ctx context.Context, db *usersStore) {
 	alice, err := db.Create(ctx, "alice", "alice@example.com", CreateUserOptions{})
 	require.NoError(t, err)
 
@@ -1325,7 +1325,7 @@ func usersDeleteEmail(t *testing.T, ctx context.Context, db *users) {
 	require.Equal(t, want, got)
 }
 
-func usersFollow(t *testing.T, ctx context.Context, db *users) {
+func usersFollow(t *testing.T, ctx context.Context, db *usersStore) {
 	usersStore := NewUsersStore(db.DB)
 	alice, err := usersStore.Create(ctx, "alice", "alice@example.com", CreateUserOptions{})
 	require.NoError(t, err)
@@ -1348,7 +1348,7 @@ func usersFollow(t *testing.T, ctx context.Context, db *users) {
 	assert.Equal(t, 1, bob.NumFollowers)
 }
 
-func usersIsFollowing(t *testing.T, ctx context.Context, db *users) {
+func usersIsFollowing(t *testing.T, ctx context.Context, db *usersStore) {
 	usersStore := NewUsersStore(db.DB)
 	alice, err := usersStore.Create(ctx, "alice", "alice@example.com", CreateUserOptions{})
 	require.NoError(t, err)
@@ -1369,7 +1369,7 @@ func usersIsFollowing(t *testing.T, ctx context.Context, db *users) {
 	assert.False(t, got)
 }
 
-func usersUnfollow(t *testing.T, ctx context.Context, db *users) {
+func usersUnfollow(t *testing.T, ctx context.Context, db *usersStore) {
 	usersStore := NewUsersStore(db.DB)
 	alice, err := usersStore.Create(ctx, "alice", "alice@example.com", CreateUserOptions{})
 	require.NoError(t, err)


### PR DESCRIPTION


## Test plan

CI