### PR TITLE
ci(moon): set default VCS branch to main

### DIFF
--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -3,3 +3,7 @@ $schema: "https://moonrepo.dev/schemas/workspace.json"
 projects:
   gogs: "."
   web: "web"
+
+vcs:
+  manager: "git"
+  defaultBranch: "main"


### PR DESCRIPTION
## Summary

- Moon defaults to `master` when no VCS config is declared, but this repo's default branch is `main`.
- Web lint failed in CI with `fatal: ambiguous argument 'master': unknown revision or path not in the working tree` when moon tried to compute affected files against `master`.
- Declare `vcs.defaultBranch: "main"` in `.moon/workspace.yml` so moon targets the correct branch.

## Test plan

- [ ] CI Web workflow lint step succeeds without the `ambiguous argument 'master'` error.