### PR TITLE
sync: prevent duplicate UniqueQueue entries under concurrent Add

### DIFF
--- a/internal/sync/unique_queue.go
+++ b/internal/sync/unique_queue.go
@@ -41,12 +41,12 @@ func (q *UniqueQueue) Exist(id any) bool {
 // AddFunc adds new instance to the queue with a custom runnable function,
 // the queue is blocked until the function exits.
 func (q *UniqueQueue) AddFunc(id any, fn func()) {
-	if q.Exist(id) {
-		return
-	}
-
 	idStr := fmt.Sprintf("%v", id)
 	q.table.Lock()
+	if q.table.pool[idStr] {
+		q.table.Unlock()
+		return
+	}
 	q.table.pool[idStr] = true
 	if fn != nil {
 		fn()

--- a/internal/sync/unique_queue_test.go
+++ b/internal/sync/unique_queue_test.go
@@ -1,0 +1,33 @@
+package sync
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUniqueQueueAddConcurrentDuplicate(t *testing.T) {
+	q := NewUniqueQueue(100)
+	const goroutines = 50
+
+	q.table.Lock()
+
+	var ready sync.WaitGroup
+	ready.Add(goroutines)
+	var done sync.WaitGroup
+	done.Add(goroutines)
+	for range goroutines {
+		go func() {
+			ready.Done()
+			q.Add("same")
+			done.Done()
+		}()
+	}
+
+	ready.Wait()
+	q.table.Unlock()
+	done.Wait()
+
+	assert.Len(t, q.queue, 1)
+}


### PR DESCRIPTION
## Summary

- Move the duplicate check under the same lock as marking an item queued.
- Add a regression test for concurrent `Add` calls using the same identity.

## Why

Concurrent calls to UniqueQueue.Add can all observe that an identity is absent before any caller marks it as queued. That can enqueue duplicate entries for the same identity.

## Tests

- `go test -race ./internal/sync`