### PR TITLE
fix: preserve instance URL for SSH submodule links

### DIFF
--- a/internal/gitx/submodule.go
+++ b/internal/gitx/submodule.go
@@ -20,6 +20,7 @@ func InferSubmoduleURL(baseURL string, mod *git.Submodule) string {
 	if !strings.HasSuffix(baseURL, "/") {
 		baseURL += "/"
 	}
+	parsedBase, _ := url.Parse(baseURL)
 
 	raw := strings.TrimSuffix(mod.URL, "/")
 	raw = strings.TrimSuffix(raw, ".git")
@@ -36,7 +37,7 @@ func InferSubmoduleURL(baseURL string, mod *git.Submodule) string {
 			return mod.URL
 		}
 		parsed = &url.URL{
-			Scheme: "http",
+			Scheme: "ssh",
 			Host:   match[0][2],
 			Path:   match[0][3],
 		}
@@ -46,10 +47,21 @@ func InferSubmoduleURL(baseURL string, mod *git.Submodule) string {
 	case "http", "https":
 		raw = parsed.String()
 	case "ssh":
-		raw = fmt.Sprintf("http://%s%s", parsed.Hostname(), parsed.Path)
+		raw = inferWebURLForSSHSubmodule(parsedBase, parsed)
 	default:
 		return raw
 	}
 
 	return fmt.Sprintf("%s/commit/%s", raw, mod.Commit)
+}
+
+func inferWebURLForSSHSubmodule(base, submodule *url.URL) string {
+	path := submodule.Path
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	if base != nil && base.Scheme != "" && base.Host != "" && base.Hostname() == submodule.Hostname() {
+		return fmt.Sprintf("%s://%s%s", base.Scheme, base.Host, path)
+	}
+	return fmt.Sprintf("http://%s%s", submodule.Hostname(), path)
 }

--- a/internal/gitx/submodule_test.go
+++ b/internal/gitx/submodule_test.go
@@ -30,12 +30,28 @@ func TestInferSubmoduleURL(t *testing.T) {
 			expURL: "http://github.com/gogs/docs-api/commit/6b08f76a5313fa3d26859515b30aa17a5faa2807",
 		},
 		{
+			name: "same instance SSH URL with port",
+			submodule: &git.Submodule{
+				URL:    "ssh://git@gogs.example.com:2222/owner/other.git",
+				Commit: "6b08f76a5313fa3d26859515b30aa17a5faa2807",
+			},
+			expURL: "https://gogs.example.com/owner/other/commit/6b08f76a5313fa3d26859515b30aa17a5faa2807",
+		},
+		{
 			name: "SSH URL in SCP syntax",
 			submodule: &git.Submodule{
 				URL:    "git@github.com:gogs/docs-api.git",
 				Commit: "6b08f76a5313fa3d26859515b30aa17a5faa2807",
 			},
 			expURL: "http://github.com/gogs/docs-api/commit/6b08f76a5313fa3d26859515b30aa17a5faa2807",
+		},
+		{
+			name: "same instance SSH URL in SCP syntax",
+			submodule: &git.Submodule{
+				URL:    "git@gogs.example.com:owner/other.git",
+				Commit: "6b08f76a5313fa3d26859515b30aa17a5faa2807",
+			},
+			expURL: "https://gogs.example.com/owner/other/commit/6b08f76a5313fa3d26859515b30aa17a5faa2807",
 		},
 		{
 			name: "relative path",


### PR DESCRIPTION
Fixes #2953

## Summary
- Use the current repository external URL when an SSH submodule points back to the same Gogs host.
- Keep the existing fallback for external SSH and SCP-style submodule URLs.
- Add regression coverage for same-instance SSH URLs with custom ports and SCP syntax.

## Verification
- `go test ./internal/gitx`
- `go test ./internal/template`
- `go test ./internal/route/repo`
- `git diff --check`