### PR TITLE
Fix spacing if BuildTime is missing.

### DIFF
--- a/templates/admin/dashboard.tmpl
+++ b/templates/admin/dashboard.tmpl
@@ -23,7 +23,7 @@
 							{{else}}
 								N/A
 							{{end}}
-                                                </dd>
+							</dd>
 						<dt>{{.i18n.Tr "admin.dashboard.build_commit"}}</dt>
 						<dd>
 							{{if .BuildCommit}}

--- a/templates/admin/dashboard.tmpl
+++ b/templates/admin/dashboard.tmpl
@@ -23,7 +23,7 @@
 							{{else}}
 								N/A
 							{{end}}
-							</dd>
+						</dd>
 						<dt>{{.i18n.Tr "admin.dashboard.build_commit"}}</dt>
 						<dd>
 							{{if .BuildCommit}}

--- a/templates/admin/dashboard.tmpl
+++ b/templates/admin/dashboard.tmpl
@@ -17,7 +17,13 @@
 						<dt>{{.i18n.Tr "admin.dashboard.go_version"}}</dt>
 						<dd>{{.GoVersion}}</dd>
 						<dt>{{.i18n.Tr "admin.dashboard.build_time"}}</dt>
-						<dd>{{.BuildTime}}</dd>
+						<dd>
+							{{if .BuildTime}}
+								{{.BuildTime}}
+							{{else}}
+								N/A
+							{{end}}
+                                                </dd>
 						<dt>{{.i18n.Tr "admin.dashboard.build_commit"}}</dt>
 						<dd>
 							{{if .BuildCommit}}


### PR DESCRIPTION
## Describe the pull request
When BuildTime is not populated, the information box in the Admin Dashboard looks a bit weird. 
![Before Fix](https://github.com/user-attachments/assets/f72a07e5-fdb7-43a4-81ca-54801b78ca7e)

Link to the issue: #7799 

## Checklist

- [X] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [X] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [X] I have added test cases to cover the new code or have provided the test plan.

## Test plan
1. Clone repo and get tools
2. Build the project using `go build -o gogs`
3. Run server, and check Admin Dashboard page
4. Build Information box should not overlap with the Build Commit field
