### PR TITLE
chore: replace reflect.Ptr with reflect.Pointer

### DIFF
--- a/internal/form/form.go
+++ b/internal/form/form.go
@@ -41,7 +41,7 @@ func Assign(form any, data map[string]any) {
 	typ := reflect.TypeOf(form)
 	val := reflect.ValueOf(form)
 
-	if typ.Kind() == reflect.Ptr {
+	if typ.Kind() == reflect.Pointer {
 		typ = typ.Elem()
 		val = val.Elem()
 	}
@@ -95,7 +95,7 @@ func validate(errs binding.Errors, data map[string]any, f Form, l macaron.Locale
 	Assign(f, data)
 
 	typ := reflect.TypeOf(f)
-	if typ.Kind() == reflect.Ptr {
+	if typ.Kind() == reflect.Pointer {
 		typ = typ.Elem()
 	}
 


### PR DESCRIPTION
Replace two occurrences of `reflect.Ptr` with the canonical `reflect.Pointer` in `internal/form/form.go` to fix the govet `inline` analyzer warnings:

```
internal/form/form.go:44:19: inline: Constant reflect.Ptr should be inlined (govet)
internal/form/form.go:98:19: inline: Constant reflect.Ptr should be inlined (govet)
```

`reflect.Ptr` is the legacy alias for `reflect.Pointer`; behavior is unchanged.

## Test plan
- [x] `task lint` passes with zero issues.