### PR TITLE
Replace Docker `latest` on main with an `edge` tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -60,12 +60,12 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: |
-            gogs/gogs:latest
-            ghcr.io/gogs/gogs:latest
+            gogs/gogs:edge
+            ghcr.io/gogs/gogs:edge
       - name: Scan for container vulnerabilities
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
-          image-ref: gogs/gogs:latest
+          image-ref: gogs/gogs:edge
           exit-code: '1'
       - name: Send email on failure
         uses: unknwon/send-email-on-failure@89339a1bc93f4ad1d30f3b7e4911fcba985c9adb # v1
@@ -126,13 +126,13 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: |
-            gogs/gogs:next-latest
-            ghcr.io/gogs/gogs:next-latest
-            registry.digitalocean.com/gogs/gogs:next-latest
+            gogs/gogs:next-edge
+            ghcr.io/gogs/gogs:next-edge
+            registry.digitalocean.com/gogs/gogs:next-edge
       - name: Scan for container vulnerabilities
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
-          image-ref: gogs/gogs:next-latest
+          image-ref: gogs/gogs:next-edge
           exit-code: '1'
       - name: Send email on failure
         uses: unknwon/send-email-on-failure@89339a1bc93f4ad1d30f3b7e4911fcba985c9adb # v1
@@ -263,12 +263,14 @@ jobs:
           TAGS="gogs/gogs:$IMAGE_TAG
           ghcr.io/gogs/gogs:$IMAGE_TAG"
 
-          # Add minor version tag for stable releases (no prerelease suffix per semver).
+          # Add minor version and `latest` tags for stable releases (no prerelease suffix per semver).
           if [[ ! "$IMAGE_TAG" =~ - ]]; then
             MINOR_TAG=$(echo "$IMAGE_TAG" | cut -d. -f1,2)
             TAGS="$TAGS
           gogs/gogs:$MINOR_TAG
-          ghcr.io/gogs/gogs:$MINOR_TAG"
+          ghcr.io/gogs/gogs:$MINOR_TAG
+          gogs/gogs:latest
+          ghcr.io/gogs/gogs:latest"
           fi
 
           echo "TAGS<<EOF" >> $GITHUB_ENV
@@ -332,12 +334,14 @@ jobs:
           TAGS="gogs/gogs:next-$IMAGE_TAG
           ghcr.io/gogs/gogs:next-$IMAGE_TAG"
 
-          # Add minor version tag for stable releases (no prerelease suffix per semver).
+          # Add minor version and `next-latest` tags for stable releases (no prerelease suffix per semver).
           if [[ ! "$IMAGE_TAG" =~ - ]]; then
             MINOR_TAG=$(echo "$IMAGE_TAG" | cut -d. -f1,2)
             TAGS="$TAGS
           gogs/gogs:next-$MINOR_TAG
-          ghcr.io/gogs/gogs:next-$MINOR_TAG"
+          ghcr.io/gogs/gogs:next-$MINOR_TAG
+          gogs/gogs:next-latest
+          ghcr.io/gogs/gogs:next-latest"
           fi
 
           echo "TAGS<<EOF" >> $GITHUB_ENV

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -255,6 +255,10 @@ jobs:
       contents: read
       packages: write
     steps:
+      - name: Check out code
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          fetch-depth: 0
       - name: Compute image tags
         run: |
           IMAGE_TAG=$(echo $GITHUB_REF_NAME | cut -c 2-)
@@ -263,21 +267,32 @@ jobs:
           TAGS="gogs/gogs:$IMAGE_TAG
           ghcr.io/gogs/gogs:$IMAGE_TAG"
 
-          # Add minor version and `latest` tags for stable releases (no prerelease suffix per semver).
+          # For stable releases (no prerelease suffix per semver), add the
+          # minor-version tag only if this release is the highest patch of that
+          # minor line, and add `latest` only if this release is the highest
+          # stable version across the repository. Back-patches on older lines
+          # must not clobber moving tags.
           if [[ ! "$IMAGE_TAG" =~ - ]]; then
+            STABLE_TAGS=$(git tag --list 'v*' | sed 's/^v//' | grep -v -- '-' || true)
+            HIGHEST_STABLE=$(echo "$STABLE_TAGS" | sort -V | tail -n 1)
             MINOR_TAG=$(echo "$IMAGE_TAG" | cut -d. -f1,2)
