### PR TITLE
fix(systemd script): define RestartSec as 2

### DIFF
--- a/scripts/systemd/gogs.service
+++ b/scripts/systemd/gogs.service
@@ -17,6 +17,7 @@ Group=git
 WorkingDirectory=/home/git/gogs
 ExecStart=/home/git/gogs/gogs web
 Restart=always
+RestartSec=2s
 Environment=USER=git HOME=/home/git
 
 # Some distributions may not support these hardening directives. If you cannot start the service due


### PR DESCRIPTION
## Describe the pull request

The value of RestartSec is suggested to be greater than 1. (defaults to 100 ms)
[suggestion on https://serverfault.com/](https://serverfault.com/questions/610795/is-it-better-to-use-the-systemd-service-units-restart-restartsec-or-use-a-sy).

The reason is that

"The default limit is to allow 5 restarts in a 10sec period. If a service goes over that threshold due to the Restart= config option in the service definition, it will not attempt to restart any further.
The rates are configured with the StartLimitIntervalSec= (defaults to 10 s) and StartLimitBurst= (defaults to 5) options and the Restart= option controls when SystemD tries to restart a service."

 [explanation on https://serverfault.com/](https://serverfault.com/questions/845471/service-start-request-repeated-too-quickly-refusing-to-start-limit)

[manual of systemd](https://www.man7.org/linux/man-pages/man5/systemd-system.conf.5.html)

Link to the issue: "n/a" 

## Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [ ] I have added test cases to cover the new code or have provided the test plan.

