### PR TITLE
feat: add /api/web/user/sign-out and nest user info under /user/info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,14 @@ All notable changes to Gogs are documented in this file.
 
 ## 0.15.0+dev (`main`)
 
+### Added
+
+- `POST /api/web/user/sign-out` endpoint that destroys the current session and clears the username, remember-me, and CSRF cookies.
+
 ### Changed
 
 - Docker builds from `main` are now published only as `gogs/gogs:edge`, using the next-generation `Dockerfile.next`. The legacy `Dockerfile` no longer produces `main` builds. The `gogs/gogs:latest` and `gogs/gogs:next-latest` tags now always point to the highest published stable release, never to a back-patch on an older line. [#8278](https://github.com/gogs/gogs/pull/8278)
+- Renamed `GET /api/web/user-info` to `GET /api/web/user/info`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,9 @@ All notable changes to Gogs are documented in this file.
 
 ## 0.15.0+dev (`main`)
 
-### Added
-
-- `POST /api/web/user/sign-out` endpoint that destroys the current session and clears the username, remember-me, and CSRF cookies. [#8284](https://github.com/gogs/gogs/pull/8284)
-
 ### Changed
 
 - Docker builds from `main` are now published only as `gogs/gogs:edge`, using the next-generation `Dockerfile.next`. The legacy `Dockerfile` no longer produces `main` builds. The `gogs/gogs:latest` and `gogs/gogs:next-latest` tags now always point to the highest published stable release, never to a back-patch on an older line. [#8278](https://github.com/gogs/gogs/pull/8278)
-- Renamed `GET /api/web/user-info` to `GET /api/web/user/info`. [#8284](https://github.com/gogs/gogs/pull/8284)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,12 @@ All notable changes to Gogs are documented in this file.
 
 ### Added
 
-- `POST /api/web/user/sign-out` endpoint that destroys the current session and clears the username, remember-me, and CSRF cookies.
+- `POST /api/web/user/sign-out` endpoint that destroys the current session and clears the username, remember-me, and CSRF cookies. [#8284](https://github.com/gogs/gogs/pull/8284)
 
 ### Changed
 
 - Docker builds from `main` are now published only as `gogs/gogs:edge`, using the next-generation `Dockerfile.next`. The legacy `Dockerfile` no longer produces `main` builds. The `gogs/gogs:latest` and `gogs/gogs:next-latest` tags now always point to the highest published stable release, never to a back-patch on an older line. [#8278](https://github.com/gogs/gogs/pull/8278)
-- Renamed `GET /api/web/user-info` to `GET /api/web/user/info`.
+- Renamed `GET /api/web/user-info` to `GET /api/web/user/info`. [#8284](https://github.com/gogs/gogs/pull/8284)
 
 ### Fixed
 

--- a/cmd/gogs/internal/web/api.go
+++ b/cmd/gogs/internal/web/api.go
@@ -35,9 +35,7 @@ func webAPIInjector(c flamego.Context) {
 	user, _ := ctx.Value(webAPIUserKey{}).(*database.User)
 	sess, _ := ctx.Value(webAPISessionKey{}).(session.Store)
 	mc, _ := ctx.Value(webAPIMacaronKey{}).(*macaron.Context)
-	c.Map(user)
-	c.Map(sess)
-	c.Map(mc)
+	c.Map(user, sess, mc)
 }
 
 func mountWebAPIRoutes(f *flamego.Flame) {

--- a/cmd/gogs/internal/web/api.go
+++ b/cmd/gogs/internal/web/api.go
@@ -31,13 +31,11 @@ func bridgeToWebAPI(webHandler http.Handler) func(c *context.Context) {
 }
 
 func webAPIInjector(c flamego.Context) {
-	user, _ := c.Request().Context().Value(webAPIUserKey{}).(*database.User)
+	ctx := c.Request().Context()
+	user, _ := ctx.Value(webAPIUserKey{}).(*database.User)
+	sess, _ := ctx.Value(webAPISessionKey{}).(session.Store)
+	mc, _ := ctx.Value(webAPIMacaronKey{}).(*macaron.Context)
 	c.Map(user)
-}
-
-func sessionInjector(c flamego.Context) {
-	sess, _ := c.Request().Context().Value(webAPISessionKey{}).(session.Store)
-	mc, _ := c.Request().Context().Value(webAPIMacaronKey{}).(*macaron.Context)
 	c.Map(sess)
 	c.Map(mc)
 }
@@ -63,10 +61,10 @@ func mountWebAPIRoutes(f *flamego.Flame) {
 
 	f.Group("/api/web", func() {
 		f.Group("/user", func() {
-			f.Get("/info", webAPIInjector, userInfoHandler)
-			f.Post("/sign-out", sessionInjector, userSignOutHandler)
+			f.Get("/info", userInfoHandler)
+			f.Post("/sign-out", userSignOutHandler)
 		})
-	})
+	}, webAPIInjector)
 }
 
 type userInfo struct {

--- a/cmd/gogs/internal/web/api.go
+++ b/cmd/gogs/internal/web/api.go
@@ -6,23 +6,40 @@ import (
 	"net/http"
 
 	"github.com/flamego/flamego"
+	"github.com/go-macaron/session"
+	"gopkg.in/macaron.v1"
 
+	"gogs.io/gogs/internal/conf"
 	"gogs.io/gogs/internal/context"
 	"gogs.io/gogs/internal/database"
 )
 
-type webAPIBridgeKey struct{}
+type (
+	webAPIUserKey    struct{}
+	webAPISessionKey struct{}
+	webAPIMacaronKey struct{}
+)
 
 func bridgeToWebAPI(webHandler http.Handler) func(c *context.Context) {
 	return func(c *context.Context) {
-		ctx := stdctx.WithValue(c.Req.Context(), webAPIBridgeKey{}, c.User)
+		ctx := c.Req.Context()
+		ctx = stdctx.WithValue(ctx, webAPIUserKey{}, c.User)
+		ctx = stdctx.WithValue(ctx, webAPISessionKey{}, c.Session)
+		ctx = stdctx.WithValue(ctx, webAPIMacaronKey{}, c.Context)
 		webHandler.ServeHTTP(c.Resp, c.Req.WithContext(ctx))
 	}
 }
 
 func webAPIInjector(c flamego.Context) {
-	user, _ := c.Request().Context().Value(webAPIBridgeKey{}).(*database.User)
+	user, _ := c.Request().Context().Value(webAPIUserKey{}).(*database.User)
 	c.Map(user)
+}
+
+func sessionInjector(c flamego.Context) {
+	sess, _ := c.Request().Context().Value(webAPISessionKey{}).(session.Store)
+	mc, _ := c.Request().Context().Value(webAPIMacaronKey{}).(*macaron.Context)
+	c.Map(sess)
+	c.Map(mc)
 }
 
 func mountWebAPIRoutes(f *flamego.Flame) {
@@ -45,8 +62,11 @@ func mountWebAPIRoutes(f *flamego.Flame) {
 	})
 
 	f.Group("/api/web", func() {
-		f.Get("/user-info", userInfoHandler)
-	}, webAPIInjector)
+		f.Group("/user", func() {
+			f.Get("/info", webAPIInjector, userInfoHandler)
+			f.Post("/sign-out", sessionInjector, userSignOutHandler)
+		})
+	})
 }
 
 type userInfo struct {
@@ -68,4 +88,13 @@ func userInfoHandler(user *database.User) (statusCode int, resp *userInfo, err e
 			CanCreateOrganization: user.CanCreateOrganization(),
 		},
 		nil
+}
+
+func userSignOutHandler(sess session.Store, mc *macaron.Context) (statusCode int, resp any, err error) {
+	_ = sess.Flush()
+	_ = sess.Destory(mc)
+	mc.SetCookie(conf.Security.CookieUsername, "", -1, conf.Server.Subpath)
+	mc.SetCookie(conf.Security.CookieRememberName, "", -1, conf.Server.Subpath)
+	mc.SetCookie(conf.Session.CSRFCookieName, "", -1, conf.Server.Subpath)
+	return http.StatusNoContent, nil, nil
 }

--- a/web/src/components/Navbar.tsx
+++ b/web/src/components/Navbar.tsx
@@ -305,10 +305,30 @@ function NavLink({ href, external, children }: { href: string; external?: boolea
 
 function SignOutForm({ children }: { children: React.ReactNode }) {
   return (
-    <form action={subUrl("/user/logout")} method="POST" className="inline">
+    <form
+      action={subUrl("/api/web/user/sign-out")}
+      method="POST"
+      className="inline"
+      onSubmit={(event) => {
+        event.preventDefault();
+        void signOut();
+      }}
+    >
       {children}
     </form>
   );
+}
+
+async function signOut() {
+  try {
+    await fetch(subUrl("/api/web/user/sign-out"), {
+      method: "POST",
+      credentials: "same-origin",
+    });
+  } catch (err) {
+    console.error("signOut: request failed", err);
+  }
+  window.location.assign(subUrl("/"));
 }
 
 function MobileLink({

--- a/web/src/lib/user-info.ts
+++ b/web/src/lib/user-info.ts
@@ -9,7 +9,7 @@ export interface UserInfo {
 
 export async function fetchUserInfo(): Promise<UserInfo | null> {
   try {
-    const res = await fetch(subUrl("/api/web/user-info"), { credentials: "same-origin" });
+    const res = await fetch(subUrl("/api/web/user/info"), { credentials: "same-origin" });
     if (res.status === 204) return null;
     if (!res.ok) {
       console.error(`fetchUserInfo: unexpected status ${res.status}`);


### PR DESCRIPTION
## Summary

- Add `POST /api/web/user/sign-out` that destroys the macaron session and clears the username, remember-me, and CSRF cookies, returning 204.
- Rename `GET /api/web/user-info` to `GET /api/web/user/info` to group user-scoped endpoints under `/api/web/user/*`.
- Bridge the macaron `session.Store` and `*macaron.Context` into the flamego web API via per-route injectors so the new sign-out handler can clear session state without leaving macaron land.
- Point the React `SignOutForm` at the new endpoint via `fetch`, then redirect to `/`.

## Test plan

- [ ] `moon run gogs:lint` and `moon run gogs:build` pass.
- [ ] `moon run web:lint` passes.
- [ ] Manually sign in, hit the sign-out button in the Navbar, verify the session cookie and username/remember-me cookies are cleared and the page lands on `/` as a signed-out user.
- [ ] `curl -i $URL/api/web/user/info` while signed in returns 200 with user JSON; signed out returns 204.
- [ ] `curl -i -X POST $URL/api/web/user/sign-out` while signed in returns 204 and subsequent requests are signed out.