### PR TITLE
all: upgrade to Go 1.26

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
       - name: Install Task
         uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:
@@ -61,7 +61,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        go-version: [ 1.25.x ]
+        go-version: [ 1.26.x ]
         platform: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -89,7 +89,7 @@ jobs:
     name: Test Windows
     strategy:
       matrix:
-        go-version: [ 1.25.x ]
+        go-version: [ 1.26.x ]
         platform: [ windows-latest ]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -112,7 +112,7 @@ jobs:
     name: Postgres
     strategy:
       matrix:
-        go-version: [ 1.25.x ]
+        go-version: [ 1.26.x ]
         platform: [ ubuntu-latest ]
     runs-on: ${{ matrix.platform }}
     services:
@@ -151,7 +151,7 @@ jobs:
     name: MySQL
     strategy:
       matrix:
-        go-version: [ 1.25.x ]
+        go-version: [ 1.26.x ]
         platform: [ ubuntu-22.04 ] # Use the lowest version possible for backwards compatibility
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
       - name: Determine version
         id: version
         run: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module gogs.io/gogs
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
@@ -136,5 +136,5 @@ require (
 	modernc.org/sqlite v1.39.0 // indirect
 )
 
-// +heroku goVersion go1.25
+// +heroku goVersion go1.26
 // +heroku install ./cmd/gogs


### PR DESCRIPTION
## Summary
- Update `go.mod` to use Go 1.26.0.
- Update CI workflows (`go.yml`, `release.yml`) to use Go 1.26.x.
- Update Heroku Go version hint.

## Test plan
- [ ] CI passes with Go 1.26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)