### PR TITLE
chore: upgrade go-mockgen for 1.22

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -34,8 +34,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          # go-mockgen panics on Go 1.22.x, see https://github.com/derision-test/go-mockgen/issues/51
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Install Task
         uses: arduino/setup-task@v2
         with:

--- a/gen.go
+++ b/gen.go
@@ -5,4 +5,4 @@
 package main
 
 //go:generate go install golang.org/x/tools/cmd/goimports@v0.17.0
-//go:generate go run github.com/derision-test/go-mockgen/cmd/go-mockgen@v1.3.7
+//go:generate go run github.com/derision-test/go-mockgen/v2/cmd/go-mockgen@v2.0.1


### PR DESCRIPTION


## Test plan

CI