-            TAGS="$TAGS
+            HIGHEST_IN_MINOR=$(echo "$STABLE_TAGS" | grep "^${MINOR_TAG}\." | sort -V | tail -n 1)
+
+            if [[ "$IMAGE_TAG" == "$HIGHEST_IN_MINOR" ]]; then
+              TAGS="$TAGS
           gogs/gogs:$MINOR_TAG
-          ghcr.io/gogs/gogs:$MINOR_TAG
+          ghcr.io/gogs/gogs:$MINOR_TAG"
+            fi
+            if [[ "$IMAGE_TAG" == "$HIGHEST_STABLE" ]]; then
+              TAGS="$TAGS
           gogs/gogs:latest
           ghcr.io/gogs/gogs:latest"
+            fi
           fi
 
           echo "TAGS<<EOF" >> $GITHUB_ENV
           echo "$TAGS" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
-      - name: Check out code
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
         with:
@@ -326,6 +341,10 @@ jobs:
       contents: read
       packages: write
     steps:
+      - name: Check out code
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          fetch-depth: 0
       - name: Compute image tags
         run: |
           IMAGE_TAG=$(echo $GITHUB_REF_NAME | cut -c 2-)
@@ -334,21 +353,32 @@ jobs:
           TAGS="gogs/gogs:next-$IMAGE_TAG
           ghcr.io/gogs/gogs:next-$IMAGE_TAG"
 
-          # Add minor version and `next-latest` tags for stable releases (no prerelease suffix per semver).
+          # For stable releases (no prerelease suffix per semver), add the
+          # minor-version tag only if this release is the highest patch of that
+          # minor line, and add `next-latest` only if this release is the
+          # highest stable version across the repository. Back-patches on older
+          # lines must not clobber moving tags.
           if [[ ! "$IMAGE_TAG" =~ - ]]; then
+            STABLE_TAGS=$(git tag --list 'v*' | sed 's/^v//' | grep -v -- '-' || true)
+            HIGHEST_STABLE=$(echo "$STABLE_TAGS" | sort -V | tail -n 1)
             MINOR_TAG=$(echo "$IMAGE_TAG" | cut -d. -f1,2)
-            TAGS="$TAGS
+            HIGHEST_IN_MINOR=$(echo "$STABLE_TAGS" | grep "^${MINOR_TAG}\." | sort -V | tail -n 1)
+
+            if [[ "$IMAGE_TAG" == "$HIGHEST_IN_MINOR" ]]; then
+              TAGS="$TAGS
           gogs/gogs:next-$MINOR_TAG
-          ghcr.io/gogs/gogs:next-$MINOR_TAG
+          ghcr.io/gogs/gogs:next-$MINOR_TAG"
+            fi
+            if [[ "$IMAGE_TAG" == "$HIGHEST_STABLE" ]]; then
+              TAGS="$TAGS
           gogs/gogs:next-latest
           ghcr.io/gogs/gogs:next-latest"
+            fi
           fi
 
           echo "TAGS<<EOF" >> $GITHUB_ENV
           echo "$TAGS" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
-      - name: Check out code
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,65 +15,6 @@ on:
     types: [ published ]
 
 jobs:
-  buildx:
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'gogs/gogs' }}
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-      contents: read
-      packages: write
-    steps:
-      - name: Check out code
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
-        with:
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
-      - name: Inspect builder
-        run: |
-          echo "Name:      ${{ steps.buildx.outputs.name }}"
-          echo "Endpoint:  ${{ steps.buildx.outputs.endpoint }}"
-          echo "Status:    ${{ steps.buildx.outputs.status }}"
-          echo "Flags:     ${{ steps.buildx.outputs.flags }}"
-          echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
-      - name: Login to Docker Hub
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Login to GitHub Container registry
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push images
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
-          push: true
-          tags: |
-            gogs/gogs:edge
-            ghcr.io/gogs/gogs:edge
-      - name: Scan for container vulnerabilities
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
-        with:
-          image-ref: gogs/gogs:edge
-          exit-code: '1'
-      - name: Send email on failure
-        uses: unknwon/send-email-on-failure@89339a1bc93f4ad1d30f3b7e4911fcba985c9adb # v1
-        if: ${{ failure() }}
-        with:
-          smtp_username: ${{ secrets.SMTP_USERNAME }}
-          smtp_password: ${{ secrets.SMTP_PASSWORD }}
-
   buildx-next:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'gogs/gogs' }}
     concurrency:
