### PR TITLE
fix: space in bahasa indonesia

### DIFF
--- a/conf/locale/locale_id-ID.ini
+++ b/conf/locale/locale_id-ID.ini
@@ -1405,8 +1405,8 @@ mirror_sync_delete=synced and deleted reference <code>%[2]s</code> at <a href="%
 ago=lalu
 from_now=dari sekarang
 now=sekarang
-1s=1detik %s
-1m=1menit %s
+1s=1 detik %s
+1m=1 menit %s
 1h=1 jam %s
 1d=1 hari %s
 1w=1 Minggu %s


### PR DESCRIPTION
## Fix Wording in Bahasa Indonesia

Just add space for Bahasa Indonesia word so it will make good UI for tools

```
1s=1detik %s
1m=1menit %s
```
to
```
1s=1 detik %s
1m=1 menit %s
```