### PR TITLE
Set timeout to explicit 0 in gogs.js

### DIFF
--- a/public/js/gogs.js
+++ b/public/js/gogs.js
@@ -1474,6 +1474,7 @@ $(document).ready(function() {
       headers: { "X-CSRF-Token": csrf },
       maxFiles: $dropzone.data("max-file"),
       maxFilesize: $dropzone.data("max-size"),
+      timeout: 0,
       acceptedFiles:
         $dropzone.data("accepts") === "*/*" ? null : $dropzone.data("accepts"),
       addRemoveLinks: true,


### PR DESCRIPTION
## Describe the pull request

A simple fix in public/js/gogs.js making bug upload not result in a timeout (added just one line)

Link to the issue: closes https://github.com/gogs/gogs/issues/6149

## Checklist

- [X] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [X] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [ ] I have added test cases to cover the new code or have provided the test plan.

## Test plan

- Set the max_size of `attachment` to a high number

```toml
[release.attachment]
ENABLED          = true
ALLOWED_TYPES    = */*
MAX_SIZE         = 512
MAX_FILES        = 20
```

- Upload a file to releases

![image](https://github.com/user-attachments/assets/8cf29c73-c8ec-42a3-9660-681a583b577a)

It doesn't randomly timeout!