### PR TITLE
refactor: inline disallowed-username regex in UsersStore.Authenticate

### DIFF
--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -51,16 +51,16 @@ func (err ErrLoginSourceMismatch) Error() string {
 	return fmt.Sprintf("login source mismatch: %v", err.args)
 }
 
+// disallowedUsernameChars matches any character not allowed in a username:
+// anything outside ASCII letters, digits, underscore, hyphen, or dot.
+var disallowedUsernameChars = regexp.MustCompile(`[^\d\w-_\.]`)
+
 // Authenticate validates username and password via given login source ID. It
 // returns ErrUserNotExist when the user was not found.
 //
 // When the "loginSourceID" is negative, it aborts the process and returns
 // ErrUserNotExist if the user was not found in the database.
 //
-// disallowedUsernameChars matches any character not allowed in a username:
-// anything outside ASCII letters, digits, underscore, hyphen, or dot.
-var disallowedUsernameChars = regexp.MustCompile(`[^\d\w-_\.]`)
-
 // When the "loginSourceID" is non-negative, it returns ErrLoginSourceMismatch
 // if the user has different login source ID than the "loginSourceID".
 //

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -5,12 +5,12 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 	"unicode/utf8"
 
 	"github.com/cockroachdb/errors"
-	"github.com/go-macaron/binding"
 	"gorm.io/gorm"
 	log "unknwon.dev/clog/v2"
 
@@ -57,6 +57,10 @@ func (err ErrLoginSourceMismatch) Error() string {
 // When the "loginSourceID" is negative, it aborts the process and returns
 // ErrUserNotExist if the user was not found in the database.
 //
+// disallowedUsernameChars matches any character not allowed in a username:
+// anything outside ASCII letters, digits, underscore, hyphen, or dot.
+var disallowedUsernameChars = regexp.MustCompile(`[^\d\w-_\.]`)
+
 // When the "loginSourceID" is non-negative, it returns ErrLoginSourceMismatch
 // if the user has different login source ID than the "loginSourceID".
 //
@@ -129,7 +133,7 @@ func (s *UsersStore) Authenticate(ctx context.Context, login, password string, l
 	}
 
 	// Validate username make sure it satisfies requirement.
-	if binding.AlphaDashDotPattern.MatchString(extAccount.Name) {
+	if disallowedUsernameChars.MatchString(extAccount.Name) {
 		return nil, errors.Newf("invalid pattern for attribute 'username' [%s]: must be valid alpha or numeric or dash(-_) or dot characters", extAccount.Name)
 	}
 


### PR DESCRIPTION
## Summary

Stacked on top of #8272. Replaces the `binding.AlphaDashDotPattern` reference in `internal/database/users.go` with a file-local `regexp.Regexp` with the same character class.

The DB-layer username check pulled `github.com/go-macaron/binding` in solely for one regex value, which coupled a storage-layer validation to a web-framework package. Inlining it removes that import from `internal/database` and makes one more file Flamego-migration-ready.

The package is still depended on by `internal/form/*` and the route registration site; the swap PR removes it entirely.

## Test plan

- [x] `task lint` passes
- [x] `go build ./cmd/gogs/` succeeds
- [x] Behavior preserved: same `[^\d\w-_\.]` character class, same `MatchString` truthiness, same error message.
