### PR TITLE
Fix s6-svscan path in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,4 +41,4 @@ VOLUME ["/data", "/backup"]
 EXPOSE 22 3000
 HEALTHCHECK CMD (curl -o /dev/null -sS http://localhost:3000/healthcheck) || exit 1
 ENTRYPOINT ["/app/gogs/docker/start.sh"]
-CMD ["/bin/s6-svscan", "/app/gogs/docker/s6/"]
+CMD ["/usr/bin/s6-svscan", "/app/gogs/docker/s6/"]


### PR DESCRIPTION
Related to #7864

## Describe the pull request

Fix the path of the s6-svscan binary path in the Dockerfile. As mentionned in the issue, it is probably to the alpine base image change (from `3.17` to `3.21`).

Link to the issue: https://github.com/gogs/gogs/issues/7864#issuecomment-2558323928

Credit to @cryptovaltt

## Checklist

- [X] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [X] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [X] I have added test cases to cover the new code or have provided the test plan.

## Test plan

Build the image and check if the application can be ran. E.g.:

```bash
docker build -t gogs:working-7864 -f Dockerfile .
docker run --name=gogs -p 10022:22 -p 10880:3000 -v gogs:working-7864 --rm
```
