### PR TITLE
install: fix SMTP password config name to save

### DIFF
--- a/internal/route/install.go
+++ b/internal/route/install.go
@@ -343,7 +343,7 @@ func InstallPost(c *context.Context, f form.Install) {
 		cfg.Section("email").Key("HOST").SetValue(f.SMTPHost)
 		cfg.Section("email").Key("FROM").SetValue(f.SMTPFrom)
 		cfg.Section("email").Key("USER").SetValue(f.SMTPUser)
-		cfg.Section("email").Key("PASSWD").SetValue(f.SMTPPasswd)
+		cfg.Section("email").Key("PASSWORD").SetValue(f.SMTPPasswd)
 	} else {
 		cfg.Section("email").Key("ENABLED").SetValue("false")
 	}


### PR DESCRIPTION
fix SMTP password config name from PASSWD to PASSWORD on install.

## Describe the pull request

After installation, I found that sending emails was not working. Then I noticed that the email password was not being loaded because the initial installation configured the password in a field called PASSWD but apparently this field was renamed to PASSWORD. I tested using the new name and the email was sent successfully.


