### PR TITLE
security: fix cross-repository label modification vulnerability

### DIFF
--- a/internal/route/repo/issue.go
+++ b/internal/route/repo/issue.go
@@ -1056,9 +1056,9 @@ func NewLabel(c *context.Context, f form.CreateLabel) {
 }
 
 func UpdateLabel(c *context.Context, f form.CreateLabel) {
-	l, err := database.GetLabelByID(f.ID)
+	l, err := database.GetLabelOfRepoByID(c.Repo.Repository.ID, f.ID)
 	if err != nil {
-		c.NotFoundOrError(err, "get label by ID")
+		c.NotFoundOrError(err, "get label of repository by ID")
 		return
 	}
 


### PR DESCRIPTION
## Summary

- Fix broken access control vulnerability in `UpdateLabel` that allowed cross-repository label tampering

## Details

The `UpdateLabel` function in `internal/route/repo/issue.go` used `database.GetLabelByID(f.ID)` which fetches labels without validating repository ownership. This allowed authenticated users with write access to any repository to modify labels belonging to other repositories.

Changed to use `database.GetLabelOfRepoByID(c.Repo.Repository.ID, f.ID)` which validates the label belongs to the current repository at the database layer, consistent with how `DeleteLabel` and the API's `EditLabel` handle this.


## References

- https://github.com/gogs/gogs/security/advisories/GHSA-cv22-72px-f4gh

🤖 Generated with [Claude Code](https://claude.com/claude-code)