@@ -126,13 +67,13 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: |
-            gogs/gogs:next-edge
-            ghcr.io/gogs/gogs:next-edge
-            registry.digitalocean.com/gogs/gogs:next-edge
+            gogs/gogs:edge
+            ghcr.io/gogs/gogs:edge
+            registry.digitalocean.com/gogs/gogs:edge
       - name: Scan for container vulnerabilities
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
-          image-ref: gogs/gogs:next-edge
+          image-ref: gogs/gogs:edge
           exit-code: '1'
       - name: Send email on failure
         uses: unknwon/send-email-on-failure@89339a1bc93f4ad1d30f3b7e4911fcba985c9adb # v1
@@ -258,7 +199,10 @@ jobs:
       - name: Check out code
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
+          # Full history with tags is required so the next step can determine
+          # whether this release is the highest stable version across the repo.
           fetch-depth: 0
+          fetch-tags: true
       - name: Compute image tags
         run: |
           IMAGE_TAG=$(echo $GITHUB_REF_NAME | cut -c 2-)
@@ -325,6 +269,11 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: ${{ env.TAGS }}
+      - name: Scan for container vulnerabilities
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        with:
+          image-ref: gogs/gogs:${{ env.IMAGE_TAG }}
+          exit-code: '1'
       - name: Send email on failure
         uses: unknwon/send-email-on-failure@89339a1bc93f4ad1d30f3b7e4911fcba985c9adb # v1
         if: ${{ failure() }}
@@ -344,7 +293,10 @@ jobs:
       - name: Check out code
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
+          # Full history with tags is required so the next step can determine
+          # whether this release is the highest stable version across the repo.
           fetch-depth: 0
+          fetch-tags: true
       - name: Compute image tags
         run: |
           IMAGE_TAG=$(echo $GITHUB_REF_NAME | cut -c 2-)
