### PR TITLE
api: fix nil pointer dereference when listing user repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to Gogs are documented in this file.
 
 - Submodules using `ssh://` protocol and a port number are not rendered correctly. [#4941](https://github.com/gogs/gogs/issues/4941)
 - Missing link to user profile on the first commit in commits history page. [#7404](https://github.com/gogs/gogs/issues/7404)
+- Route `GET /api/v1/user/repos` responses 500 when accessible repositories contain forks. [#8069](https://github.com/gogs/gogs/pull/8069)
 
 ## 0.13.3
 

--- a/internal/route/api/v1/repo/repo.go
+++ b/internal/route/api/v1/repo/repo.go
@@ -116,29 +116,28 @@ func listUserRepositories(c *context.APIContext, username string) {
 		return
 	}
 
-	accessibleRepos, err := database.Handle.Repositories().GetByCollaboratorIDWithAccessMode(c.Req.Context(), user.ID)
+	accessibleReposWithAccessMode, err := database.Handle.Repositories().GetByCollaboratorIDWithAccessMode(c.Req.Context(), user.ID)
 	if err != nil {
 		c.Error(err, "get repositories accesses by collaborator")
 		return
 	}
 
-	// Load attributes for accessible repositories
-	accessibleRepoSlice := make([]*database.Repository, 0, len(accessibleRepos))
-	for repo := range accessibleRepos {
-		accessibleRepoSlice = append(accessibleRepoSlice, repo)
+	accessibleRepos := make([]*database.Repository, 0, len(accessibleReposWithAccessMode))
+	for repo := range accessibleReposWithAccessMode {
+		accessibleRepos = append(accessibleRepos, repo)
 	}
-	if err = database.RepositoryList(accessibleRepoSlice).LoadAttributes(); err != nil {
+	if err = database.RepositoryList(accessibleRepos).LoadAttributes(); err != nil {
 		c.Error(err, "load attributes for accessible repositories")
 		return
 	}
 
 	numOwnRepos := len(ownRepos)
-	repos := make([]*api.Repository, 0, numOwnRepos+len(accessibleRepos))
+	repos := make([]*api.Repository, 0, numOwnRepos+len(accessibleReposWithAccessMode))
 	for _, r := range ownRepos {
 		repos = append(repos, r.APIFormatLegacy(&api.Permission{Admin: true, Push: true, Pull: true}))
 	}
 
-	for repo, access := range accessibleRepos {
+	for repo, access := range accessibleReposWithAccessMode {
 		repos = append(repos,
 			repo.APIFormatLegacy(&api.Permission{
 				Admin: access >= database.AccessModeAdmin,


### PR DESCRIPTION
## Describe the pull request

In `listUserRepositories`, after querying the associated repo, attributes were not loaded, causing `BaseRepo` to be nil when executing `apiRepo.Parent = r.BaseRepo.APIFormatLegacy(p)` in `APIFormatLegacy`. Add code to load attributes to fix this issue.

Link to the issue: Closes https://github.com/gogs/gogs/issues/7830

## Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [ ] I have added test cases to cover the new code or have provided the test plan.

## Test plan

<!-- Please provide concrete but concise steps to proof things are working as stated, see an example in https://github.com/gogs/gogs/pull/7345 -->
