### PR TITLE
fix(Dockerfile.next): install curl

### DIFF
--- a/Dockerfile.next
+++ b/Dockerfile.next
@@ -23,6 +23,7 @@ RUN addgroup -g ${GOGS_GID} -S git && \
 RUN apk --no-cache --no-progress add \
   bash \
   ca-certificates \
+  curl \
   git \
   linux-pam \
   openssh-keygen


### PR DESCRIPTION
## Describe the pull request

curl is required by healthcheck command
curl is installed in legacy docker image but not in docker-next image
Consequently, docker-next image never get healthy.

## Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [ ] I have added test cases to cover the new code or have provided the test plan.
