### PR TITLE
chore: fix miss makezero bug

### DIFF
--- a/internal/database/org.go
+++ b/internal/database/org.go
@@ -412,7 +412,7 @@ func RemoveOrgUser(orgID, userID int64) error {
 	}
 
 	// Delete all repository accesses and unwatch them.
-	repoIDs := make([]int64, len(repos))
+	repoIDs := make([]int64, 0, len(repos))
 	for i := range repos {
 		repoIDs = append(repoIDs, repos[i].ID)
 		if err = watchRepo(sess, user.ID, repos[i].ID, false); err != nil {


### PR DESCRIPTION
## Describe the pull request

I was running github actions to run linter [makezero](https://github.com/ashanbrown/makezero) for top github golang repos.

see issues https://github.com/alingse/go-linter-runner/issues/1

and the github actions output https://github.com/alingse/go-linter-runner/actions/runs/9241873083/job/25423942721

the repoIDs was only filled with `[0, 0, 0]` and this `In("repo_id",  repoIDs)` will not cause a real bug.

```
	if len(repoIDs) > 0 {
		if _, err = sess.Where("user_id = ?", user.ID).In("repo_id", repoIDs).Delete(new(Access)); err != nil {
			return err
		}
	}
```


## Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [x] I have added test cases to cover the new code or have provided the test plan.

## Test plan

