### PR TITLE
docker: allow running Gogs with a different user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN apk --no-cache --no-progress add \
   tzdata \
   rsync
 
+ARG USER_GOGS
 ENV GOGS_CUSTOM /data/gogs
 
 # Configure LibC Name Service

--- a/docker/build/finalize.sh
+++ b/docker/build/finalize.sh
@@ -18,11 +18,6 @@ wget --quiet https://github.com/tianon/gosu/releases/download/1.14/gosu-${arch} 
 echo "${checksum}  /usr/sbin/gosu" | sha256sum -cs
 chmod +x /usr/sbin/gosu
 
-# Create git user for Gogs
-addgroup -S git
-adduser -G git -H -D -g 'Gogs Git User' git -h /data/git -s /bin/bash && usermod -p '*' git && passwd -u git
-echo "export GOGS_CUSTOM=${GOGS_CUSTOM}" >> /etc/profile
-
 # Final cleaning
 rm -rf /app/gogs/build
 rm -rf /app/gogs/docker/build

--- a/docker/s6/gogs/run
+++ b/docker/s6/gogs/run
@@ -5,4 +5,4 @@ if test -f ./setup; then
     source ./setup
 fi
 
-exec gosu "$USER" /app/gogs/gogs web
+exec gosu "$USER_GOGS" /app/gogs/gogs web

--- a/docker/s6/gogs/run
+++ b/docker/s6/gogs/run
@@ -1,8 +1,13 @@
 #!/bin/sh
+if test -n "$USER_GOGS"; then 
+    export USER=$USER_GOGS 
+else
+    export USER=git
+fi
 
 if test -f ./setup; then
     # shellcheck disable=SC2039,SC1091,SC3046
     source ./setup
 fi
 
-exec gosu "$USER_GOGS" /app/gogs/gogs web
+exec gosu "$USER" /app/gogs/gogs web

--- a/docker/s6/gogs/setup
+++ b/docker/s6/gogs/setup
@@ -1,13 +1,20 @@
 #!/bin/sh
-
-if ! test -d ~git/.ssh; then
-    gosu "$USER_GOGS" mkdir -p ~$USER_GOGS/.ssh
-    chmod 700 ~$USER_GOGS/.ssh
+if test -n "$USER_GOGS"; then 
+    export USER=$USER_GOGS 
+else
+    export USER=git
 fi
 
-if ! test -f ~$USER_GOGS/.ssh/environment; then
-    gosu "$USER_GOGS" echo "GOGS_CUSTOM=${GOGS_CUSTOM}" > ~$USER_GOGS/.ssh/environment
-    chmod 600 ~$USER_GOGS/.ssh/environment
+USER_HOME=$(eval echo ~$USER)
+
+if ! test -d $USER_HOME/.ssh; then
+    gosu "$USER" mkdir -p $USER_HOME/.ssh
+    chmod 700 $USER_HOME/.ssh
+fi
+
+if ! test -f $USER_HOME/.ssh/environment; then
+    gosu "$USER" echo "GOGS_CUSTOM=${GOGS_CUSTOM}" > $USER_HOME/.ssh/environment
+    chmod 600 $USER_HOME/.ssh/environment
 fi
 
 cd /app/gogs || exit 1
@@ -17,6 +24,6 @@ ln -sfn /data/gogs/log  ./log
 ln -sfn /data/gogs/data ./data
 
 # Backward Compatibility with Gogs Container v0.6.15
-ln -sfn /data/git /home/git
+ln -sfn /data/git /home/$USER
 
-chmod 0755 /data /data/gogs ~$USER_GOGS/
+chmod 0755 /data /data/gogs $USER_HOME/

--- a/docker/s6/gogs/setup
+++ b/docker/s6/gogs/setup
@@ -1,13 +1,13 @@
 #!/bin/sh
 
 if ! test -d ~git/.ssh; then
-    gosu "$USER" mkdir -p ~git/.ssh
-    chmod 700 ~git/.ssh
+    gosu "$USER_GOGS" mkdir -p ~$USER_GOGS/.ssh
+    chmod 700 ~$USER_GOGS/.ssh
 fi
 
