### PR TITLE
repository: validate remote address on mirror address update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to Gogs are documented in this file.
 - _Security:_ Stored XSS in Jupyter notebook (`.ipynb`) preview through Markdown links with `javascript:` URLs. [#8319](https://github.com/gogs/gogs/pull/8319) - [GHSA-jq8v-rmf6-65jw](https://github.com/gogs/gogs/security/advisories/GHSA-jq8v-rmf6-65jw)
 - _Security:_ Missing authorization check on the attachment download endpoint allowed anyone who knew (or guessed) an attachment UUID to download files belonging to private repositories. [#8320](https://github.com/gogs/gogs/pull/8320) - [GHSA-p9f5-h3rx-j5qw](https://github.com/gogs/gogs/security/advisories/GHSA-p9f5-h3rx-j5qw)
 - _Security:_ Organization team and member management actions accepted GET requests, allowing a logged-in owner to be tricked into adding an attacker to the Owners team via a crafted link. [#8321](https://github.com/gogs/gogs/pull/8321) - [GHSA-pwx3-qcgw-vh7h](https://github.com/gogs/gogs/security/advisories/GHSA-pwx3-qcgw-vh7h)
-- _Security:_ SSRF via mirror address update bypassing clone address validation. [#8225](https://github.com/gogs/gogs/pull/8225)
+- _Security:_ SSRF via mirror address update bypassing clone address validation. [#8225](https://github.com/gogs/gogs/pull/8225) - [GHSA-wv27-2vqp-j7g5](https://github.com/gogs/gogs/security/advisories/GHSA-wv27-2vqp-j7g5)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to Gogs are documented in this file.
 - _Security:_ Stored XSS in Jupyter notebook (`.ipynb`) preview through Markdown links with `javascript:` URLs. [#8319](https://github.com/gogs/gogs/pull/8319) - [GHSA-jq8v-rmf6-65jw](https://github.com/gogs/gogs/security/advisories/GHSA-jq8v-rmf6-65jw)
 - _Security:_ Missing authorization check on the attachment download endpoint allowed anyone who knew (or guessed) an attachment UUID to download files belonging to private repositories. [#8320](https://github.com/gogs/gogs/pull/8320) - [GHSA-p9f5-h3rx-j5qw](https://github.com/gogs/gogs/security/advisories/GHSA-p9f5-h3rx-j5qw)
 - _Security:_ Organization team and member management actions accepted GET requests, allowing a logged-in owner to be tricked into adding an attacker to the Owners team via a crafted link. [#8321](https://github.com/gogs/gogs/pull/8321) - [GHSA-pwx3-qcgw-vh7h](https://github.com/gogs/gogs/security/advisories/GHSA-pwx3-qcgw-vh7h)
+- _Security:_ SSRF via mirror address update bypassing clone address validation. [#8225](https://github.com/gogs/gogs/pull/8225)
 
 ### Removed
 

--- a/internal/form/repo.go
+++ b/internal/form/repo.go
@@ -52,12 +52,19 @@ func (f *MigrateRepo) Validate(ctx *macaron.Context, errs binding.Errors) bindin
 	return validate(errs, ctx.Data, f, ctx.Locale)
 }
 
+type ParseRemoteAddrOptions struct {
+	CloneAddr    string
+	User         *database.User
+	AuthUsername string
+	AuthPassword string
+}
+
 // ParseRemoteAddr checks if given remote address is valid,
 // and returns composed URL with needed username and password.
 // It also checks if given user has permission when remote address
 // is actually a local path.
-func (f MigrateRepo) ParseRemoteAddr(user *database.User) (string, error) {
-	remoteAddr := strings.TrimSpace(f.CloneAddr)
+func ParseRemoteAddr(options ParseRemoteAddrOptions) (string, error) {
+	remoteAddr := strings.TrimSpace(options.CloneAddr)
 
 	// Remote address can be HTTP/HTTPS/Git URL or local path.
 	if strings.HasPrefix(remoteAddr, "http://") ||
@@ -72,15 +79,15 @@ func (f MigrateRepo) ParseRemoteAddr(user *database.User) (string, error) {
 			return "", database.ErrInvalidCloneAddr{IsBlockedLocalAddress: true}
 		}
 
-		if len(f.AuthUsername)+len(f.AuthPassword) > 0 {
-			u.User = url.UserPassword(f.AuthUsername, f.AuthPassword)
+		if len(options.AuthUsername)+len(options.AuthPassword) > 0 {
+			u.User = url.UserPassword(options.AuthUsername, options.AuthPassword)
 		}
 		// To prevent CRLF injection in git protocol, see https://github.com/gogs/gogs/issues/6413
 		if u.Scheme == "git" && (strings.Contains(remoteAddr, "%0d") || strings.Contains(remoteAddr, "%0a")) {
 			return "", database.ErrInvalidCloneAddr{IsURLError: true}
 		}
 		remoteAddr = u.String()
-	} else if !user.CanImportLocal() {
+	} else if !options.User.CanImportLocal() {
 		return "", database.ErrInvalidCloneAddr{IsPermissionDenied: true}
 	} else if !osx.IsDir(remoteAddr) {
 		return "", database.ErrInvalidCloneAddr{IsInvalidPath: true}

--- a/internal/route/api/v1/repo_repo.go
+++ b/internal/route/api/v1/repo_repo.go
@@ -251,7 +251,12 @@ func migrate(c *context.APIContext, f form.MigrateRepo) {
 		}
 	}
 
-	remoteAddr, err := f.ParseRemoteAddr(c.User)
+	remoteAddr, err := form.ParseRemoteAddr(form.ParseRemoteAddrOptions{
+		CloneAddr:    f.CloneAddr,
+		User:         c.User,
+		AuthUsername: f.AuthUsername,
+		AuthPassword: f.AuthPassword,
+	})
 	if err != nil {
 		if database.IsErrInvalidCloneAddr(err) {
 			addrErr := err.(database.ErrInvalidCloneAddr)

--- a/internal/route/repo/repo.go
+++ b/internal/route/repo/repo.go
@@ -170,7 +170,12 @@ func MigratePost(c *context.Context, f form.MigrateRepo) {
 		return
 	}
 
-	remoteAddr, err := f.ParseRemoteAddr(c.User)
+	remoteAddr, err := form.ParseRemoteAddr(form.ParseRemoteAddrOptions{
+		CloneAddr:    f.CloneAddr,
+		User:         c.User,
+		AuthUsername: f.AuthUsername,
+		AuthPassword: f.AuthPassword,
+	})
 	if err != nil {
 		if database.IsErrInvalidCloneAddr(err) {
 			c.Data["Err_CloneAddr"] = true

--- a/internal/route/repo/setting.go
+++ b/internal/route/repo/setting.go
@@ -121,7 +121,34 @@ func SettingsPost(c *context.Context, f form.RepoSetting) {
 				return
 			}
 		}
-		if err := c.Repo.Mirror.SaveAddress(f.MirrorAddress); err != nil {
+
+		remoteAddr, err := form.ParseRemoteAddr(form.ParseRemoteAddrOptions{
+			CloneAddr: f.MirrorAddress,
+			User:      c.User,
+		})
+		if err != nil {
+			if database.IsErrInvalidCloneAddr(err) {
+				c.Data["Err_CloneAddr"] = true
+				addrErr := err.(database.ErrInvalidCloneAddr)
+				switch {
+				case addrErr.IsURLError:
+					c.RenderWithErr(c.Tr("repo.migrate.clone_address")+c.Tr("form.url_error"), http.StatusBadRequest, tmplRepoSettingsOptions, &f)
+				case addrErr.IsPermissionDenied:
+					c.RenderWithErr(c.Tr("repo.migrate.permission_denied"), http.StatusForbidden, tmplRepoSettingsOptions, &f)
+				case addrErr.IsInvalidPath:
+					c.RenderWithErr(c.Tr("repo.migrate.invalid_local_path"), http.StatusBadRequest, tmplRepoSettingsOptions, &f)
+				case addrErr.IsBlockedLocalAddress:
+					c.RenderWithErr(c.Tr("repo.migrate.clone_address_resolved_to_blocked_local_address"), http.StatusForbidden, tmplRepoSettingsOptions, &f)
+				default:
+					c.Error(err, "unexpected error")
+				}
+			} else {
+				c.Error(err, "parse remote address")
+			}
+			return
+		}
+
+		if err := c.Repo.Mirror.SaveAddress(remoteAddr); err != nil {
 			c.Error(err, "save address")
 			return
 		}

--- a/internal/route/repo/setting.go
+++ b/internal/route/repo/setting.go
@@ -128,7 +128,6 @@ func SettingsPost(c *context.Context, f form.RepoSetting) {
 		})
 		if err != nil {
 			if database.IsErrInvalidCloneAddr(err) {
-				c.Data["Err_CloneAddr"] = true
 				addrErr := err.(database.ErrInvalidCloneAddr)
 				switch {
 				case addrErr.IsURLError:

--- a/internal/route/repo/setting.go
+++ b/internal/route/repo/setting.go
@@ -128,6 +128,7 @@ func SettingsPost(c *context.Context, f form.RepoSetting) {
 		})
 		if err != nil {
 			if database.IsErrInvalidCloneAddr(err) {
+				c.FormErr("MirrorAddress")
 				addrErr := err.(database.ErrInvalidCloneAddr)
 				switch {
 				case addrErr.IsURLError:

--- a/templates/repo/settings/options.tmpl
+++ b/templates/repo/settings/options.tmpl
@@ -84,7 +84,7 @@
 								<label for="interval">{{.i18n.Tr "repo.mirror_interval"}}</label>
 								<input id="interval" name="interval" type="number" value="{{.MirrorInterval}}">
 							</div>
-							<div class="field">
+							<div class="field {{if .Err_MirrorAddress}}error{{end}}">
 								<label for="mirror_address">{{.i18n.Tr "repo.mirror_address"}}</label>
 								<input id="mirror_address" name="mirror_address" value="{{.Mirror.RawAddress}}" required>
 								<p class="help">{{.i18n.Tr "repo.mirror_address_desc"}}</p>


### PR DESCRIPTION
## Describe the pull request

Mirror address update (`SaveAddress`) bypasses all validation enforced during mirror creation (`ParseRemoteAddr`), including protocol whitelist (`http://`, `https://`, `git://` only), local network address blocking (`netx.IsBlockedLocalHostname`), and CRLF injection checks for `git://` URLs. 

A mirror repository admin can exploit this by first creating a mirror with a valid URL, then changing the address to `file:///path/to/other-repo.git` to read contents of other local repositories on the server, or to internal network addresses for SSRF. 

This patch applies equivalent validation in the update path to match the creation path.

Ref: https://github.com/gogs/gogs/security/advisories/GHSA-wv27-2vqp-j7g5

## Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [ ] I have added test cases to cover the new code or have provided the test plan. (if applicable)
- [x] I have added an entry to [CHANGELOG](https://github.com/gogs/gogs/blob/main/CHANGELOG.md). (if applicable)

## Test plan

- [x] Update a mirror address to `file:///path/to/other-repo.git`, verify it is rejected.
- [x] Update a mirror address to `http://127.0.0.1:3000`, verify it is rejected.
- [x] Update a mirror address to a valid `https://` remote, verify it works and sync succeeds.
- [x] Create a new mirror via migration with a valid URL, verify existing validation is unaffected.
