### PR TITLE
Fix wiki markdown relative links

### DIFF
--- a/internal/route/repo/wiki.go
+++ b/internal/route/repo/wiki.go
@@ -39,6 +39,10 @@ type PageMeta struct {
 	Updated time.Time
 }
 
+func wikiMarkdownURLPrefix(repoLink string) string {
+	return repoLink + "/wiki"
+}
+
 func renderWikiPage(c *context.Context, isViewPage bool) (*git.Repository, string) {
 	wikiPath := c.Repo.Repository.WikiPath()
 	wikiRepo, err := git.Open(wikiPath)
@@ -99,7 +103,7 @@ func renderWikiPage(c *context.Context, isViewPage bool) (*git.Repository, strin
 		return nil, ""
 	}
 	if isViewPage {
-		c.Data["content"] = string(markup.Markdown(p, c.Repo.RepoLink, c.Repo.Repository.ComposeMetas()))
+		c.Data["content"] = string(markup.Markdown(p, wikiMarkdownURLPrefix(c.Repo.RepoLink), c.Repo.Repository.ComposeMetas()))
 	} else {
 		c.Data["content"] = string(p)
 	}

--- a/internal/route/repo/wiki_test.go
+++ b/internal/route/repo/wiki_test.go
@@ -1,0 +1,15 @@
+package repo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"gogs.io/gogs/internal/markup"
+)
+
+func TestWikiMarkdownURLPrefix(t *testing.T) {
+	content := markup.Markdown("[Home](Home)", wikiMarkdownURLPrefix("/alice/project"), nil)
+
+	assert.Contains(t, string(content), `href="/alice/project/wiki/Home"`)
+}


### PR DESCRIPTION
Fixes #2851.

IssueHunt bounty: https://issuehunt.io/r/gogs/gogs/issues/2851

## Changes

- Render wiki page markdown with the wiki URL prefix (`/owner/repo/wiki`) instead of the repository root.
- Adds a regression test proving a relative wiki markdown link such as `[Home](Home)` resolves to `/owner/repo/wiki/Home`.

## Tests

- `go test ./internal/route/repo -run TestWikiMarkdownURLPrefix`
- `go test ./internal/markup -run Test_Markdown`
- `go test ./internal/route/repo ./internal/markup`
- `git diff --check`
