### PR TITLE
security: require authentication for attachment uploads

### DIFF
--- a/internal/cmd/web.go
+++ b/internal/cmd/web.go
@@ -329,9 +329,12 @@ func runWeb(c *cli.Context) error {
 					return
 				}
 			})
+		}, ignSignIn)
+
+		m.Group("", func() {
 			m.Post("/issues/attachments", repo.UploadIssueAttachment)
 			m.Post("/releases/attachments", repo.UploadReleaseAttachment)
-		}, ignSignIn)
+		}, reqSignIn)
 
 		m.Group("/:username", func() {
 			m.Post("/action/:action", user.Action)


### PR DESCRIPTION
## Summary

- Fix unauthenticated file upload vulnerability (GHSA-fc3h-92p8-h36f)
- Move `/issues/attachments` and `/releases/attachments` endpoints from `ignSignIn` to `reqSignIn` route group

## Background

The `/issues/attachments` and `/releases/attachments` endpoints were placed in the `ignSignIn` route group, which only enforces authentication when `RequireSignInView` is enabled. Since the default is disabled, anonymous users could upload arbitrary files to the server.

This could be exploited for:
- Disk exhaustion via repeated uploads
- Using the Gogs instance as a public file host
- Hosting malware or phishing payloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)