### PR TITLE
web: migrate /robots.txt to Flamego handler

### DIFF
--- a/cmd/gogs/internal/web/web.go
+++ b/cmd/gogs/internal/web/web.go
@@ -710,20 +710,20 @@ func newRoutingHandler() (http.Handler, error) {
 	return f, nil
 }
 
-func getRobotsTxt(c flamego.Context) {
-	if !conf.HasRobotsTxt {
-		c.ResponseWriter().WriteHeader(http.StatusNotFound)
-		return
-	}
-	http.ServeFile(c.ResponseWriter(), c.Request().Request, filepath.Join(conf.CustomDir(), "robots.txt"))
-}
-
 func getRedirect(c flamego.Context) {
 	to := c.Request().URL.Query().Get("to")
 	if !urlx.IsSameSite(to) {
 		to = conf.Server.Subpath + "/"
 	}
 	c.Redirect(to, http.StatusSeeOther)
+}
+
+func getRobotsTxt(w http.ResponseWriter, r *http.Request) {
+	if !conf.HasRobotsTxt {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	http.ServeFile(w, r, filepath.Join(conf.CustomDir(), "robots.txt"))
 }
 
 // newMacaron initializes Macaron instance.

--- a/cmd/gogs/internal/web/web.go
+++ b/cmd/gogs/internal/web/web.go
@@ -575,18 +575,6 @@ func Run(configPath string, portOverride int) error {
 		})
 	})
 
-	// **********************
-	// ----- robots.txt -----
-	// **********************
-
-	m.Get("/robots.txt", func(w http.ResponseWriter, r *http.Request) {
-		if conf.HasRobotsTxt {
-			http.ServeFile(w, r, filepath.Join(conf.CustomDir(), "robots.txt"))
-		} else {
-			w.WriteHeader(http.StatusNotFound)
-		}
-	})
-
 	// Flag for port number in case first time run conflict.
 	if portOverride > 0 {
 		port := strconv.Itoa(portOverride)
@@ -704,6 +692,7 @@ func newRoutingHandler() (http.Handler, error) {
 	})
 
 	f.Get("/redirect", getRedirect)
+	f.Get("/robots.txt", getRobotsTxt)
 
 	// The captcha middleware writes the response. This route exists so the request reaches it.
 	f.Get("/captcha/image.jpeg", func() {})
@@ -719,6 +708,15 @@ func newRoutingHandler() (http.Handler, error) {
 		return nil, errors.Wrap(err, "mount web app routes")
 	}
 	return f, nil
+}
+
+func getRobotsTxt(c flamego.Context) {
+	w := c.ResponseWriter()
+	if !conf.HasRobotsTxt {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	http.ServeFile(w, c.Request().Request, filepath.Join(conf.CustomDir(), "robots.txt"))
 }
 
 func getRedirect(c flamego.Context) {

--- a/cmd/gogs/internal/web/web.go
+++ b/cmd/gogs/internal/web/web.go
@@ -711,12 +711,11 @@ func newRoutingHandler() (http.Handler, error) {
 }
 
 func getRobotsTxt(c flamego.Context) {
-	w := c.ResponseWriter()
 	if !conf.HasRobotsTxt {
-		w.WriteHeader(http.StatusNotFound)
+		c.ResponseWriter().WriteHeader(http.StatusNotFound)
 		return
 	}
-	http.ServeFile(w, c.Request().Request, filepath.Join(conf.CustomDir(), "robots.txt"))
+	http.ServeFile(c.ResponseWriter(), c.Request().Request, filepath.Join(conf.CustomDir(), "robots.txt"))
 }
 
 func getRedirect(c flamego.Context) {


### PR DESCRIPTION
## What

Migrates the `/robots.txt` route from the inline Macaron handler to a Flamego handler.

- Adds `getRobotsTxt` (Flamego handler) holding the existing logic: 404 when there is no `custom/robots.txt`, otherwise `http.ServeFile` from `conf.CustomDir()`.
- Registers `f.Get("/robots.txt", getRobotsTxt)` in `newRoutingHandler`.
- Removes the dedicated Macaron route. Requests now fall through `m.Any("/*", c.ServeWeb())`, which forwards into the same Flamego handler, where the router matches `/robots.txt`.

## Behavior note

Because the route is reached through the catch-all rather than a standalone Macaron route, the request now passes through the session and CSRF middleware. The response therefore carries `Set-Cookie` headers it did not before. The served body and status codes are unchanged.

## Testing

Verified against a server started via `moon run gogs:dev`:

- No `custom/robots.txt` -> `404`.
- `custom/robots.txt` present -> `200`, `Content-Type: text/plain; charset=utf-8`, exact file contents.

`moon run gogs:lint` is clean and the build passes.