### PR TITLE
Show merge commit label in commit view

### DIFF
--- a/conf/locale/locale_en-US.ini
+++ b/conf/locale/locale_en-US.ini
@@ -879,6 +879,7 @@ settings.description_desc = Description of repository. Maximum 512 characters le
 settings.description_length = Available characters
 
 diff.browse_source = Browse Source
+diff.merge_commit = Merge commit
 diff.parent = parent
 diff.commit = commit
 diff.data_not_available = Diff Data Not Available.

--- a/internal/route/repo/commit.go
+++ b/internal/route/repo/commit.go
@@ -31,9 +31,15 @@ func RefCommits(c *context.Context) {
 	}
 }
 
-// TODO(unknwon)
+// RenderIssueLinks returns commits with issue links rendered in messages.
+//
+// TODO(unknwon): Implement issue link rendering.
 func RenderIssueLinks(oldCommits []*git.Commit, _ string) []*git.Commit {
 	return oldCommits
+}
+
+func hasMultipleParents(parents []string) bool {
+	return len(parents) > 1
 }
 
 func renderCommits(c *context.Context, filename string) {
@@ -160,6 +166,7 @@ func Diff(c *context.Context) {
 	c.Data["Author"] = tryGetUserByEmail(c.Req.Context(), commit.Author.Email)
 	c.Data["Diff"] = diff
 	c.Data["Parents"] = parents
+	c.Data["IsMergeCommit"] = hasMultipleParents(parents)
 	c.Data["DiffNotAvailable"] = diff.NumFiles() == 0
 	c.Data["SourcePath"] = conf.Server.Subpath + "/" + path.Join(userName, repoName, "src", commitID)
 	c.Data["RawPath"] = conf.Server.Subpath + "/" + path.Join(userName, repoName, "raw", commitID)

--- a/internal/route/repo/commit_test.go
+++ b/internal/route/repo/commit_test.go
@@ -1,0 +1,13 @@
+package repo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasMultipleParents(t *testing.T) {
+	assert.False(t, hasMultipleParents(nil))
+	assert.False(t, hasMultipleParents([]string{"parent-a"}))
+	assert.True(t, hasMultipleParents([]string{"parent-a", "parent-b"}))
+}

--- a/templates/repo/diff/page.tmpl
+++ b/templates/repo/diff/page.tmpl
@@ -24,6 +24,11 @@
 				<span class="text grey" id="authored-time">{{TimeSince .Commit.Author.When $.Lang}}</span>
 				<div class="ui right">
 					<div class="ui horizontal list">
+						{{if .IsMergeCommit}}
+							<div class="item">
+								<span class="ui grey basic label">{{.i18n.Tr "repo.diff.merge_commit"}}</span>
+							</div>
+						{{end}}
 						{{if .Parents}}
 							<div class="item">
 								{{.i18n.Tr "repo.diff.parent"}}


### PR DESCRIPTION
Closes #2696

The commits list already marks merge commits based on `ParentsCount > 1`, but the individual commit page only showed the parent SHAs. This applies the same signal on the commit page so merge commits are easier to spot there too.

Changes:
- set `IsMergeCommit` when the viewed commit has more than one parent
- render a compact `Merge commit` label next to the commit metadata
- cover the parent-count helper with a focused test

IssueHunt: https://issuehunt.io/repos/16752620/issues/2696

Checks:
- `git diff --check`
- DeepSource on this PR: Docker, Go, and Shell passed