### PR TITLE
cmd: show detected config path in web command help

### DIFF
--- a/cmd/gogs/web.go
+++ b/cmd/gogs/web.go
@@ -53,7 +53,7 @@ and it takes care of all the other things for you`,
 	Action: runWeb,
 	Flags: []cli.Flag{
 		stringFlag("port, p", "3000", "Temporary port number to prevent conflict"),
-		stringFlag("config, c", "", "Custom configuration file path"),
+		stringFlag("config, c", filepath.Join(conf.CustomDir(), "conf", "app.ini"), "Custom configuration file path"),
 	},
 }
 


### PR DESCRIPTION
## Summary
- Display the detected custom configuration file path as the default value for `--config` flag in `gogs web --help`, so users can see which config file will be used without having to guess.

## Test plan
- [x] Run `./.bin/gogs web --help` and verify the `--config` flag shows the resolved config path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)