### PR TITLE
web: disable Geist Mono ligatures on code surfaces

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -20,6 +20,23 @@
 
 @custom-variant dark (&:where(.dark, .dark *));
 
+/* Geist Mono carries a standard ligature set (liga, on by default) that
+   substitutes single glyphs for programming symbol sequences. In a code or diff
+   viewer this alters how the literal source bytes look. Turn ligatures off on
+   every mono surface so code-shaped content renders character-for-character.
+   font-variant-ligatures inherits, so listing diffs-container here also reaches
+   the @pierre/diffs shadow root, which never sets the property itself. */
+@layer base {
+  .font-mono,
+  code,
+  pre,
+  kbd,
+  samp,
+  diffs-container {
+    font-variant-ligatures: none;
+  }
+}
+
 @theme {
   --color-background: initial;
   --color-foreground: initial;
@@ -179,6 +196,11 @@
 diffs-container {
   --diffs-font-family: var(--font-mono);
   --diffs-header-font-family: var(--font-sans);
+  /* The inherited font-variant-ligatures: none above already disables ligatures
+     inside the shadow root. Pin the library's own --diffs-font-features off too,
+     so the diff stays ligature-free through @pierre/diffs' sanctioned knob and
+     not just the inherited property. */
+  --diffs-font-features: "liga" 0;
   --diffs-light-bg: var(--color-background);
   --diffs-dark-bg: var(--color-background);
   --diffs-tab-size: 4;


### PR DESCRIPTION
## Problem

Geist Mono Variable carries a standard ligature set (`liga`, on by default) that substitutes single glyphs for programming symbol sequences. In the diff and code viewers this alters how the literal source bytes look, which produced an unexpected glyph in a `.gitignore` comment line. Ligatures don't belong in a code viewer where character-for-character fidelity matters.

(The font has no `calt`/contextual-alternates feature, only `liga`, verified against the shipped `geist-mono-latin-wght-normal.woff2`.)

## Change

- Add a base-layer rule setting `font-variant-ligatures: none` on every mono surface (`.font-mono`, `code`, `pre`, `kbd`, `samp`, `diffs-container`). This disables `liga` regardless of `font-feature-settings`.
- Because `font-variant-ligatures` inherits, listing `diffs-container` reaches the `@pierre/diffs` shadow root, which never sets the property itself.
- Also pin the library's own `--diffs-font-features` off as defense-in-depth, using its sanctioned variable rather than relying solely on the inherited property.

## Test plan

- `moon run web:lint` passes.
- Confirmed the offending glyph no longer renders in the diff viewer with the change applied.