### PR TITLE
gogs.service: Remove syslog.target

### DIFF
--- a/scripts/systemd/gogs.service
+++ b/scripts/systemd/gogs.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Gogs
-After=syslog.target
 After=network.target
 After=mariadb.service mysql.service mysqld.service postgresql.service memcached.service redis.service
 


### PR DESCRIPTION
Remove syslog.target from service file, this target hasn't existed for over a decade.

https://github.com/systemd/systemd/blob/6aa8d43ade72e24c9426e604f7fc4b7582b9db7c/NEWS#L72-L73

## Checklist

- [X] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [X] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [X] I have added test cases to cover the new code or have provided the test plan.
