### PR TITLE
Use case-insensitive matching for Git error "Not a valid object name"

### DIFF
--- a/internal/route/repo/pull.go
+++ b/internal/route/repo/pull.go
@@ -230,7 +230,7 @@ func PrepareViewPullInfo(c *context.Context, issue *database.Issue) *gitx.PullRe
 	baseRepoPath := database.RepoPath(repo.Owner.Name, repo.Name)
 	prMeta, err := gitx.Module.PullRequestMeta(headGitRepo.Path(), baseRepoPath, pull.HeadBranch, pull.BaseBranch)
 	if err != nil {
-		if strings.Contains(err.Error(), "fatal: Not a valid object name") {
+		if strings.Contains(strings.ToLower(err.Error()), "fatal: not a valid object name") {
 			c.Data["IsPullReuqestBroken"] = true
 			c.Data["BaseTarget"] = "deleted"
 			c.Data["NumCommits"] = 0


### PR DESCRIPTION
Fixes #8190

Git is lowercasing the `fatal: Not a valid object name` error message
to follow its CodingGuidelines. This change makes the string matching
case-insensitive so it works with both the current and future Git versions.

Changes:
- Use `strings.ToLower()` before checking for the error substring

See: https://lore.kernel.org/git/pull.2052.git.1771836302101.gitgitgadget@gmail.com