### PR TITLE
docs: document MariaDB support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The Gogs (`/gɑgz/`) project aims to build a simple, stable and extensible self-
 - Jupyter Notebook and PDF rendering.
 - Authentication via SMTP, LDAP, reverse proxy, GitHub.com and GitHub Enterprise with 2FA.
 - Customize HTML templates, static files and many others.
-- Rich database backend support, including PostgreSQL, MySQL, SQLite3 or any database backend that speaks one of those protocols.
+- Rich database backend support, including PostgreSQL, MySQL, MariaDB, SQLite3 or any database backend that speaks one of those protocols.
 - Have localization over [31 languages](https://crowdin.com/project/gogs).
 
 ## 💾 Hardware requirements

--- a/docs/dev/local_development.md
+++ b/docs/dev/local_development.md
@@ -29,9 +29,9 @@ Gogs has the following dependencies:
 - Database upon your choice (pick one, we choose PostgreSQL in this document):
     - [PostgreSQL](https://wiki.postgresql.org/wiki/Detailed_installation_guides) (v9.6 or higher)
     - [MySQL](https://dev.mysql.com/downloads/mysql/) with `ENGINE=InnoDB` (v5.7 or higher)
-    - [MariaDB](https://mariadb.org/) (v10.3 or higher); configured with `TYPE = mysql` in `app.ini`
+    - [MariaDB](https://mariadb.org/) with `TYPE = mysql` (v10.3 or higher)
+    - [TiDB](https://github.com/pingcap/tidb) with `TYPE = mysql`
     - [SQLite3](https://www.sqlite.org/index.html)
-    - [TiDB](https://github.com/pingcap/tidb)
 
 ### macOS
 

--- a/docs/dev/local_development.md
+++ b/docs/dev/local_development.md
@@ -29,6 +29,7 @@ Gogs has the following dependencies:
 - Database upon your choice (pick one, we choose PostgreSQL in this document):
     - [PostgreSQL](https://wiki.postgresql.org/wiki/Detailed_installation_guides) (v9.6 or higher)
     - [MySQL](https://dev.mysql.com/downloads/mysql/) with `ENGINE=InnoDB` (v5.7 or higher)
+    - [MariaDB](https://mariadb.org/) (v10.3 or higher); configured with `TYPE = mysql` in `app.ini`
     - [SQLite3](https://www.sqlite.org/index.html)
     - [TiDB](https://github.com/pingcap/tidb)
 

--- a/docs/dev/local_development.md
+++ b/docs/dev/local_development.md
@@ -30,7 +30,6 @@ Gogs has the following dependencies:
     - [PostgreSQL](https://wiki.postgresql.org/wiki/Detailed_installation_guides) (v9.6 or higher)
     - [MySQL](https://dev.mysql.com/downloads/mysql/) with `ENGINE=InnoDB` (v5.7 or higher)
     - [MariaDB](https://mariadb.org/) with `TYPE = mysql` (v10.3 or higher)
-    - [TiDB](https://github.com/pingcap/tidb) with `TYPE = mysql`
     - [SQLite3](https://www.sqlite.org/index.html)
 
 ### macOS

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -8,6 +8,7 @@ icon: "download"
 
 1. Gogs requires use of one of the following database backends:
     - MySQL, >= 5.7
+    - MariaDB, >= 10.3
     - PostgreSQL, >= 9.6
     - SQLite 3
 1. Git, >= 1.8.3, on both server and client side
@@ -25,7 +26,7 @@ icon: "download"
 
 ## Initialize database
 
-If you choose to use MySQL or PostgreSQL as your database backend, you need to first complete the initial database creation.
+If you choose to use MySQL, MariaDB or PostgreSQL as your database backend, you need to first complete the initial database creation.
 
 <Tabs>
   <Tab title="PostgreSQL">
@@ -36,12 +37,14 @@ If you choose to use MySQL or PostgreSQL as your database backend, you need to f
     psql -c "CREATE DATABASE gogs OWNER gogs ENCODING 'UTF8';"
     ```
   </Tab>
-  <Tab title="MySQL">
-    Use the [bundled script](https://github.com/gogs/gogs/blob/main/scripts/mysql.sql) to create the database with proper encoding:
+  <Tab title="MySQL / MariaDB">
+    Use the [bundled script](https://github.com/gogs/gogs/blob/main/scripts/mysql.sql) to create the database with proper encoding. The script detects MariaDB and applies the appropriate InnoDB settings for older releases automatically:
 
     ```zsh
     mysql -u root -p < scripts/mysql.sql
     ```
+
+    In `app.ini`, set `[database] TYPE = mysql` for both MySQL and MariaDB — Gogs talks to MariaDB through the MySQL wire protocol.
   </Tab>
 </Tabs>
 

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -44,7 +44,7 @@ If you choose to use MySQL, MariaDB or PostgreSQL as your database backend, you 
     mysql -u root -p < scripts/mysql.sql
     ```
 
-    In `app.ini`, set `[database] TYPE = mysql` for both MySQL and MariaDB — Gogs talks to MariaDB through the MySQL wire protocol.
+    In `app.ini`, set `[database] TYPE = mysql` for both MySQL and MariaDB. Gogs talks to MariaDB through the MySQL wire protocol.
   </Tab>
 </Tabs>
 


### PR DESCRIPTION
## Describe the pull request

Document MariaDB (same as MySQL: TYPE = mysql). README + installation + local dev docs. Docs only.
≥ 10.3: matches scripts/mysql.sql (legacy InnoDB branch only below 10.3).

