### PR TITLE
markup: migrate from blackfriday to goldmark

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,6 @@ require (
 	github.com/olekukonko/tablewriter v1.1.3
 	github.com/pquerna/otp v1.5.0
 	github.com/prometheus/client_golang v1.23.0
-	github.com/russross/blackfriday v1.6.0
 	github.com/sergi/go-diff v1.4.0
 	github.com/sourcegraph/run v0.12.0
 	github.com/stretchr/testify v1.11.1
@@ -45,6 +44,7 @@ require (
 	github.com/unknwon/i18n v0.0.0-20190805065654-5c6446a380b6
 	github.com/unknwon/paginater v0.0.0-20170405233947-45e5d631308e
 	github.com/urfave/cli v1.22.17
+	github.com/yuin/goldmark v1.7.16
 	golang.org/x/crypto v0.47.0
 	golang.org/x/image v0.35.0
 	golang.org/x/net v0.48.0

--- a/go.sum
+++ b/go.sum
@@ -399,8 +399,6 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qq
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
-github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
-github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/saintfish/chardet v0.0.0-20120816061221-3af4cd4741ca h1:NugYot0LIVPxTvN8n+Kvkn6TrbMyxQiuvKdEwFdR9vI=
@@ -457,6 +455,8 @@ github.com/urfave/cli v1.22.17 h1:SYzXoiPfQjHBbkYxbew5prZHS1TOLT3ierW8SYLqtVQ=
 github.com/urfave/cli v1.22.17/go.mod h1:b0ht0aqgH/6pBYzzxURyrM4xXNgsoT/n2ZzwQiEhNVo=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.7.16 h1:n+CJdUxaFMiDUNnWC3dMWCIQJSkxH4uz3ZwQBkAlVNE=
+github.com/yuin/goldmark v1.7.16/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 github.com/ziutek/mymysql v1.5.4 h1:GB0qdRGsTwQSBVYuVShFBKaXSnSnYYC2d9knnE1LHFs=
 github.com/ziutek/mymysql v1.5.4/go.mod h1:LMSpPZ6DbqWFxNCHW77HeMg9I646SAhApZ/wKdgO/C0=
 go.bobheadxi.dev/streamline v1.2.1 h1:IqKSA1TbeuDqCzYNAwtlh8sqf3tsQus8XgJdkCWFT8c=

--- a/internal/context/notice.go
+++ b/internal/context/notice.go
@@ -54,5 +54,5 @@ func (c *Context) renderNoticeBanner() {
 		return
 	}
 
-	c.Data["ServerNotice"] = string(markup.RawMarkdown(buf, ""))
+	c.Data["ServerNotice"] = string(markup.SanitizeBytes(markup.RawMarkdown(buf, "")))
 }

--- a/internal/markup/markdown.go
+++ b/internal/markup/markdown.go
@@ -35,8 +35,10 @@ func IsMarkdownFile(name string) bool {
 	return false
 }
 
-var validLinksPattern = lazyregexp.New(`^[a-z][\w-]+://|^mailto:`)
-var linkifyURLRegexp = regexp.MustCompile(`^(?:http|https|ftp)://[-a-zA-Z0-9@:%._+~#=]{1,256}(?:\.[a-z]+)?(?::\d+)?(?:[/#?][-a-zA-Z0-9@:%_+.~#$!?&/=();,'\^{}\[\]` + "`" + `]*)?`)
+var (
+	validLinksPattern = lazyregexp.New(`^[a-z][\w-]+://|^mailto:`)
+	linkifyURLRegexp  = regexp.MustCompile(`^(?:http|https|ftp)://[-a-zA-Z0-9@:%._+~#=]{1,256}(?:\.[a-z]+)?(?::\d+)?(?:[/#?][-a-zA-Z0-9@:%_+.~#$!?&/=();,'\^{}\[\]` + "`" + `]*)?`)
+)
 
 func isLink(link []byte) bool {
 	return validLinksPattern.Match(link)

--- a/internal/markup/markdown.go
+++ b/internal/markup/markdown.go
@@ -4,10 +4,9 @@ import (
 	"bytes"
 	"fmt"
 	"html"
-	"log"
+	"net/url"
 	"path"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/yuin/goldmark"
@@ -18,6 +17,7 @@ import (
 	goldmarkhtml "github.com/yuin/goldmark/renderer/html"
 	"github.com/yuin/goldmark/text"
 	"github.com/yuin/goldmark/util"
+	log "unknwon.dev/clog/v2"
 
 	"gogs.io/gogs/internal/conf"
 	"gogs.io/gogs/internal/lazyregexp"
@@ -37,7 +37,7 @@ func IsMarkdownFile(name string) bool {
 
 var (
 	validLinksPattern = lazyregexp.New(`^[a-z][\w-]+://|^mailto:`)
-	linkifyURLRegexp  = regexp.MustCompile(`^(?:http|https|ftp)://[-a-zA-Z0-9@:%._+~#=]{1,256}(?:\.[a-z]+)?(?::\d+)?(?:[/#?][-a-zA-Z0-9@:%_+.~#$!?&/=();,'\^{}\[\]` + "`" + `]*)?`)
+	linkifyURLRegexp  = lazyregexp.New(`^(?:http|https|ftp)://[-a-zA-Z0-9@:%._+~#=]{1,256}(?:\.[a-z]+)?(?::\d+)?(?:[/#?][-a-zA-Z0-9@:%_+.~#$!?&/=();,'\^{}\[\]` + "`" + `]*)?`)
 )
 
 func isLink(link []byte) bool {
@@ -56,11 +56,23 @@ func (t *linkTransformer) Transform(node *ast.Document, reader text.Reader, _ pa
 		if link, ok := n.(*ast.Link); ok {
 			dest := link.Destination
 			if len(dest) > 0 && !isLink(dest) && dest[0] != '#' {
-				link.Destination = []byte(path.Join(t.urlPrefix, string(dest)))
+				link.Destination = []byte(joinURLPath(t.urlPrefix, string(dest)))
 			}
 		}
 		return ast.WalkContinue, nil
 	})
+}
+
+// joinURLPath joins a base URL prefix with a relative path. It uses net/url for
+// absolute URL prefixes to preserve the scheme and host, and path.Join for
+// path-only prefixes.
+func joinURLPath(prefix, relPath string) string {
+	u, err := url.Parse(prefix)
+	if err != nil || u.Scheme == "" {
+		return path.Join(prefix, relPath)
+	}
+	u.Path = path.Join(u.Path, relPath)
+	return u.String()
 }
 
 type gogsRenderer struct {
@@ -135,7 +147,7 @@ func RawMarkdown(body []byte, urlPrefix string) []byte {
 		extension.Table,
 		extension.Strikethrough,
 		extension.TaskList,
-		extension.NewLinkify(extension.WithLinkifyURLRegexp(linkifyURLRegexp)),
+		extension.NewLinkify(extension.WithLinkifyURLRegexp(linkifyURLRegexp.Regexp())),
 	}
 
 	if conf.Smartypants.Enabled {
@@ -143,7 +155,6 @@ func RawMarkdown(body []byte, urlPrefix string) []byte {
 	}
 
 	rendererOpts := []renderer.Option{
-		goldmarkhtml.WithUnsafe(),
 		renderer.WithNodeRenderers(
 			util.Prioritized(&gogsRenderer{urlPrefix: urlPrefix}, 0),
 		),
@@ -165,8 +176,8 @@ func RawMarkdown(body []byte, urlPrefix string) []byte {
 
 	var buf bytes.Buffer
 	if err := md.Convert(body, &buf); err != nil {
-		log.Printf("markup: failed to convert Markdown: %v", err)
-		return nil
+		log.Error("Failed to convert Markdown: %v", err)
+		return []byte(html.EscapeString(string(body)))
 	}
 	return buf.Bytes()
 }

--- a/internal/markup/markdown_test.go
+++ b/internal/markup/markdown_test.go
@@ -1,19 +1,20 @@
 package markup_test
 
 import (
-	"bytes"
 	"strings"
 	"testing"
 
-	"github.com/russross/blackfriday"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"gogs.io/gogs/internal/conf"
 	. "gogs.io/gogs/internal/markup"
 )
 
 func Test_IsMarkdownFile(t *testing.T) {
-	// TODO: Refactor to accept a list of extensions
+	oldExts := conf.Markdown.FileExtensions
+	defer func() { conf.Markdown.FileExtensions = oldExts }()
+
 	conf.Markdown.FileExtensions = strings.Split(".md,.markdown,.mdown,.mkd", ",")
 	tests := []struct {
 		ext    string
@@ -32,41 +33,53 @@ func Test_IsMarkdownFile(t *testing.T) {
 	}
 }
 
-func Test_Markdown(t *testing.T) {
-	// TODO: Refactor to accept URL
+func Test_RawMarkdown_AutoLink(t *testing.T) {
+	oldURL := conf.Server.ExternalURL
+	defer func() { conf.Server.ExternalURL = oldURL }()
+
 	conf.Server.ExternalURL = "http://localhost:3000/"
 
-	htmlFlags := 0
-	htmlFlags |= blackfriday.HTML_SKIP_STYLE
-	htmlFlags |= blackfriday.HTML_OMIT_CONTENTS
-	renderer := &MarkdownRenderer{
-		Renderer: blackfriday.HtmlRenderer(htmlFlags, "", ""),
-	}
-
 	tests := []struct {
-		input  string
-		expVal string
+		name  string
+		input string
+		want  string
 	}{
-		// Issue URL
-		{input: "http://localhost:3000/user/repo/issues/3333", expVal: "<a href=\"http://localhost:3000/user/repo/issues/3333\">#3333</a>"},
-		{input: "http://1111/2222/ssss-issues/3333?param=blah&blahh=333", expVal: "<a href=\"http://1111/2222/ssss-issues/3333?param=blah&amp;blahh=333\">http://1111/2222/ssss-issues/3333?param=blah&amp;blahh=333</a>"},
-		{input: "http://test.com/issues/33333", expVal: "<a href=\"http://test.com/issues/33333\">http://test.com/issues/33333</a>"},
-		{input: "http://test.com/issues/3", expVal: "<a href=\"http://test.com/issues/3\">http://test.com/issues/3</a>"},
-		{input: "http://issues/333", expVal: "<a href=\"http://issues/333\">http://issues/333</a>"},
-		{input: "https://issues/333", expVal: "<a href=\"https://issues/333\">https://issues/333</a>"},
-		{input: "http://tissues/0", expVal: "<a href=\"http://tissues/0\">http://tissues/0</a>"},
-
-		// Commit URL
-		{input: "http://localhost:3000/user/project/commit/d8a994ef243349f321568f9e36d5c3f444b99cae", expVal: " <code><a href=\"http://localhost:3000/user/project/commit/d8a994ef243349f321568f9e36d5c3f444b99cae\">d8a994ef24</a></code>"},
-		{input: "http://localhost:3000/user/project/commit/d8a994ef243349f321568f9e36d5c3f444b99cae#diff-2", expVal: " <code><a href=\"http://localhost:3000/user/project/commit/d8a994ef243349f321568f9e36d5c3f444b99cae#diff-2\">d8a994ef24</a></code>"},
-		{input: "https://external-link.gogs.io/gogs/gogs/commit/d8a994ef243349f321568f9e36d5c3f444b99cae#diff-2", expVal: "<a href=\"https://external-link.gogs.io/gogs/gogs/commit/d8a994ef243349f321568f9e36d5c3f444b99cae#diff-2\">https://external-link.gogs.io/gogs/gogs/commit/d8a994ef243349f321568f9e36d5c3f444b99cae#diff-2</a>"},
-		{input: "https://commit/d8a994ef243349f321568f9e36d5c3f444b99cae", expVal: "<a href=\"https://commit/d8a994ef243349f321568f9e36d5c3f444b99cae\">https://commit/d8a994ef243349f321568f9e36d5c3f444b99cae</a>"},
+		{
+			name:  "issue URL from same instance",
+			input: "http://localhost:3000/user/repo/issues/3333",
+			want:  `<a href="http://localhost:3000/user/repo/issues/3333">#3333</a>`,
+		},
+		{
+			name:  "non-matching issue-like URL",
+			input: "http://1111/2222/ssss-issues/3333?param=blah&blahh=333",
+			want:  `<a href="http://1111/2222/ssss-issues/3333?param=blah&amp;blahh=333">http://1111/2222/ssss-issues/3333?param=blah&amp;blahh=333</a>`,
+		},
+		{
+			name:  "external issue URL",
+			input: "http://test.com/issues/33333",
+			want:  `http://test.com/issues/33333`,
+		},
+		{
+			name:  "commit URL from same instance",
+			input: "http://localhost:3000/user/project/commit/d8a994ef243349f321568f9e36d5c3f444b99cae",
+			want:  `<code><a href="http://localhost:3000/user/project/commit/d8a994ef243349f321568f9e36d5c3f444b99cae">d8a994ef24</a></code>`,
+		},
+		{
+			name:  "commit URL with fragment from same instance",
+			input: "http://localhost:3000/user/project/commit/d8a994ef243349f321568f9e36d5c3f444b99cae#diff-2",
+			want:  `<code><a href="http://localhost:3000/user/project/commit/d8a994ef243349f321568f9e36d5c3f444b99cae#diff-2">d8a994ef24</a></code>`,
+		},
+		{
+			name:  "external commit URL",
+			input: "https://external-link.gogs.io/gogs/gogs/commit/d8a994ef243349f321568f9e36d5c3f444b99cae#diff-2",
+			want:  `https://external-link.gogs.io/gogs/gogs/commit/d8a994ef243349f321568f9e36d5c3f444b99cae#diff-2`,
+		},
 	}
 	for _, test := range tests {
-		t.Run("", func(t *testing.T) {
-			buf := new(bytes.Buffer)
-			renderer.AutoLink(buf, []byte(test.input), blackfriday.LINK_TYPE_NORMAL)
-			assert.Equal(t, test.expVal, buf.String())
+		t.Run(test.name, func(t *testing.T) {
+			result := string(RawMarkdown([]byte(test.input), ""))
+			require.NotEmpty(t, result)
+			assert.Contains(t, result, test.want)
 		})
 	}
 }

--- a/internal/markup/markdown_test.go
+++ b/internal/markup/markdown_test.go
@@ -73,6 +73,106 @@ func Test_RawMarkdown_AutoLink(t *testing.T) {
 			input: "https://external-link.gogs.io/gogs/gogs/commit/d8a994ef243349f321568f9e36d5c3f444b99cae#diff-2",
 			want:  "<p><a href=\"https://external-link.gogs.io/gogs/gogs/commit/d8a994ef243349f321568f9e36d5c3f444b99cae#diff-2\">https://external-link.gogs.io/gogs/gogs/commit/d8a994ef243349f321568f9e36d5c3f444b99cae#diff-2</a></p>\n",
 		},
+		{
+			name:  "issue URL with single digit",
+			input: "http://test.com/issues/3",
+			want:  "<p><a href=\"http://test.com/issues/3\">http://test.com/issues/3</a></p>\n",
+		},
+		{
+			name:  "host without dot in issue-like URL",
+			input: "http://issues/333",
+			want:  "<p><a href=\"http://issues/333\">http://issues/333</a></p>\n",
+		},
+		{
+			name:  "https host without dot in issue-like URL",
+			input: "https://issues/333",
+			want:  "<p><a href=\"https://issues/333\">https://issues/333</a></p>\n",
+		},
+		{
+			name:  "host without dot resembling keyword",
+			input: "http://tissues/0",
+			want:  "<p><a href=\"http://tissues/0\">http://tissues/0</a></p>\n",
+		},
+		{
+			name:  "https commit-like URL without dot",
+			input: "https://commit/d8a994ef243349f321568f9e36d5c3f444b99cae",
+			want:  "<p><a href=\"https://commit/d8a994ef243349f321568f9e36d5c3f444b99cae\">https://commit/d8a994ef243349f321568f9e36d5c3f444b99cae</a></p>\n",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := string(RawMarkdown([]byte(test.input), ""))
+			assert.Equal(t, test.want, got)
+		})
+	}
+
+	t.Run("cross-repo issue URL from same instance", func(t *testing.T) {
+		got := string(RawMarkdown([]byte("http://localhost:3000/other/repo/issues/42"), "/user/myrepo"))
+		assert.Equal(t, "<p><a href=\"http://localhost:3000/other/repo/issues/42\">other/repo#42</a></p>\n", got)
+	})
+
+	t.Run("same-repo issue URL with fragment", func(t *testing.T) {
+		got := string(RawMarkdown([]byte("http://localhost:3000/user/myrepo/issues/42#issuecomment-1"), "/user/myrepo"))
+		assert.Equal(t, "<p><a href=\"http://localhost:3000/user/myrepo/issues/42#issuecomment-1\">#42</a></p>\n", got)
+	})
+}
+
+func Test_RawMarkdown_LinkRewriting(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		urlPrefix string
+		want      string
+	}{
+		{
+			name:      "relative link with path-only prefix",
+			input:     "[text](other-file.md)",
+			urlPrefix: "/user/repo/src/branch/main",
+			want:      "<p><a href=\"/user/repo/src/branch/main/other-file.md\">text</a></p>\n",
+		},
+		{
+			name:      "relative link with absolute URL prefix",
+			input:     "[text](other-file.md)",
+			urlPrefix: "http://localhost:3000/user/repo/src/branch/main",
+			want:      "<p><a href=\"http://localhost:3000/user/repo/src/branch/main/other-file.md\">text</a></p>\n",
+		},
+		{
+			name:      "absolute link not rewritten",
+			input:     "[text](https://example.com/page)",
+			urlPrefix: "/user/repo/src/branch/main",
+			want:      "<p><a href=\"https://example.com/page\">text</a></p>\n",
+		},
+		{
+			name:      "anchor-only link not rewritten",
+			input:     "[text](#section)",
+			urlPrefix: "/user/repo/src/branch/main",
+			want:      "<p><a href=\"#section\">text</a></p>\n",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := string(RawMarkdown([]byte(test.input), test.urlPrefix))
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+func Test_RawMarkdown_HTMLPassthrough(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "inline HTML tags are stripped",
+			input: "Hello <em>world</em>",
+			want:  "<p>Hello <!-- raw HTML omitted -->world<!-- raw HTML omitted --></p>\n",
+		},
+		{
+			name:  "block HTML tags are stripped",
+			input: "<div>content</div>",
+			want:  "<!-- raw HTML omitted -->\n",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/markup/markdown_test.go
+++ b/internal/markup/markdown_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"gogs.io/gogs/internal/conf"
 	. "gogs.io/gogs/internal/markup"
@@ -47,39 +46,38 @@ func Test_RawMarkdown_AutoLink(t *testing.T) {
 		{
 			name:  "issue URL from same instance",
 			input: "http://localhost:3000/user/repo/issues/3333",
-			want:  `<a href="http://localhost:3000/user/repo/issues/3333">#3333</a>`,
+			want:  "<p><a href=\"http://localhost:3000/user/repo/issues/3333\">#3333</a></p>\n",
 		},
 		{
 			name:  "non-matching issue-like URL",
 			input: "http://1111/2222/ssss-issues/3333?param=blah&blahh=333",
-			want:  `<a href="http://1111/2222/ssss-issues/3333?param=blah&amp;blahh=333">http://1111/2222/ssss-issues/3333?param=blah&amp;blahh=333</a>`,
+			want:  "<p><a href=\"http://1111/2222/ssss-issues/3333?param=blah&amp;blahh=333\">http://1111/2222/ssss-issues/3333?param=blah&amp;blahh=333</a></p>\n",
 		},
 		{
 			name:  "external issue URL",
 			input: "http://test.com/issues/33333",
-			want:  `http://test.com/issues/33333`,
+			want:  "<p><a href=\"http://test.com/issues/33333\">http://test.com/issues/33333</a></p>\n",
 		},
 		{
 			name:  "commit URL from same instance",
 			input: "http://localhost:3000/user/project/commit/d8a994ef243349f321568f9e36d5c3f444b99cae",
-			want:  `<code><a href="http://localhost:3000/user/project/commit/d8a994ef243349f321568f9e36d5c3f444b99cae">d8a994ef24</a></code>`,
+			want:  "<p> <code><a href=\"http://localhost:3000/user/project/commit/d8a994ef243349f321568f9e36d5c3f444b99cae\">d8a994ef24</a></code></p>\n",
 		},
 		{
 			name:  "commit URL with fragment from same instance",
 			input: "http://localhost:3000/user/project/commit/d8a994ef243349f321568f9e36d5c3f444b99cae#diff-2",
-			want:  `<code><a href="http://localhost:3000/user/project/commit/d8a994ef243349f321568f9e36d5c3f444b99cae#diff-2">d8a994ef24</a></code>`,
+			want:  "<p> <code><a href=\"http://localhost:3000/user/project/commit/d8a994ef243349f321568f9e36d5c3f444b99cae#diff-2\">d8a994ef24</a></code></p>\n",
 		},
 		{
 			name:  "external commit URL",
 			input: "https://external-link.gogs.io/gogs/gogs/commit/d8a994ef243349f321568f9e36d5c3f444b99cae#diff-2",
-			want:  `https://external-link.gogs.io/gogs/gogs/commit/d8a994ef243349f321568f9e36d5c3f444b99cae#diff-2`,
+			want:  "<p><a href=\"https://external-link.gogs.io/gogs/gogs/commit/d8a994ef243349f321568f9e36d5c3f444b99cae#diff-2\">https://external-link.gogs.io/gogs/gogs/commit/d8a994ef243349f321568f9e36d5c3f444b99cae#diff-2</a></p>\n",
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result := string(RawMarkdown([]byte(test.input), ""))
-			require.NotEmpty(t, result)
-			assert.Contains(t, result, test.want)
+			got := string(RawMarkdown([]byte(test.input), ""))
+			assert.Equal(t, test.want, got)
 		})
 	}
 }


### PR DESCRIPTION
## Describe the pull request

Migrate the Markdown rendering engine from `russross/blackfriday` (v1) to `yuin/goldmark`, a CommonMark-compliant Markdown parser and renderer.

Key changes:
- Replace `blackfriday.Renderer` with goldmark's extensible pipeline: AST transformers for link rewriting and a custom `NodeRenderer` for autolink handling (commit/issue URL shortening).
- Enable goldmark extensions for tables, strikethrough, task lists, and URL linkification to match previous behavior.
- Add `joinURLPath` to correctly join URL prefixes that include a scheme and host.
- Apply proper `html.EscapeString` on all URLs written into rendered output.
- Sanitize `RawMarkdown` output for the server notice banner via `markup.SanitizeBytes`.
- Expand test coverage with dedicated test functions for autolinks (including cross-repo issue references), relative link rewriting, and HTML passthrough behavior.

Link to the issue: n/a

## Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [x] I have added test cases to cover the new code or have provided the test plan.
- [ ] I have added an entry to [CHANGELOG](https://github.com/gogs/gogs/blob/main/CHANGELOG.md).

## Test plan

1. Run `task test` and verify all tests pass, in particular the new tests in `internal/markup/markdown_test.go`.
2. Start a Gogs instance and verify Markdown rendering in issues, comments, and the file viewer:
   - Relative links are rewritten with the correct URL prefix.
   - Autolinked commit URLs from the same instance render as short SHA codes.
   - Autolinked issue URLs render as `#N` for same-repo and `owner/repo#N` for cross-repo.
   - Email autolinks render as `mailto:` links.
   - Tables, strikethrough, and task lists render correctly.
3. Set a server notice in admin settings and confirm the banner renders sanitized Markdown.