### PR TITLE
refactor: replace toolbox middleware with a minimal /healthcheck handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to Gogs are documented in this file.
 - The `[email] DISABLE_HELO` configuration option. HELO/EHLO is now always sent during SMTP handshake. [#8164](https://github.com/gogs/gogs/pull/8164)
 - Support for MSSQL as the database backend. Stay on 0.14 for continued usage. [#8173](https://github.com/gogs/gogs/pull/8173)
 - Support for `memcache` as the cache adapter. Stay on 0.14 for continued usage. [#8270](https://github.com/gogs/gogs/pull/8270)
+- The `/debug`, `/debug/pprof/*`, `/debug/profile/*`, and `/urlmap.json` endpoints. The `/healthcheck` endpoint is preserved.
 
 ## 0.14.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to Gogs are documented in this file.
 - The `[email] DISABLE_HELO` configuration option. HELO/EHLO is now always sent during SMTP handshake. [#8164](https://github.com/gogs/gogs/pull/8164)
 - Support for MSSQL as the database backend. Stay on 0.14 for continued usage. [#8173](https://github.com/gogs/gogs/pull/8173)
 - Support for `memcache` as the cache adapter. Stay on 0.14 for continued usage. [#8270](https://github.com/gogs/gogs/pull/8270)
-- The `/debug`, `/debug/pprof/*`, `/debug/profile/*`, and `/urlmap.json` endpoints. The `/healthcheck` endpoint is preserved.
+- The `/debug`, `/debug/pprof/*`, `/debug/profile/*`, and `/urlmap.json` endpoints. [#8271](https://github.com/gogs/gogs/pull/8271)
 
 ## 0.14.2
 

--- a/cmd/gogs/web.go
+++ b/cmd/gogs/web.go
@@ -151,9 +151,6 @@ func newMacaron() *macaron.Macaron {
 	return m
 }
 
-// healthCheck reports whether external dependencies are reachable. Returns
-// HTTP 200 with a body line per dependency on success, or HTTP 503 with the
-// first failing dependency's error on failure.
 func healthCheck(w http.ResponseWriter, r *http.Request) {
 	if err := database.Ping(); err != nil {
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")

--- a/cmd/gogs/web.go
+++ b/cmd/gogs/web.go
@@ -19,7 +19,6 @@ import (
 	"github.com/go-macaron/gzip"
 	"github.com/go-macaron/i18n"
 	"github.com/go-macaron/session"
-	"github.com/go-macaron/toolbox"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/urfave/cli/v3"
 	"gopkg.in/macaron.v1"
@@ -148,15 +147,26 @@ func newMacaron() *macaron.Macaron {
 	m.Use(captcha.Captchaer(captcha.Options{
 		SubURL: conf.Server.Subpath,
 	}))
-	m.Use(toolbox.Toolboxer(m, toolbox.Options{
-		HealthCheckFuncs: []*toolbox.HealthCheckFuncDesc{
-			{
-				Desc: "Database connection",
-				Func: database.Ping,
-			},
-		},
-	}))
+	m.Route("/healthcheck", "HEAD,GET", healthCheck)
 	return m
+}
+
+// healthCheck reports whether external dependencies are reachable. Returns
+// HTTP 200 with a body line per dependency on success, or HTTP 503 with the
+// first failing dependency's error on failure.
+func healthCheck(w http.ResponseWriter, r *http.Request) {
+	if err := database.Ping(); err != nil {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = fmt.Fprintf(w, "* Database connection: %s\n", err)
+		return
+	}
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	if r.Method == http.MethodHead {
+		return
+	}
+	_, _ = w.Write([]byte("* Database connection: OK\n"))
 }
 
 func runWeb(_ stdctx.Context, cmd *cli.Command) error {

--- a/cmd/gogs/web.go
+++ b/cmd/gogs/web.go
@@ -147,7 +147,7 @@ func newMacaron() *macaron.Macaron {
 	m.Use(captcha.Captchaer(captcha.Options{
 		SubURL: conf.Server.Subpath,
 	}))
-	m.Route("/healthcheck", "HEAD,GET", healthCheck)
+	m.Route("/healthcheck", http.MethodHead+","+http.MethodGet, healthCheck)
 	return m
 }
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/go-macaron/gzip v0.0.0-20160222043647-cad1c6580a07
 	github.com/go-macaron/i18n v0.6.0
 	github.com/go-macaron/session v1.0.3
-	github.com/go-macaron/toolbox v0.0.0-20190813233741-94defb8383c6
 	github.com/gogs/chardet v0.0.0-20150115103509-2404f7772561
 	github.com/gogs/cron v0.0.0-20171120032916-9f6c956d3e14
 	github.com/gogs/git-module v1.8.7

--- a/go.sum
+++ b/go.sum
@@ -122,8 +122,6 @@ github.com/go-macaron/inject v0.0.0-20200308113650-138e5925c53b/go.mod h1:VFI2o2
 github.com/go-macaron/session v0.0.0-20190805070824-1a3cdc6f5659/go.mod h1:tLd0QEudXocQckwcpCq5pCuTCuYc24I0bRJDuRe9OuQ=
 github.com/go-macaron/session v1.0.3 h1:YnSfcm24a4HHRnZzBU30FGvoo4kR6vYbTeyTlA1dya4=
 github.com/go-macaron/session v1.0.3/go.mod h1:NKoSrKpBFGEgeDtdLr/mnGaxa2LZVOg8/LwZKwPgQr0=
-github.com/go-macaron/toolbox v0.0.0-20190813233741-94defb8383c6 h1:x/v1iUWlqXTKVg17ulB0qCgcM2s+eysAbr/dseKLLss=
-github.com/go-macaron/toolbox v0.0.0-20190813233741-94defb8383c6/go.mod h1:YFNJ/JT4yLnpuIXTFef30SZkxGHUczjGZGFaZpPcdn0=
 github.com/go-redis/redis/v8 v8.11.5 h1:AcZZR7igkdvfVmQTPnu9WE37LRrO/YrBH5zWyjDC0oI=
 github.com/go-redis/redis/v8 v8.11.5/go.mod h1:gREzHqY1hg6oD9ngVRbLStwAWKhA0FEgq8Jd4h5lpwo=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=


### PR DESCRIPTION
## Summary

Replaces the `go-macaron/toolbox` dependency with a minimal `http.HandlerFunc` that serves `HEAD`/`GET /healthcheck`, returning HTTP 200 (or 503 on database ping failure).

With its default options, the toolbox middleware also registered `/debug`, `/debug/pprof/*`, `/debug/profile/*`, and `/urlmap.json` — all dropped here. The `/healthcheck` endpoint is preserved with the same response shape (one line per dependency).

Also removes one parity gap for the upcoming Flamego migration, since `go-macaron/toolbox` has no Flamego equivalent.

## Test plan

- [x] `task lint` passes
- [x] `go build ./cmd/gogs/` succeeds (89MB binary)
- [ ] Manual: `curl -i http://localhost:3000/healthcheck` returns 200 with `* Database connection: OK`
- [ ] Manual: `curl -i http://localhost:3000/debug/pprof/heap` returns 404
