### PR TITLE
markup: restrict data URI scheme to safe image MIME types

### DIFF
--- a/internal/markup/sanitizer_test.go
+++ b/internal/markup/sanitizer_test.go
@@ -26,6 +26,20 @@ func Test_Sanitizer(t *testing.T) {
 		{input: `<input type="hidden">`, expVal: ``},
 		{input: `<input type="checkbox">`, expVal: `<input type="checkbox">`},
 		{input: `<input checked disabled autofocus>`, expVal: `<input checked="" disabled="">`},
+
+		// Data URIs: safe image types should be allowed
+		{input: `<img src="data:image/png;base64,abc">`, expVal: `<img src="data:image/png;base64,abc">`},
+		{input: `<img src="data:image/jpeg;base64,abc">`, expVal: `<img src="data:image/jpeg;base64,abc">`},
+		{input: `<img src="data:image/gif;base64,abc">`, expVal: `<img src="data:image/gif;base64,abc">`},
+		{input: `<img src="data:image/webp;base64,abc">`, expVal: `<img src="data:image/webp;base64,abc">`},
+
+		// Data URIs: text/html must be stripped to prevent XSS (GHSA-xrcr-gmf5-2r8j)
+		{input: `<a href="data:text/html;base64,PHNjcmlwdD5hbGVydCgnWFNTJyk8L3NjcmlwdD4=">Click</a>`, expVal: `Click`},
+		{input: `<a href="data:text/html,<script>alert(1)</script>">XSS</a>`, expVal: `XSS`},
+		{input: `<img src="data:text/html;base64,abc">`, expVal: ``},
+
+		// Data URIs: SVG must be stripped (can contain embedded JavaScript)
+		{input: `<img src="data:image/svg+xml;base64,abc">`, expVal: ``},
 	}
 	for _, test := range tests {
 		t.Run(test.input, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Restrict the `data:` URL scheme in the HTML sanitizer to only allow safe image MIME types (png, jpeg, gif, webp, x-icon) instead of blanket-allowing all data URIs.
- Add test coverage for both allowed and blocked data URI patterns.

Ref: https://github.com/gogs/gogs/security/advisories/GHSA-xrcr-gmf5-2r8j