### PR TITLE
Update README banner for dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-![gogs-brand](https://user-images.githubusercontent.com/2946214/146899259-6a8b58ad-8d6e-40d2-ab02-79dc6aadabbf.png)
+![Gogs](docs/images/logo-light.svg#gh-light-mode-only)
+![Gogs](docs/images/logo-dark.svg#gh-dark-mode-only)
 
 [![GitHub Workflow Status](https://img.shields.io/github/checks-status/gogs/gogs/main?logo=github&style=for-the-badge)](https://github.com/gogs/gogs/actions?query=branch%3Amain) [![Sourcegraph](https://img.shields.io/badge/view%20on-Sourcegraph-brightgreen.svg?style=for-the-badge&logo=sourcegraph)](https://sourcegraph.com/github.com/gogs/gogs)
 


### PR DESCRIPTION
## Summary
- replace the remote PNG README banner with local SVG logo assets
- use GitHub light and dark mode image fragments for automatic theme switching

## Testing
- Not run, documentation-only change.