-if ! test -f ~git/.ssh/environment; then
-    gosu "$USER" echo "GOGS_CUSTOM=${GOGS_CUSTOM}" > ~git/.ssh/environment
-    chmod 600 ~git/.ssh/environment
+if ! test -f ~$USER_GOGS/.ssh/environment; then
+    gosu "$USER_GOGS" echo "GOGS_CUSTOM=${GOGS_CUSTOM}" > ~$USER_GOGS/.ssh/environment
+    chmod 600 ~$USER_GOGS/.ssh/environment
 fi
 
 cd /app/gogs || exit 1
@@ -19,4 +19,4 @@ ln -sfn /data/gogs/data ./data
 # Backward Compatibility with Gogs Container v0.6.15
 ln -sfn /data/git /home/git
 
-chmod 0755 /data /data/gogs ~git/
+chmod 0755 /data /data/gogs ~$USER_GOGS/

--- a/docker/s6/gogs/setup
+++ b/docker/s6/gogs/setup
@@ -24,6 +24,6 @@ ln -sfn /data/gogs/log  ./log
 ln -sfn /data/gogs/data ./data
 
 # Backward Compatibility with Gogs Container v0.6.15
-ln -sfn /data/git /home/$USER
+ln -sfn /data/$USER /home/$USER
 
 chmod 0755 /data /data/gogs $USER_HOME/

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -48,27 +48,27 @@ create_volume_subfolder() {
 
 setids() {
     # export USER=$USER_GOGS
-    USER_ID=$(id -u $USER)
-    GROUP_ID=$(id -g $USER)
+    USER_ID="$(id -u "${USER}")"
+    GROUP_ID="$(id -g "${USER}")"
 
-    PUID=${PUID:-${USER_ID}}
-    PGID=${PGID:-${GROUP_ID}}
+    PUID="${PUID:-${USER_ID}}"
+    PGID="${PGID:-${GROUP_ID}}"
 
-    echo "setting groupID as $PGID"
-    echo "setting userID as $PUID"
+    echo "setting groupID as ${PGID}"
+    echo "setting userID as ${PUID}"
 
-    groupmod -o -g "$PGID" $USER
-    usermod -o -u "$PUID" $USER
+    groupmod -o -g "$PGID" "$USER"
+    usermod -o -u "$PUID" "$USER"
 }
 
 manageusername() {
     if test -n "$USER_GOGS"; then 
-        export USER=$USER_GOGS 
+        export USER="$USER_GOGS" 
     else
         export USER=git
     fi
 
-    export USER_HOME=$(eval echo ~$USER)
+    export USER_HOME=$"(eval echo ~$USER)"
 }
 
 createuser(){
@@ -79,8 +79,8 @@ createuser(){
         return
     fi
     # Create user/group to run Gogs
-    addgroup -S $USER
-    adduser -G $USER -H -D -g 'Gogs Git User' $USER -h /data/$USER -s /bin/bash && usermod -p '*' $USER && passwd -u $USER
+    addgroup -S "$USER"
+    adduser -G "$USER" -H -D -g 'Gogs Git User' "$USER" -h /data/"$USER" -s /bin/bash && usermod -p '*' "$USER" && passwd -u "$USER"
     # add gogs configuration in profile file
     echo "export GOGS_CUSTOM=$GOGS_CUSTOM" >> /etc/profile
     # add allowed user to ssh server configuration

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -47,13 +47,22 @@ create_volume_subfolder() {
 }
 
 setids() {
-    export USER=git
+    # export USER=$USER_GOGS
     PUID=${PUID:-1000}
     PGID=${PGID:-1000}
     groupmod -o -g "$PGID" $USER
     usermod -o -u "$PUID" $USER
 }
 
+createuser(){
+    export USER=$USER_GOGS
+    # Create git user for Gogs
+    addgroup -S $USER_GOGS
+    adduser -G $USER -H -D -g 'Gogs Git User' $USER -h /data/$USER -s /bin/bash && usermod -p '*' $USER && passwd -u $USER
+    echo "export GOGS_CUSTOM=$GOGS_CUSTOM" >> /etc/profile
+}
+
+createuser
 setids
 cleanup
 create_volume_subfolder

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -56,10 +56,20 @@ setids() {
 
 createuser(){
     export USER=$USER_GOGS
-    # Create git user for Gogs
+
+    # check if user alread exists
+    exists=$(cat /etc/passwd | grep "$USER")
+    if test -n "$exists"; then
+        # if exists return
+        return
+    fi
+    # Create user/group to run Gogs
     addgroup -S $USER_GOGS
     adduser -G $USER -H -D -g 'Gogs Git User' $USER -h /data/$USER -s /bin/bash && usermod -p '*' $USER && passwd -u $USER
+    # add gogs configuration in profile file
     echo "export GOGS_CUSTOM=$GOGS_CUSTOM" >> /etc/profile
+    # add allowed user to ssh server configuration
+    echo "AllowUsers $USER" >> /app/gogs/docker/sshd_config
 }
 
 createuser

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -54,9 +54,17 @@ setids() {
     usermod -o -u "$PUID" $USER
 }
 
-createuser(){
-    export USER=$USER_GOGS
+manageusername() {
+    if test -n "$USER_GOGS"; then 
+        export USER=$USER_GOGS 
+    else
+        export USER=git
+    fi
 
+    export USER_HOME=$(eval echo ~$USER)
+}
+
+createuser(){
     # check if user alread exists
     exists=$(cat /etc/passwd | grep "$USER")
     if test -n "$exists"; then
@@ -64,14 +72,16 @@ createuser(){
         return
     fi
     # Create user/group to run Gogs
-    addgroup -S $USER_GOGS
+    addgroup -S $USER
     adduser -G $USER -H -D -g 'Gogs Git User' $USER -h /data/$USER -s /bin/bash && usermod -p '*' $USER && passwd -u $USER
+    mkdir -p $USER_HOME
     # add gogs configuration in profile file
     echo "export GOGS_CUSTOM=$GOGS_CUSTOM" >> /etc/profile
     # add allowed user to ssh server configuration
     echo "AllowUsers $USER" >> /app/gogs/docker/sshd_config
 }
 
+manageusername
 createuser
 setids
 cleanup

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -73,7 +73,7 @@ manageusername() {
 
 createuser(){
     # check if user alread exists
-    exists=$(cat /etc/passwd | grep "$USER")
+    exists=$(grep "$USER" /etc/passwd )
     if test -n "$exists"; then
         # if exists return
         return

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -74,7 +74,6 @@ createuser(){
     # Create user/group to run Gogs
     addgroup -S $USER
     adduser -G $USER -H -D -g 'Gogs Git User' $USER -h /data/$USER -s /bin/bash && usermod -p '*' $USER && passwd -u $USER
-    mkdir -p $USER_HOME
     # add gogs configuration in profile file
     echo "export GOGS_CUSTOM=$GOGS_CUSTOM" >> /etc/profile
     # add allowed user to ssh server configuration

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -48,8 +48,15 @@ create_volume_subfolder() {
 
 setids() {
     # export USER=$USER_GOGS
-    PUID=${PUID:-1000}
-    PGID=${PGID:-1000}
+    USER_ID=$(id -u $USER)
+    GROUP_ID=$(id -g $USER)
+
+    PUID=${PUID:-${USER_ID}}
+    PGID=${PGID:-${GROUP_ID}}
+
+    echo "setting groupID as $PGID"
+    echo "setting userID as $PUID"
+
     groupmod -o -g "$PGID" $USER
     usermod -o -u "$PUID" $USER
 }


### PR DESCRIPTION
At the moment the user running Gogs is git, although this is valid for the vast majority of the cases, there are situations where a different user needs to be configured.

For example: we need that a repository in Gogs is synchronized with an existing git repository in which user git is already used and allow only the commits coming from Gogs repository. In this case we need a specific user name different from the standard one.

PLEASE NOTE:

It's very important to notice that the user written in the app.ini configuration file (created during the gogs installation) must be consistent with the user set in the GOGS_USER environment variable.
Actually, this is completely left to the user, who must be aware to set the very same user.

As a future fix, it would be good to prefill the user input box in the installation screen with the value of the passed GOGS_USER.

Link to the issue: "n/a"