### PR TITLE
fix(release): remove "v" prefix from archive names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
         id: version
         run: |
           if [ "${{ github.event_name }}" = "release" ]; then
-            echo "version=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+            echo "version=${{ github.event.release.tag_name }}" | sed 's/version=v/version=/' >> "$GITHUB_OUTPUT"
             echo "release_tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
           elif [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
             echo "version=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Strip the "v" prefix from release tag when constructing archive names
- Changes `gogs_v0.14.1_darwin_amd64.zip` to `gogs_0.14.1_darwin_amd64.zip`

## Test plan
- [ ] Verify the release workflow runs successfully on this PR
- [ ] Check that archive names in the test release don't include the "v" prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)