### PR TITLE
refactor: move main package from root to cmd/gogs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
               -X \"gogs.io/gogs/internal/conf.BuildCommit=$(git rev-parse HEAD)\"
             " \
             $TAGS_FLAG \
-            -trimpath -o "$BINARY_NAME"
+            -trimpath -o "$BINARY_NAME" ./cmd/gogs
       - name: Prepare archive contents
         run: |
           mkdir -p dist/gogs

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -24,7 +24,7 @@ tasks:
           -X "{{.PKG_PATH}}.BuildCommit={{.BUILD_COMMIT}}"
         '
         -tags '{{.TAGS}}'
-        -trimpath -o .bin/gogs{{.BINARY_EXT}}
+        -trimpath -o .bin/gogs{{.BINARY_EXT}} ./cmd/gogs
     vars:
       PKG_PATH: gogs.io/gogs/internal/conf
       BUILD_TIME:
@@ -33,7 +33,7 @@ tasks:
         sh: git rev-parse HEAD
     sources:
       - go.mod
-      - gogs.go
+      - cmd/gogs/*.go
       - internal/**/*.go
       - conf/**/*
       - public/**/*

--- a/cmd/gogs/admin.go
+++ b/cmd/gogs/admin.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"context"
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	Admin = cli.Command{
+	adminCommand = cli.Command{
 		Name:  "admin",
 		Usage: "Perform admin operations on command line",
 		Description: `Allow using internal logic of Gogs without hacking into the source code

--- a/cmd/gogs/backup.go
+++ b/cmd/gogs/backup.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"context"
@@ -20,7 +20,7 @@ import (
 	"gogs.io/gogs/internal/osutil"
 )
 
-var Backup = cli.Command{
+var backupCommand = cli.Command{
 	Name:  "backup",
 	Usage: "Backup files and database",
 	Description: `Backup dumps and compresses all related files and database into zip file,

--- a/cmd/gogs/cert.go
+++ b/cmd/gogs/cert.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package cmd
+package main
 
 import (
 	"crypto/ecdsa"
@@ -22,7 +22,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-var Cert = cli.Command{
+var certCommand = cli.Command{
 	Name:  "cert",
 	Usage: "Generate self-signed certificate",
 	Description: `Generate a self-signed X.509 certificate for a TLS server.

--- a/cmd/gogs/cmd.go
+++ b/cmd/gogs/cmd.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"time"
@@ -21,7 +21,6 @@ func boolFlag(name, usage string) cli.BoolFlag {
 	}
 }
 
-//nolint:deadcode,unused
 func intFlag(name string, value int, usage string) cli.IntFlag {
 	return cli.IntFlag{
 		Name:  name,
@@ -30,7 +29,6 @@ func intFlag(name string, value int, usage string) cli.IntFlag {
 	}
 }
 
-//nolint:deadcode,unused
 func durationFlag(name string, value time.Duration, usage string) cli.DurationFlag {
 	return cli.DurationFlag{
 		Name:  name,

--- a/cmd/gogs/hook.go
+++ b/cmd/gogs/hook.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"bufio"
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	Hook = cli.Command{
+	hookCommand = cli.Command{
 		Name:        "hook",
 		Usage:       "Delegate commands to corresponding Git hooks",
 		Description: "All sub-commands should only be called by Git",

--- a/cmd/gogs/import.go
+++ b/cmd/gogs/import.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"bufio"
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	Import = cli.Command{
+	importCommand = cli.Command{
 		Name:  "import",
 		Usage: "Import portable data as local Gogs data",
 		Description: `Allow user import data from other Gogs installations to local instance

--- a/cmd/gogs/main.go
+++ b/cmd/gogs/main.go
@@ -7,7 +7,6 @@ import (
 	"github.com/urfave/cli"
 	log "unknwon.dev/clog/v2"
 
-	"gogs.io/gogs/internal/cmd"
 	"gogs.io/gogs/internal/conf"
 )
 
@@ -21,14 +20,14 @@ func main() {
 	app.Usage = "A painless self-hosted Git service"
 	app.Version = conf.App.Version
 	app.Commands = []cli.Command{
-		cmd.Web,
-		cmd.Serv,
-		cmd.Hook,
-		cmd.Cert,
-		cmd.Admin,
-		cmd.Import,
-		cmd.Backup,
-		cmd.Restore,
+		webCommand,
+		servCommand,
+		hookCommand,
+		certCommand,
+		adminCommand,
+		importCommand,
+		backupCommand,
+		restoreCommand,
 	}
 	if err := app.Run(os.Args); err != nil {
 		log.Fatal("Failed to start application: %v", err)

--- a/cmd/gogs/restore.go
+++ b/cmd/gogs/restore.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"context"
@@ -18,7 +18,7 @@ import (
 	"gogs.io/gogs/internal/semverutil"
 )
 
-var Restore = cli.Command{
+var restoreCommand = cli.Command{
 	Name:  "restore",
 	Usage: "Restore files and database from backup",
 	Description: `Restore imports all related files and database from a backup archive.

--- a/cmd/gogs/serv.go
+++ b/cmd/gogs/serv.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"context"
@@ -21,7 +21,7 @@ const (
 	accessDeniedMessage = "Repository does not exist or you do not have access"
 )
 
-var Serv = cli.Command{
+var servCommand = cli.Command{
 	Name:        "serv",
 	Usage:       "This command should only be called by SSH shell",
 	Description: `Serv provide access auth for repositories`,

--- a/cmd/gogs/web.go
+++ b/cmd/gogs/web.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"crypto/tls"
@@ -45,7 +45,7 @@ import (
 	"gogs.io/gogs/templates"
 )
 
-var Web = cli.Command{
+var webCommand = cli.Command{
 	Name:  "web",
 	Usage: "Start web server",
 	Description: `Gogs web server is the only thing you need to run,

--- a/internal/conf/static.go
+++ b/internal/conf/static.go
@@ -231,7 +231,7 @@ var (
 )
 
 type AppOpts struct {
-	// ⚠️ WARNING: Should only be set by the main package (i.e. "gogs.go").
+	// ⚠️ WARNING: Should only be set by the main package (i.e. "cmd/gogs/main.go").
 	Version string `ini:"-"`
 
 	BrandName string
@@ -502,7 +502,7 @@ func checkInvalidOptions(config *ini.File) (warnings []string) {
 // HookMode indicates whether program starts as Git server-side hook callback.
 // All operations should be done synchronously to prevent program exits before finishing.
 //
-// ⚠️ WARNING: Should only be set by "internal/cmd/serv.go".
+// ⚠️ WARNING: Should only be set by "cmd/gogs/serv.go".
 var HookMode bool
 
 // Indicates which database backend is currently being used.


### PR DESCRIPTION
## Summary

- Move `gogs.go` to `cmd/gogs/main.go` following Go project layout conventions
- Merge `internal/cmd/` into `cmd/gogs/` as a single main package
- Unexport command variables that no longer need to be exported
- Update build configuration in Taskfile.yml and release workflow

## Test plan

- [x] `task build` succeeds
- [x] `task lint` passes
- [x] Binary runs and shows help correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)