### PR TITLE
security: rate-limit two-factor verification attempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Gogs are documented in this file.
 
 ## 0.15.0+dev (`main`)
 
+### Fixed
+
+- _Security:_ Brute-force protection for two-factor authentication verification endpoints. [#PR_PLACEHOLDER](https://github.com/gogs/gogs/pull/PR_PLACEHOLDER) - [GHSA-5mgh-chvj-hqf5](https://github.com/gogs/gogs/security/advisories/GHSA-5mgh-chvj-hqf5)
+
 ### Removed
 
 - The `gogs cert` subcommand. [#8153](https://github.com/gogs/gogs/pull/8153)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to Gogs are documented in this file.
 
 ### Fixed
 
-- _Security:_ Brute-force protection for two-factor authentication verification endpoints. [#PR_PLACEHOLDER](https://github.com/gogs/gogs/pull/PR_PLACEHOLDER) - [GHSA-5mgh-chvj-hqf5](https://github.com/gogs/gogs/security/advisories/GHSA-5mgh-chvj-hqf5)
+- _Security:_ Brute-force protection for two-factor authentication verification endpoints. [#8265](https://github.com/gogs/gogs/pull/8265) - [GHSA-5mgh-chvj-hqf5](https://github.com/gogs/gogs/security/advisories/GHSA-5mgh-chvj-hqf5)
 
 ### Removed
 

--- a/conf/locale/locale_en-US.ini
+++ b/conf/locale/locale_en-US.ini
@@ -183,6 +183,7 @@ login_two_factor_recovery = Two-factor Recovery
 login_two_factor_recovery_code = Recovery Code
 login_two_factor_enter_passcode = Enter a two-factor passcode
 login_two_factor_invalid_recovery_code = Recovery code already used or invalid.
+login_two_factor_too_many_attempts = Too many failed two-factor attempts. Please wait a few minutes and try again.
 
 [mail]
 activate_account = Please activate your account

--- a/internal/route/user/auth.go
+++ b/internal/route/user/auth.go
@@ -204,10 +204,52 @@ func LoginTwoFactor(c *context.Context) {
 	c.Success(tmplUserAuthTwoFactor)
 }
 
+// twoFactorMaxFailedAttempts caps the number of failed two-factor verification
+// attempts allowed within twoFactorFailedAttemptsTTL before the user is
+// temporarily locked out. The counter is keyed by user ID and shared between
+// the TOTP and recovery code handlers so an attacker cannot bypass the limit
+// by alternating endpoints.
+const (
+	twoFactorMaxFailedAttempts = 5
+	twoFactorFailedAttemptsTTL = 10 * 60 // 10 minutes, in seconds.
+)
+
+// twoFactorLockedOut reports whether the user has exceeded the failed
+// two-factor attempt threshold. The caller is expected to flash an error and
+// redirect when this returns true.
+func twoFactorLockedOut(c *context.Context, userID int64) bool {
+	v, _ := c.Cache.Get(userx.TwoFactorFailedAttemptsCacheKey(userID)).(int)
+	return v >= twoFactorMaxFailedAttempts
+}
+
+// recordTwoFactorFailure increments the failed attempt counter for the user,
+// extending the TTL on each failure so the lockout window slides forward.
+func recordTwoFactorFailure(c *context.Context, userID int64) {
+	key := userx.TwoFactorFailedAttemptsCacheKey(userID)
+	current, _ := c.Cache.Get(key).(int)
+	if err := c.Cache.Put(key, current+1, twoFactorFailedAttemptsTTL); err != nil {
+		log.Error("Failed to put cache 'two factor failed attempts': %v", err)
+	}
+}
+
+// clearTwoFactorFailures removes the failed attempt counter after a successful
+// verification so legitimate users are not penalized for prior typos.
+func clearTwoFactorFailures(c *context.Context, userID int64) {
+	if err := c.Cache.Delete(userx.TwoFactorFailedAttemptsCacheKey(userID)); err != nil {
+		log.Error("Failed to delete cache 'two factor failed attempts': %v", err)
+	}
+}
+
 func LoginTwoFactorPost(c *context.Context) {
 	userID, ok := c.Session.Get("twoFactorUserID").(int64)
 	if !ok {
 		c.NotFound()
+		return
+	}
+
+	if twoFactorLockedOut(c, userID) {
+		c.Flash.Error(c.Tr("auth.login_two_factor_too_many_attempts"))
+		c.RedirectSubpath("/user/login/two_factor")
 		return
 	}
 
@@ -223,6 +265,7 @@ func LoginTwoFactorPost(c *context.Context) {
 		c.Error(err, "validate TOTP")
 		return
 	} else if !valid {
+		recordTwoFactorFailure(c, userID)
 		c.Flash.Error(c.Tr("settings.two_factor_invalid_passcode"))
 		c.RedirectSubpath("/user/login/two_factor")
 		return
@@ -244,6 +287,7 @@ func LoginTwoFactorPost(c *context.Context) {
 		log.Error("Failed to put cache 'two factor passcode': %v", err)
 	}
 
+	clearTwoFactorFailures(c, userID)
 	afterLogin(c, u, c.Session.Get("twoFactorRemember").(bool))
 }
 
@@ -264,8 +308,15 @@ func LoginTwoFactorRecoveryCodePost(c *context.Context) {
 		return
 	}
 
+	if twoFactorLockedOut(c, userID) {
+		c.Flash.Error(c.Tr("auth.login_two_factor_too_many_attempts"))
+		c.RedirectSubpath("/user/login/two_factor_recovery_code")
+		return
+	}
+
 	if err := database.Handle.TwoFactors().UseRecoveryCode(c.Req.Context(), userID, c.Query("recovery_code")); err != nil {
 		if database.IsTwoFactorRecoveryCodeNotFound(err) {
+			recordTwoFactorFailure(c, userID)
 			c.Flash.Error(c.Tr("auth.login_two_factor_invalid_recovery_code"))
 			c.RedirectSubpath("/user/login/two_factor_recovery_code")
 		} else {
@@ -279,6 +330,7 @@ func LoginTwoFactorRecoveryCodePost(c *context.Context) {
 		c.Error(err, "get user by ID")
 		return
 	}
+	clearTwoFactorFailures(c, userID)
 	afterLogin(c, u, c.Session.Get("twoFactorRemember").(bool))
 }
 

--- a/internal/userx/userx.go
+++ b/internal/userx/userx.go
@@ -131,6 +131,12 @@ func TwoFactorCacheKey(userID int64, passcode string) string {
 	return fmt.Sprintf("twoFactor::%d::%s", userID, passcode)
 }
 
+// TwoFactorFailedAttemptsCacheKey returns the key used for tracking the number
+// of failed two-factor verification attempts for the user.
+func TwoFactorFailedAttemptsCacheKey(userID int64) string {
+	return fmt.Sprintf("twoFactorFailedAttempts::%d", userID)
+}
+
 // RandomSalt returns randomly generated 10-character string that can be used as
 // the user salt.
 func RandomSalt() (string, error) {

--- a/internal/userx/userx_test.go
+++ b/internal/userx/userx_test.go
@@ -188,6 +188,11 @@ func TestTwoFactorCacheKey(t *testing.T) {
 	assert.Equal(t, "twoFactor::1::113654", got)
 }
 
+func TestTwoFactorFailedAttemptsCacheKey(t *testing.T) {
+	got := TwoFactorFailedAttemptsCacheKey(1)
+	assert.Equal(t, "twoFactorFailedAttempts::1", got)
+}
+
 func TestRandomSalt(t *testing.T) {
 	salt1, err := RandomSalt()
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

Cap failed TOTP and recovery code submissions to a small budget per user to prevent brute-forcing the second factor when primary credentials are already known. The counter is keyed by user ID in the existing cache and shared across both verification handlers, so alternating endpoints does not bypass the limit. The counter is cleared on successful verification so legitimate users are not penalized for prior typos.

Addresses [GHSA-5mgh-chvj-hqf5](https://github.com/gogs/gogs/security/advisories/GHSA-5mgh-chvj-hqf5).

## Test plan

- [x] `task lint` passes.
- [x] `go test ./internal/userx/...` passes.
- [ ] Manually verify lockout after the configured threshold of failed attempts.
- [ ] Manually verify the counter resets on successful TOTP / recovery code submission.