### PR TITLE
database: lock mock properly to avoid data race in tests

### DIFF
--- a/internal/database/actions_test.go
+++ b/internal/database/actions_test.go
@@ -706,6 +706,7 @@ func actionsPushTag(t *testing.T, ctx context.Context, s *ActionsStore) {
 	// NOTE: We set a noop mock here to avoid data race with other tests that writes
 	// to the mock server because this function holds a lock.
 	conf.SetMockServer(t, conf.ServerOpts{})
+	conf.SetMockSSH(t, conf.SSHOpts{})
 
 	alice, err := newUsersStore(s.db).Create(ctx, "alice", "alice@example.com", CreateUserOptions{})
 	require.NoError(t, err)


### PR DESCRIPTION
Fixes tests data race found in https://github.com/gogs/gogs/actions/runs/12457230279/job/34771555537
