### PR TITLE
Fix submodule links with SSH ports

### DIFF
--- a/internal/gitx/submodule.go
+++ b/internal/gitx/submodule.go
@@ -11,6 +11,7 @@ import (
 )
 
 var scpSyntax = lazyregexp.New(`^([a-zA-Z0-9_]+@)?([a-zA-Z0-9._-]+):(.*)$`)
+var scpSyntaxWithPort = lazyregexp.New(`^[0-9]{1,5}/([^/]+/.+)$`)
 
 // InferSubmoduleURL returns the inferred external URL of the submodule at best effort.
 // The `baseURL` should be the URL of the current repository. If the submodule URL looks
@@ -35,10 +36,15 @@ func InferSubmoduleURL(baseURL string, mod *git.Submodule) string {
 		if len(match) == 0 {
 			return mod.URL
 		}
+		path := match[0][3]
+		base, _ := url.Parse(baseURL)
+		if portMatch := scpSyntaxWithPort.FindAllStringSubmatch(path, -1); len(portMatch) > 0 && strings.EqualFold(match[0][2], base.Hostname()) {
+			path = portMatch[0][1]
+		}
 		parsed = &url.URL{
 			Scheme: "http",
 			Host:   match[0][2],
-			Path:   match[0][3],
+			Path:   path,
 		}
 	}
 

--- a/internal/gitx/submodule_test.go
+++ b/internal/gitx/submodule_test.go
@@ -38,6 +38,22 @@ func TestInferSubmoduleURL(t *testing.T) {
 			expURL: "http://github.com/gogs/docs-api/commit/6b08f76a5313fa3d26859515b30aa17a5faa2807",
 		},
 		{
+			name: "SSH URL in SCP syntax with port",
+			submodule: &git.Submodule{
+				URL:    "git@gogs.example.com:2222/gogs/docs-api.git",
+				Commit: "6b08f76a5313fa3d26859515b30aa17a5faa2807",
+			},
+			expURL: "http://gogs.example.com/gogs/docs-api/commit/6b08f76a5313fa3d26859515b30aa17a5faa2807",
+		},
+		{
+			name: "external SSH URL in SCP syntax with numeric namespace",
+			submodule: &git.Submodule{
+				URL:    "git@example.com:2222/gogs/docs-api.git",
+				Commit: "6b08f76a5313fa3d26859515b30aa17a5faa2807",
+			},
+			expURL: "http://example.com/2222/gogs/docs-api/commit/6b08f76a5313fa3d26859515b30aa17a5faa2807",
+		},
+		{
 			name: "relative path",
 			submodule: &git.Submodule{
 				URL:    "../repo2.git",


### PR DESCRIPTION
Fixes #2953.

IssueHunt bounty: https://issuehunt.io/repos/16752620/issues/2953

## What changed
- Detect scp-like submodule URLs where the path starts with an SSH port, such as `git@gogs.example.com:2222/user/repo.git`
- Strip that port segment before building the inferred HTTP repository link
- Add a regression case for scp syntax with a port

## Testing
- `go test ./internal/gitx -run TestInferSubmoduleURL`
- `go test ./internal/gitx`
- `git diff --check`