### PR TITLE
fix(.editorconfig): remove setting end_of_line and make Git track EOL changes on Windows

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,6 @@ root = true
 
 [*]
 charset = utf-8
-end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 


### PR DESCRIPTION
…line changes on Windows

## Describe the pull request

By default, Git automatically changes end_of_line between LF and CRLF.
In this case, when a file is opened in an editor with editorconfig on Windows, and then saved without any textual changes,
editorconfig will change end_of_line from CRLF to LF.
At the same time, Git will notice this change. You have to commit it or restore it.

Just let Git handle it, I suggest removing the setting of end_of_line in editorconfig.

Link to the issue:  n/a" 

## Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [ ] I have added test cases to cover the new code or have provided the test plan.


