### PR TITLE
test: cover disk-mode mail template render paths

### DIFF
--- a/internal/email/email_test.go
+++ b/internal/email/email_test.go
@@ -1,6 +1,9 @@
 package email
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -9,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"gogs.io/gogs/internal/conf"
+	"gogs.io/gogs/internal/testx"
 )
 
 // TestRenderEmbeddedTemplates ensures every builtin mail template parses and
@@ -122,3 +126,106 @@ func (testDoer) ID() int64                               { return 1 }
 func (testDoer) DisplayName() string                     { return "alice" }
 func (testDoer) Email() string                           { return "alice@example.test" }
 func (testDoer) GenerateEmailActivateCode(string) string { return "abc" }
+
+// The helper tests below run inside a subprocess so they can install fresh
+// values for GOGS_WORK_DIR and GOGS_CUSTOM before conf.WorkDir / conf.CustomDir
+// memoize via sync.Once. The parent test sets up a temp directory tree and
+// invokes the helper via testx.Exec, mirroring the pattern used in
+// internal/conf/computed_test.go.
+
+// TestRenderFromDiskHelper exercises the LoadAssetsFromDisk=true path:
+//   - primary template loads from <work>/templates/mail.
+//   - <custom>/templates/mail overrides the primary copy when present.
+//   - templates reload on every render call, so an edit to the custom file
+//     between two renders is observed without restarting the process.
+//   - removing the custom file falls back to the primary copy.
+func TestRenderFromDiskHelper(t *testing.T) {
+	if !testx.WantHelperProcess() {
+		return
+	}
+
+	workDir := os.Getenv("GOGS_WORK_DIR")
+	customDir := os.Getenv("GOGS_CUSTOM")
+
+	conf.SetMockApp(t, conf.AppOpts{BrandName: "Gogs"})
+	conf.SetMockServer(t, conf.ServerOpts{
+		ExternalURL:        "https://example.test/",
+		LoadAssetsFromDisk: true,
+	})
+
+	const tplPath = "auth/activate"
+	primary := filepath.Join(workDir, "templates", "mail", tplPath+".tmpl")
+	custom := filepath.Join(customDir, "templates", "mail", tplPath+".tmpl")
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(primary), 0o755))
+	require.NoError(t, os.WriteFile(primary, []byte("PRIMARY {{.Username}}"), 0o644))
+
+	body, err := render(tplPath, map[string]any{"Username": "alice"})
+	require.NoError(t, err)
+	require.Equal(t, "PRIMARY alice", body)
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(custom), 0o755))
+	require.NoError(t, os.WriteFile(custom, []byte("CUSTOM v1 {{.Username}}"), 0o644))
+
+	body, err = render(tplPath, map[string]any{"Username": "alice"})
+	require.NoError(t, err)
+	require.Equal(t, "CUSTOM v1 alice", body)
+
+	require.NoError(t, os.WriteFile(custom, []byte("CUSTOM v2 {{.Username}}"), 0o644))
+
+	body, err = render(tplPath, map[string]any{"Username": "alice"})
+	require.NoError(t, err)
+	require.Equal(t, "CUSTOM v2 alice", body, "hot-reload should pick up edits without a restart")
+
+	require.NoError(t, os.Remove(custom))
+
+	body, err = render(tplPath, map[string]any{"Username": "alice"})
+	require.NoError(t, err)
+	require.Equal(t, "PRIMARY alice", body, "removing the custom override should fall back to the primary copy")
+
+	fmt.Fprintln(os.Stdout, "ok")
+}
+
+func TestRenderFromDisk(t *testing.T) {
+	workDir := t.TempDir()
+	customDir := t.TempDir()
+	out, err := testx.Exec("TestRenderFromDiskHelper",
+		"GOGS_WORK_DIR="+workDir,
+		"GOGS_CUSTOM="+customDir,
+	)
+	require.NoError(t, err, out)
+	assert.Equal(t, "ok", out)
+}
+
+// TestRenderMissingDiskRootHelper asserts that booting with
+// LoadAssetsFromDisk=true but no <work>/templates/mail directory fails fast on
+// first render with a wrapped ErrNotExist, rather than silently returning an
+// empty template set.
+func TestRenderMissingDiskRootHelper(t *testing.T) {
+	if !testx.WantHelperProcess() {
+		return
+	}
+
+	conf.SetMockServer(t, conf.ServerOpts{LoadAssetsFromDisk: true})
+
+	_, err := render("auth/activate", nil)
+	if err == nil {
+		fmt.Fprintln(os.Stdout, "expected error, got nil")
+		os.Exit(1)
+	}
+	if !strings.Contains(err.Error(), "stat base mail templates") {
+		fmt.Fprintf(os.Stdout, "unexpected error: %v", err)
+		os.Exit(1)
+	}
+	fmt.Fprintln(os.Stdout, "ok")
+}
+
+func TestRenderMissingDiskRoot(t *testing.T) {
+	emptyDir := t.TempDir()
+	out, err := testx.Exec("TestRenderMissingDiskRootHelper",
+		"GOGS_WORK_DIR="+emptyDir,
+		"GOGS_CUSTOM="+emptyDir,
+	)
+	require.NoError(t, err, out)
+	assert.Equal(t, "ok", out)
+}


### PR DESCRIPTION
## Summary

Stacked on top of #8272. Adds three subprocess-driven tests to `internal/email` covering paths the embedded-FS-only tests don't reach:

- Primary template loads from `<work>/templates/mail`.
- `<custom>/templates/mail` overrides the primary copy when present.
- Edits to the custom file are observed on the next render call without a process restart (matches the prior macaron hot-reload behavior under `LoadAssetsFromDisk=true`).
- Removing the custom override falls back to the primary copy.
- Booting with `LoadAssetsFromDisk=true` but no `<work>/templates/mail` directory fails fast on first render with a wrapped `ErrNotExist`.

Uses the `testx.Exec` subprocess pattern from `internal/conf/computed_test.go` because `conf.WorkDir` / `conf.CustomDir` memoize their env-var-driven values via `sync.Once`, which would otherwise cap each test run at the first observed value.

## Test plan

- [x] `go test ./internal/email/` — 4 new tests pass alongside the existing 2.
- [x] `task lint` passes.
