### PR TITLE
fix: handle malformed Basic auth credentials

### DIFF
--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -12,6 +12,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/cockroachdb/errors"
 	"github.com/unknwon/i18n"
 	log "unknwon.dev/clog/v2"
 
@@ -55,6 +56,9 @@ func BasicAuthDecode(encoded string) (string, string, error) {
 	}
 
 	auth := strings.SplitN(string(s), ":", 2)
+	if len(auth) != 2 {
+		return "", "", errors.New("malformed Basic authentication credentials")
+	}
 	return auth[0], auth[1], nil
 }
 

--- a/internal/tool/tool_test.go
+++ b/internal/tool/tool_test.go
@@ -1,0 +1,32 @@
+package tool
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBasicAuthDecode(t *testing.T) {
+	username, password, err := BasicAuthDecode(base64.StdEncoding.EncodeToString([]byte("username:password")))
+	require.NoError(t, err)
+	assert.Equal(t, "username", username)
+	assert.Equal(t, "password", password)
+}
+
+func TestBasicAuthDecode_InvalidBase64(t *testing.T) {
+	username, password, err := BasicAuthDecode("not_base64")
+	require.Error(t, err)
+	assert.Empty(t, username)
+	assert.Empty(t, password)
+}
+
+func TestBasicAuthDecode_MalformedCredentials(t *testing.T) {
+	assert.NotPanics(t, func() {
+		username, password, err := BasicAuthDecode(base64.StdEncoding.EncodeToString([]byte("username")))
+		require.Error(t, err)
+		assert.Empty(t, username)
+		assert.Empty(t, password)
+	})
+}


### PR DESCRIPTION
## Summary

- Return an error when decoded Basic auth credentials do not contain a colon.
- Add tests for valid credentials, invalid base64, and malformed decoded credentials.

## Why

BasicAuthDecode currently indexes the split decoded value without checking its length. A malformed decoded value can panic instead of returning an error.

## Tests

- `go test ./internal/tool`