### PR TITLE
database: bound collaboration access mode by `min(actor, admin)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Gogs are documented in this file.
 
 ## 0.15.0+dev (`main`)
 
+### Fixed
+
+- _Security:_ Repository collaborators with Admin access could escalate their own or others' access mode to Owner via the web UI.
+
 ### Removed
 
 - The `gogs cert` subcommand. [#8153](https://github.com/gogs/gogs/pull/8153)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to Gogs are documented in this file.
 - _Security:_ Organization team and member management actions accepted GET requests, allowing a logged-in owner to be tricked into adding an attacker to the Owners team via a crafted link. [#8321](https://github.com/gogs/gogs/pull/8321) - [GHSA-pwx3-qcgw-vh7h](https://github.com/gogs/gogs/security/advisories/GHSA-pwx3-qcgw-vh7h)
 - _Security:_ SSRF via mirror address update bypassing clone address validation. [#8225](https://github.com/gogs/gogs/pull/8225) - [GHSA-wv27-2vqp-j7g5](https://github.com/gogs/gogs/security/advisories/GHSA-wv27-2vqp-j7g5)
 - _Security:_ Open redirect on login and other post-action flows via the `redirect_to` query parameter. [#8322](https://github.com/gogs/gogs/pull/8322) - [GHSA-xxhq-69mf-w8cr](https://github.com/gogs/gogs/security/advisories/GHSA-xxhq-69mf-w8cr)
+- _Security:_ Privilege escalation to repository owner via collaboration access mode update. [#8227](https://github.com/gogs/gogs/pull/8227) - [GHSA-4565-r4x7-hg8j](https://github.com/gogs/gogs/security/advisories/GHSA-4565-r4x7-hg8j)
 
 ### Removed
 

--- a/internal/database/repo_collaboration.go
+++ b/internal/database/repo_collaboration.go
@@ -125,8 +125,8 @@ func (r *Repository) GetCollaborators() ([]*Collaborator, error) {
 
 // ChangeCollaborationAccessMode sets new access mode for the collaboration.
 func (r *Repository) ChangeCollaborationAccessMode(userID int64, mode AccessMode) error {
-	// Discard invalid input
-	if mode <= AccessModeNone || mode > AccessModeOwner {
+	// Collaborators can hold at most Admin access; Owner is reserved for the repository owner.
+	if mode <= AccessModeNone || mode > AccessModeAdmin {
 		return nil
 	}
 

--- a/internal/database/repo_collaboration.go
+++ b/internal/database/repo_collaboration.go
@@ -124,9 +124,16 @@ func (r *Repository) GetCollaborators() ([]*Collaborator, error) {
 }
 
 // ChangeCollaborationAccessMode sets new access mode for the collaboration.
-func (r *Repository) ChangeCollaborationAccessMode(userID int64, mode AccessMode) error {
-	// Discard invalid input
-	if mode <= AccessModeNone || mode > AccessModeOwner {
+// The actor's access mode bounds the new mode, so an actor can never grant a
+// level higher than their own.
+func (r *Repository) ChangeCollaborationAccessMode(actorMode AccessMode, userID int64, mode AccessMode) error {
+	// Collaborators can hold at most admin access.
+	if mode <= AccessModeNone || mode > AccessModeAdmin {
+		return nil
+	}
+
+	// Actors must not grant a level above their own.
+	if mode > actorMode {
 		return nil
 	}
 

--- a/internal/route/api/v1/repo_collaborators.go
+++ b/internal/route/api/v1/repo_collaborators.go
@@ -43,7 +43,7 @@ func addCollaborator(c *context.APIContext, form addCollaboratorRequest) {
 	}
 
 	if form.Permission != nil {
-		if err := c.Repo.Repository.ChangeCollaborationAccessMode(collaborator.ID, database.ParseAccessMode(*form.Permission)); err != nil {
+		if err := c.Repo.Repository.ChangeCollaborationAccessMode(c.Repo.AccessMode, collaborator.ID, database.ParseAccessMode(*form.Permission)); err != nil {
 			c.Error(err, "change collaboration access mode")
 			return
 		}

--- a/internal/route/repo/setting.go
+++ b/internal/route/repo/setting.go
@@ -439,6 +439,7 @@ func SettingsCollaborationPost(c *context.Context) {
 
 func ChangeCollaborationAccessMode(c *context.Context) {
 	if err := c.Repo.Repository.ChangeCollaborationAccessMode(
+		c.Repo.AccessMode,
 		c.QueryInt64("uid"),
 		database.AccessMode(c.QueryInt("mode"))); err != nil {
 		log.Error("ChangeCollaborationAccessMode: %v", err)


### PR DESCRIPTION
## Describe the pull request

Tighten `ChangeCollaborationAccessMode` in the database layer so that:

- The new access mode is capped at `AccessModeAdmin`. `AccessModeOwner` (value `4`) is reserved for the repository owner and is no longer accepted on a collaboration record. This closes the off-by-one in the previous guard (`mode > AccessModeOwner`).
- The new access mode is also bounded by the actor's own access mode. An actor can never grant a level above their own, so even if a future caller forgets the cap, an admin collaborator cannot escalate themselves or anyone else past admin.

Both call sites (`POST /:username/:reponame/settings/collaboration/access_mode` in the web UI, and `PUT /api/v1/repos/:username/:reponame/collaborators/:collaborator` in the API) now pass the caller's effective `AccessMode` through to the database function.

Advisory: [GHSA-4565-r4x7-hg8j](https://github.com/gogs/gogs/security/advisories/GHSA-4565-r4x7-hg8j)

## Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [ ] I have added test cases to cover the new code or have provided the test plan. (if applicable)
- [x] I have added an entry to [CHANGELOG](https://github.com/gogs/gogs/blob/main/CHANGELOG.md). (if applicable)

## Test plan

- [x] A collaborator with Admin access posts `mode=4` for their own UID. The response is 204 but the stored access remains Admin.
- [x] A collaborator with Admin access posts `mode=4` for another collaborator's UID. The target's access remains unchanged.
- [x] The repository owner can still perform all owner-level operations.
- [x] An organization owner (effective access Owner via the Owners team) can still change collaboration access modes up to Admin.