@@ -412,6 +364,11 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: ${{ env.TAGS }}
+      - name: Scan for container vulnerabilities
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        with:
+          image-ref: gogs/gogs:next-${{ env.IMAGE_TAG }}
+          exit-code: '1'
       - name: Send email on failure
         uses: unknwon/send-email-on-failure@89339a1bc93f4ad1d30f3b7e4911fcba985c9adb # v1
         if: ${{ failure() }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -220,7 +220,9 @@ jobs:
             STABLE_TAGS=$(git tag --list 'v*' | sed 's/^v//' | grep -v -- '-' || true)
             HIGHEST_STABLE=$(echo "$STABLE_TAGS" | sort -V | tail -n 1)
             MINOR_TAG=$(echo "$IMAGE_TAG" | cut -d. -f1,2)
-            HIGHEST_IN_MINOR=$(echo "$STABLE_TAGS" | grep "^${MINOR_TAG}\." | sort -V | tail -n 1)
+            # `|| true` keeps the step running when `grep` finds no matches,
+            # since bash runs with `-e -o pipefail` in GitHub Actions.
+            HIGHEST_IN_MINOR=$(echo "$STABLE_TAGS" | { grep "^${MINOR_TAG}\." || true; } | sort -V | tail -n 1)
 
             if [[ "$IMAGE_TAG" == "$HIGHEST_IN_MINOR" ]]; then
               TAGS="$TAGS
@@ -314,7 +316,9 @@ jobs:
             STABLE_TAGS=$(git tag --list 'v*' | sed 's/^v//' | grep -v -- '-' || true)
             HIGHEST_STABLE=$(echo "$STABLE_TAGS" | sort -V | tail -n 1)
             MINOR_TAG=$(echo "$IMAGE_TAG" | cut -d. -f1,2)
-            HIGHEST_IN_MINOR=$(echo "$STABLE_TAGS" | grep "^${MINOR_TAG}\." | sort -V | tail -n 1)
+            # `|| true` keeps the step running when `grep` finds no matches,
+            # since bash runs with `-e -o pipefail` in GitHub Actions.
+            HIGHEST_IN_MINOR=$(echo "$STABLE_TAGS" | { grep "^${MINOR_TAG}\." || true; } | sort -V | tail -n 1)
 
             if [[ "$IMAGE_TAG" == "$HIGHEST_IN_MINOR" ]]; then
               TAGS="$TAGS

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,3 +31,4 @@ This applies to all texts, including but not limited to UI, documentation, code 
 - When pushing changes to a pull request from a fork, use SSH address and do not add remote.
 - Never commit on the `main` branch directly unless being explicitly asked to do so. A single ask only grants a single commit action on the `main` branch.
 - Never amend commits unless being explicitly asked to do so.
+- When creating a git worktree, the worktree directory name must match its branch name. Do not use random or generated suffixes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to Gogs are documented in this file.
 
 ### Changed
 
-- Docker builds from `main` are now published as `gogs/gogs:edge` and `gogs/gogs:next-edge`. The `gogs/gogs:latest` and `gogs/gogs:next-latest` tags now always point to the highest published stable release. [#8278](https://github.com/gogs/gogs/pull/8278)
+- Docker builds from `main` are now published only as `gogs/gogs:edge`, using the next-generation `Dockerfile.next`. The legacy `Dockerfile` no longer produces `main` builds. The `gogs/gogs:latest` and `gogs/gogs:next-latest` tags now always point to the highest published stable release, never to a back-patch on an older line. [#8278](https://github.com/gogs/gogs/pull/8278)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Gogs are documented in this file.
 
 ## 0.15.0+dev (`main`)
 
+### Changed
+
+- Docker builds from `main` are now published as `gogs/gogs:edge` and `gogs/gogs:next-edge`. The `gogs/gogs:latest` and `gogs/gogs:next-latest` tags now always point to the highest published stable release. [#8278](https://github.com/gogs/gogs/pull/8278)
+
 ### Fixed
 
 - _Security:_ Denial of service in repository and wiki file listing pages via crafted file names. [#8116](https://github.com/gogs/gogs/pull/8116) - [GHSA-3qq3-668m-v9mj](https://github.com/gogs/gogs/security/advisories/GHSA-3qq3-668m-v9mj)


### PR DESCRIPTION
## Describe the pull request

Reworks the Docker workflow so that the `latest` tags only ever point at the most recent stable release. Builds from `main` get their own moving tag, `edge`, produced from the next-generation `Dockerfile.next`, and the legacy `Dockerfile` no longer produces `main` builds at all.

Highlights:

- Push to `main`: publishes `gogs/gogs:edge` to Docker Hub, GHCR, and the DigitalOcean registry, built from `Dockerfile.next`. The legacy `buildx` job is removed.
- Release publish: still tags the version and minor lines. The moving tags (`:latest`, `:MAJOR.MINOR`, `:next-latest`, `:next-MAJOR.MINOR`) are now only added when the released version is the highest stable tag in the repository, so a back-patch on an older line (e.g. `0.13.2` published after `0.14.0`) cannot clobber them.
- Release jobs now also run a Trivy vulnerability scan on the published image, matching the existing `main` build coverage. The release checkouts use `fetch-depth: 0` and `fetch-tags: true` so the highest-stable comparison stays resilient.
- `AGENTS.md`: documents that a git worktree's directory name must match its branch name.

Link to the issue: n/a

## Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [x] I have added test cases to cover the new code or have provided the test plan. (if applicable)
- [x] I have added an entry to [CHANGELOG](https://github.com/gogs/gogs/blob/main/CHANGELOG.md). (if applicable)

## Test plan

- [ ] After merge, confirm the next push to `main` publishes `gogs/gogs:edge` to Docker Hub, GHCR, and DigitalOcean, and that the legacy `buildx` job no longer runs.
- [ ] On the next stable release, confirm `:latest`, `:next-latest`, `:MAJOR.MINOR`, and `:next-MAJOR.MINOR` are published alongside the version tags, and that Trivy scans both images.
- [ ] On a prerelease (e.g. `v0.16.0-rc.1`), confirm only `:$VERSION` and `:next-$VERSION` are published.
- [ ] Simulate the back-patch case locally against a tag list of `v0.13.0 v0.13.1 v0.13.2 v0.14.0`: `IMAGE_TAG=0.13.2` should add only `:0.13`; `IMAGE_TAG=0.14.0` should add both `:0.14` and `:latest`.

## Notes for reviewers

- The `deploy-demo` job restarts the `gogs-demo` k8s Deployment after `buildx-next`. If that Deployment pins `gogs/gogs:next-latest`, it will need to be repointed (likely to `:edge`) in the cluster manifest, which lives outside this repo.
- `docker-next/README.md` still tells users to pull `gogs/gogs:next-latest`. That tag is still produced on stable releases, so docs remain accurate. A follow-up doc pass may want to surface `:edge` if `main` builds are user-facing.