### PR TITLE
Fix issue: synchronize the section name[mailer/email] of app.ini

### DIFF
--- a/internal/route/install.go
+++ b/internal/route/install.go
@@ -339,13 +339,13 @@ func InstallPost(c *context.Context, f form.Install) {
 	}
 
 	if len(strings.TrimSpace(f.SMTPHost)) > 0 {
-		cfg.Section("mailer").Key("ENABLED").SetValue("true")
-		cfg.Section("mailer").Key("HOST").SetValue(f.SMTPHost)
-		cfg.Section("mailer").Key("FROM").SetValue(f.SMTPFrom)
-		cfg.Section("mailer").Key("USER").SetValue(f.SMTPUser)
-		cfg.Section("mailer").Key("PASSWD").SetValue(f.SMTPPasswd)
+		cfg.Section("email").Key("ENABLED").SetValue("true")
+		cfg.Section("email").Key("HOST").SetValue(f.SMTPHost)
+		cfg.Section("email").Key("FROM").SetValue(f.SMTPFrom)
+		cfg.Section("email").Key("USER").SetValue(f.SMTPUser)
+		cfg.Section("email").Key("PASSWD").SetValue(f.SMTPPasswd)
 	} else {
-		cfg.Section("mailer").Key("ENABLED").SetValue("false")
+		cfg.Section("email").Key("ENABLED").SetValue("false")
 	}
 	cfg.Section("server").Key("OFFLINE_MODE").SetValue(com.ToStr(f.OfflineMode))
 	cfg.Section("auth").Key("REQUIRE_EMAIL_CONFIRMATION").SetValue(com.ToStr(f.RegisterConfirm))


### PR DESCRIPTION
## Describe the pull request

When the application is first launched and the app.ini is configured via the web page, the section name written to app.ini is 'mailer' (in install.go), but when app.ini is loaded, the section name read is 'email' (in conf.go). This causes the configured email server to fail to work.


## Checklist

- [y] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [y] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [n] I have added test cases to cover the new code or have provided the test plan.

## Test plan

I just changed app.ini section name, then it works.

#[mailer]
[email]
ENABLED = true