### PR TITLE
refactor: prepare email package for web framework migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ All notable changes to Gogs are documented in this file.
 
 - The `gogs cert` subcommand. [#8153](https://github.com/gogs/gogs/pull/8153)
 - The `[email] DISABLE_HELO` configuration option. HELO/EHLO is now always sent during SMTP handshake. [#8164](https://github.com/gogs/gogs/pull/8164)
-- Support for MSSQL as a database backend. Stay on 0.14 for continued usage. [#8173](https://github.com/gogs/gogs/pull/8173)
+- Support for MSSQL as the database backend. Stay on 0.14 for continued usage. [#8173](https://github.com/gogs/gogs/pull/8173)
+- Support for `memcache` as the cache adapter. Stay on 0.14 for continued usage.
 
 ## 0.14.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to Gogs are documented in this file.
 - The `gogs cert` subcommand. [#8153](https://github.com/gogs/gogs/pull/8153)
 - The `[email] DISABLE_HELO` configuration option. HELO/EHLO is now always sent during SMTP handshake. [#8164](https://github.com/gogs/gogs/pull/8164)
 - Support for MSSQL as the database backend. Stay on 0.14 for continued usage. [#8173](https://github.com/gogs/gogs/pull/8173)
-- Support for `memcache` as the cache adapter. Stay on 0.14 for continued usage.
+- Support for `memcache` as the cache adapter. Stay on 0.14 for continued usage. [#8270](https://github.com/gogs/gogs/pull/8270)
 
 ## 0.14.2
 

--- a/conf/app.ini
+++ b/conf/app.ini
@@ -261,13 +261,12 @@ MAX_LIFE_TIME = 86400
 CSRF_COOKIE_NAME = _csrf
 
 [cache]
-; The cache adapter, either "memory", "redis", or "memcache".
+; The cache adapter, either "memory" or "redis".
 ADAPTER = memory
 ; For "memory" only, GC interval in seconds.
 INTERVAL = 60
-; For "redis" and "memcache", connection host address:
+; For "redis", connection host address:
 ; - redis: network=tcp,addr=:6379,password=macaron,db=0,pool_size=100,idle_timeout=180
-; - memcache: `127.0.0.1:11211`
 HOST =
 
 [http]

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,6 @@ require (
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc // indirect
-	github.com/bradfitz/gomemcache v0.0.0-20190329173943-551aad21a668 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/clipperhouse/displaywidth v0.6.2 // indirect
 	github.com/clipperhouse/stringish v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -27,7 +27,6 @@ github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc h1:biVzkmvwrH8WK8raXaxBx6fRVTlJILwEwQGL1I/ByEI=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
-github.com/bradfitz/gomemcache v0.0.0-20190329173943-551aad21a668 h1:U/lr3Dgy4WK+hNk4tyD+nuGjpVLPEHuJSFXMw11/HPA=
 github.com/bradfitz/gomemcache v0.0.0-20190329173943-551aad21a668/go.mod h1:H0wQNHz2YrLsuXOZozoeDmnHXkNCRmMW0gwFWDfEZDA=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
-	_ "github.com/go-macaron/cache/memcache"
 	_ "github.com/go-macaron/cache/redis"
 	_ "github.com/go-macaron/session/redis"
 	"github.com/gogs/go-libravatar"

--- a/internal/email/email.go
+++ b/internal/email/email.go
@@ -16,6 +16,14 @@ import (
 	"gogs.io/gogs/templates"
 )
 
+// Translator is the minimal locale-translation contract used by mail
+// composition. It decouples this package from any specific web framework so
+// callers can pass either macaron.Context or, post-migration, Flamego's
+// i18n.Locale.
+type Translator interface {
+	Tr(format string, args ...any) string
+}
+
 const (
 	tmplAuthActivate       = "auth/activate"
 	tmplAuthActivateEmail  = "auth/activate_email"
@@ -102,7 +110,7 @@ type Issue interface {
 	HTMLURL() string
 }
 
-func SendUserMail(_ *macaron.Context, u User, tpl, code, subject, info string) error {
+func SendUserMail(_ Translator, u User, tpl, code, subject, info string) error {
 	data := map[string]any{
 		"Username":          u.DisplayName(),
 		"ActiveCodeLives":   conf.Auth.ActivateCodeLives / 60,
@@ -124,15 +132,15 @@ func SendUserMail(_ *macaron.Context, u User, tpl, code, subject, info string) e
 	return nil
 }
 
-func SendActivateAccountMail(c *macaron.Context, u User) error {
-	return SendUserMail(c, u, tmplAuthActivate, u.GenerateEmailActivateCode(u.Email()), c.Tr("mail.activate_account"), "activate account")
+func SendActivateAccountMail(t Translator, u User) error {
+	return SendUserMail(t, u, tmplAuthActivate, u.GenerateEmailActivateCode(u.Email()), t.Tr("mail.activate_account"), "activate account")
 }
 
-func SendResetPasswordMail(c *macaron.Context, u User) error {
-	return SendUserMail(c, u, tmplAuthResetPassword, u.GenerateEmailActivateCode(u.Email()), c.Tr("mail.reset_password"), "reset password")
+func SendResetPasswordMail(t Translator, u User) error {
+	return SendUserMail(t, u, tmplAuthResetPassword, u.GenerateEmailActivateCode(u.Email()), t.Tr("mail.reset_password"), "reset password")
 }
 
-func SendActivateEmailMail(c *macaron.Context, u User, email string) error {
+func SendActivateEmailMail(t Translator, u User, email string) error {
 	data := map[string]any{
 		"Username":        u.DisplayName(),
 		"ActiveCodeLives": conf.Auth.ActivateCodeLives / 60,
@@ -144,7 +152,7 @@ func SendActivateEmailMail(c *macaron.Context, u User, email string) error {
 		return errors.Wrap(err, "render")
 	}
 
-	msg, err := newMessage([]string{email}, c.Tr("mail.activate_email"), body)
+	msg, err := newMessage([]string{email}, t.Tr("mail.activate_email"), body)
 	if err != nil {
 		return errors.Wrap(err, "new message")
 	}
@@ -154,7 +162,7 @@ func SendActivateEmailMail(c *macaron.Context, u User, email string) error {
 	return nil
 }
 
-func SendRegisterNotifyMail(c *macaron.Context, u User) error {
+func SendRegisterNotifyMail(t Translator, u User) error {
 	data := map[string]any{
 		"Username": u.DisplayName(),
 	}
@@ -163,7 +171,7 @@ func SendRegisterNotifyMail(c *macaron.Context, u User) error {
 		return errors.Wrap(err, "render")
 	}
 
-	msg, err := newMessage([]string{u.Email()}, c.Tr("mail.register_notify"), body)
+	msg, err := newMessage([]string{u.Email()}, t.Tr("mail.register_notify"), body)
 	if err != nil {
 		return errors.Wrap(err, "new message")
 	}


### PR DESCRIPTION
## Summary

- Introduce `email.Translator` interface so mail composition no longer depends on `*macaron.Context` directly. Existing callers pass `c.Context` unchanged thanks to structural typing — `*macaron.Context.Tr(format string, args ...any) string` satisfies the interface.
- Drop the `memcache` cache adapter import (`_ "github.com/go-macaron/cache/memcache"`) and update `app.ini` docs. Memcache is rarely used in practice today and is not supported by the upcoming web framework migration target.

This is preparation work for a follow-up that fully replaces Macaron with Flamego; this PR is intentionally behavior-preserving and reviewable on its own.

## Test plan

- [x] `task lint` passes
- [x] `go build ./...` succeeds
- [x] `go test ./internal/conf/...` passes
