### PR TITLE
tool: honor configured ANSI charset before detection

### DIFF
--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -36,14 +36,18 @@ func DetectEncoding(content []byte) (string, error) {
 		return "UTF-8", nil
 	}
 
-	result, err := chardet.NewTextDetector().DetectBest(content)
-	if result.Charset != "UTF-8" && len(conf.Repository.ANSICharset) > 0 {
+	if len(conf.Repository.ANSICharset) > 0 {
 		log.Trace("Using default ANSICharset: %s", conf.Repository.ANSICharset)
-		return conf.Repository.ANSICharset, err
+		return conf.Repository.ANSICharset, nil
+	}
+
+	result, err := chardet.NewTextDetector().DetectBest(content)
+	if err != nil {
+		return "", err
 	}
 
 	log.Trace("Detected encoding: %s", result.Charset)
-	return result.Charset, err
+	return result.Charset, nil
 }
 
 // BasicAuthDecode decodes username and password portions of HTTP Basic Authentication

--- a/internal/tool/tool_test.go
+++ b/internal/tool/tool_test.go
@@ -1,0 +1,37 @@
+package tool
+
+import (
+	"testing"
+
+	"gogs.io/gogs/internal/conf"
+)
+
+func TestDetectEncodingUsesANSICharsetForNonUTF8(t *testing.T) {
+	conf.Repository.ANSICharset = "windows-1252"
+	t.Cleanup(func() {
+		conf.Repository.ANSICharset = ""
+	})
+
+	charset, err := DetectEncoding([]byte{0x80})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if charset != "windows-1252" {
+		t.Fatalf("charset: want %q but got %q", "windows-1252", charset)
+	}
+}
+
+func TestDetectEncodingReturnsErrorWhenCharsetNotDetected(t *testing.T) {
+	conf.Repository.ANSICharset = ""
+	t.Cleanup(func() {
+		conf.Repository.ANSICharset = ""
+	})
+
+	charset, err := DetectEncoding([]byte{0x80})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if charset != "" {
+		t.Fatalf("charset: want empty but got %q", charset)
+	}
+}


### PR DESCRIPTION
## Describe the pull request

Refs #2185.

This is a small follow-up for the configured `[repository] ANSI_CHARSET` fallback discussed later in that issue, not a new automatic charset detector.

The original ISO-8859-1 case in #2185 was already investigated years ago: `golang.org/x/net/html/charset` handled the sample better, but that approach later caused problems for GBK/Chinese content and was rolled back. The practical workaround became the `ANSI_CHARSET` setting.

This PR makes that setting deterministic for any non-UTF-8 content by using it before asking `chardet` to guess. It also avoids dereferencing a nil detection result when `chardet` cannot identify a charset.

IssueHunt: https://issuehunt.io/repos/16752620/issues/2185

## Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [x] I have added test cases to cover the new code or have provided the test plan. (if applicable)
- [ ] I have added an entry to [CHANGELOG](https://github.com/gogs/gogs/blob/main/CHANGELOG.md). (if applicable)

## Test plan

- `go test ./internal/tool -count=1`
- `go test ./internal/tool ./internal/template ./internal/gitx -count=1`
- `git diff --check`
