### PR TITLE
security: fix argument injection in pull request merge (rebase)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to Gogs are documented in this file.
 - _Security:_ SSRF via mirror address update bypassing clone address validation. [#8225](https://github.com/gogs/gogs/pull/8225) - [GHSA-wv27-2vqp-j7g5](https://github.com/gogs/gogs/security/advisories/GHSA-wv27-2vqp-j7g5)
 - _Security:_ Open redirect on login and other post-action flows via the `redirect_to` query parameter. [#8322](https://github.com/gogs/gogs/pull/8322) - [GHSA-xxhq-69mf-w8cr](https://github.com/gogs/gogs/security/advisories/GHSA-xxhq-69mf-w8cr)
 - _Security:_ Privilege escalation to repository owner via collaboration access mode update. [#8227](https://github.com/gogs/gogs/pull/8227) - [GHSA-4565-r4x7-hg8j](https://github.com/gogs/gogs/security/advisories/GHSA-4565-r4x7-hg8j)
+- _Security:_ Remote command execution via pull request rebase merges with crafted branch names. [#8301](https://github.com/gogs/gogs/pull/8301) - [GHSA-qf6p-p7ww-cwr9](https://github.com/gogs/gogs/security/advisories/GHSA-qf6p-p7ww-cwr9)
 - _Security:_ SSRF in repository migration and recurring mirror sync via HTTP redirects and stale host validation on stored mirror URLs. [#8324](https://github.com/gogs/gogs/pull/8324) - [GHSA-g2f5-gjr4-qjvm](https://github.com/gogs/gogs/security/advisories/GHSA-g2f5-gjr4-qjvm)
 
 ### Removed

--- a/internal/database/mirror.go
+++ b/internal/database/mirror.go
@@ -226,11 +226,13 @@ func mirrorGitArgs() []string {
 	return []string{"-c", "http.followRedirects=false"}
 }
 
-// mirrorGitEnv returns environment variables that keep git non-interactive
-// during mirror operations. Without these, a network failure or a missing
-// remote endpoint can make git ask for credentials and stall the server-side
-// process waiting on a terminal that never responds.
+// mirrorGitEnv returns the git-level environment variables used by every remote network
+// operation against a mirror source.
 func mirrorGitEnv() []string {
+	// Keep git non-interactive during mirror operations. Without these, a
+	// network failure or a missing remote endpoint can make git ask for
+	// credentials and stall the server-side process waiting on a terminal that
+	// never responds.
 	return []string{
 		"GIT_TERMINAL_PROMPT=0",
 		"GIT_ASKPASS=/bin/true",

--- a/internal/database/pull.go
+++ b/internal/database/pull.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -194,6 +195,15 @@ const (
 func (pr *PullRequest) Merge(doer *User, baseGitRepo *git.Repository, mergeStyle MergeStyle, commitDescription string) (err error) {
 	ctx := context.TODO()
 
+	// Reject branch names that start with a hyphen to prevent argument injection
+	// into git commands (e.g. --exec=<cmd> being passed to git rebase).
+	if strings.HasPrefix(pr.BaseBranch, "-") {
+		return errors.Newf("invalid base branch name: %q", pr.BaseBranch)
+	}
+	if strings.HasPrefix(pr.HeadBranch, "-") {
+		return errors.Newf("invalid head branch name: %q", pr.HeadBranch)
+	}
+
 	defer func() {
 		go HookQueue.Add(pr.BaseRepo.ID)
 		go AddTestPullRequestTask(doer, pr.BaseRepo.ID, pr.BaseBranch, false)
@@ -279,7 +289,7 @@ func (pr *PullRequest) Merge(doer *User, baseGitRepo *git.Repository, mergeStyle
 		// Rebase head branch based on base branch, this creates a non-branch commit state.
 		if _, stderr, err = process.ExecDir(-1, tmpBasePath,
 			fmt.Sprintf("PullRequest.Merge (git rebase): %s", tmpBasePath),
-			"git", "rebase", "--quiet", pr.BaseBranch, remoteHeadBranch); err != nil {
+			"git", "rebase", "--quiet", "--end-of-options", pr.BaseBranch, remoteHeadBranch); err != nil {
 			return errors.Newf("git rebase [%s on %s]: %s", remoteHeadBranch, pr.BaseBranch, stderr)
 		}
 

--- a/internal/database/pull.go
+++ b/internal/database/pull.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -195,15 +194,6 @@ const (
 func (pr *PullRequest) Merge(doer *User, baseGitRepo *git.Repository, mergeStyle MergeStyle, commitDescription string) (err error) {
 	ctx := context.TODO()
 
-	// Reject branch names that start with a hyphen to prevent argument injection
-	// into git commands (e.g. --exec=<cmd> being passed to git rebase).
-	if strings.HasPrefix(pr.BaseBranch, "-") {
-		return errors.Newf("invalid base branch name: %q", pr.BaseBranch)
-	}
-	if strings.HasPrefix(pr.HeadBranch, "-") {
-		return errors.Newf("invalid head branch name: %q", pr.HeadBranch)
-	}
-
 	defer func() {
 		go HookQueue.Add(pr.BaseRepo.ID)
 		go AddTestPullRequestTask(doer, pr.BaseRepo.ID, pr.BaseBranch, false)
@@ -238,10 +228,11 @@ func (pr *PullRequest) Merge(doer *User, baseGitRepo *git.Repository, mergeStyle
 	// Clone the base repository to the defined temporary directory,
 	// and checks out to base branch directly.
 	var stderr string
-	if _, stderr, err = process.ExecTimeout(5*time.Minute,
-		fmt.Sprintf("PullRequest.Merge (git clone): %s", tmpBasePath),
-		"git", "clone", "-b", pr.BaseBranch, baseGitRepo.Path(), tmpBasePath); err != nil {
-		return errors.Newf("git clone: %s", stderr)
+	if err = git.Clone(baseGitRepo.Path(), tmpBasePath, git.CloneOptions{
+		Branch:  pr.BaseBranch,
+		Timeout: 5 * time.Minute,
+	}); err != nil {
+		return errors.Newf("git clone: %v", err)
 	}
 
 	// Add remote which points to the head repository.
@@ -271,7 +262,7 @@ func (pr *PullRequest) Merge(doer *User, baseGitRepo *git.Repository, mergeStyle
 		// Merge changes from head branch.
 		if _, stderr, err = process.ExecDir(-1, tmpBasePath,
 			fmt.Sprintf("PullRequest.Merge (git merge --no-ff --no-commit): %s", tmpBasePath),
-			"git", "merge", "--no-ff", "--no-commit", remoteHeadBranch); err != nil {
+			"git", "merge", "--no-ff", "--no-commit", "--end-of-options", remoteHeadBranch); err != nil {
 			return errors.Newf("git merge --no-ff --no-commit [%s]: %v - %s", tmpBasePath, err, stderr)
 		}
 
@@ -304,14 +295,14 @@ func (pr *PullRequest) Merge(doer *User, baseGitRepo *git.Repository, mergeStyle
 		// Check out the base branch to be operated on.
 		if _, stderr, err = process.ExecDir(-1, tmpBasePath,
 			fmt.Sprintf("PullRequest.Merge (git checkout): %s", tmpBasePath),
-			"git", "checkout", pr.BaseBranch); err != nil {
+			"git", "checkout", "--end-of-options", pr.BaseBranch); err != nil {
 			return errors.Newf("git checkout '%s': %s", pr.BaseBranch, stderr)
 		}
 
 		// Merge changes from temporary branch to the base branch.
 		if _, stderr, err = process.ExecDir(-1, tmpBasePath,
 			fmt.Sprintf("PullRequest.Merge (git merge): %s", tmpBasePath),
-			"git", "merge", tmpBranch); err != nil {
+			"git", "merge", "--end-of-options", tmpBranch); err != nil {
 			return errors.Newf("git merge [%s]: %v - %s", tmpBasePath, err, stderr)
 		}
 
@@ -320,10 +311,8 @@ func (pr *PullRequest) Merge(doer *User, baseGitRepo *git.Repository, mergeStyle
 	}
 
 	// Push changes on base branch to upstream.
-	if _, stderr, err = process.ExecDir(-1, tmpBasePath,
-		fmt.Sprintf("PullRequest.Merge (git push): %s", tmpBasePath),
-		"git", "push", baseGitRepo.Path(), pr.BaseBranch); err != nil {
-		return errors.Newf("git push: %s", stderr)
+	if err = git.Push(tmpBasePath, baseGitRepo.Path(), pr.BaseBranch); err != nil {
+		return errors.Newf("git push: %v", err)
 	}
 
 	pr.MergedCommitID, err = headGitRepo.BranchCommitID(pr.HeadBranch)


### PR DESCRIPTION
Branch names starting with `--` (e.g. `--exec=<cmd>`) are passed unsanitized to `git rebase` in `Merge()`, allowing argument injection. Since `git rebase --exec` runs commands via `sh -c`, this is an RCE for any user who can create a pull request with rebase merging enabled.

This patch rejects branch names starting with `-` at the top of `Merge()`, and adds `--end-of-options` to the `git rebase` invocation as defense-in-depth (consistent with how git-module v1.8.7 already handles Clone, Push, Fetch, etc).

Ref: [GHSA-qf6p-p7ww-cwr9](https://github.com/gogs/gogs/security/advisories/GHSA-qf6p-p7ww-cwr9)