### PR TITLE
fix: detect SSL certificate errors during migration

### DIFF
--- a/internal/database/repo.go
+++ b/internal/database/repo.go
@@ -797,6 +797,15 @@ func wikiRemoteURL(remote string) string {
 	return ""
 }
 
+// isCertificateError reports whether the error is caused by an SSL/TLS certificate issue.
+func isCertificateError(err error) bool {
+	s := err.Error()
+	return strings.Contains(s, "certificate") ||
+		strings.Contains(s, "SSL") ||
+		strings.Contains(s, "x509") ||
+		strings.Contains(s, "server certificate")
+}
+
 // MigrateRepository migrates a existing repository from other project hosting.
 func MigrateRepository(doer, owner *User, opts MigrateRepoOptions) (*Repository, error) {
 	repo, err := CreateRepository(doer, owner, CreateRepoOptionsLegacy{
@@ -831,6 +840,9 @@ func MigrateRepository(doer, owner *User, opts MigrateRepoOptions) (*Repository,
 		Quiet:   true,
 		Timeout: migrateTimeout,
 	}); err != nil {
+		if isCertificateError(err) {
+			return repo, errors.New("Migration failed due to an SSL certificate error. Please contact your site admin to configure git sslVerify or install the required certificate.")
+		}
 		return repo, errors.Newf("clone: %v", err)
 	}
 


### PR DESCRIPTION
Fixes #2089

### Problem
When migrating a repository from a server with a self-signed or untrusted SSL certificate, git clone fails with a generic error message that doesn't help the user understand what went wrong.

### Solution
Added SSL/TLS certificate error detection in the migration flow. When a certificate error is detected, the user gets a clear message suggesting they contact the site admin to configure git sslVerify or install the required certificate.

This follows the approach suggested by @unknwon in the issue: detect the certificate error and inform the user via UI.

### Changes
- Added  helper that checks for common SSL/TLS error patterns (certificate, SSL, x509, server certificate)
- Modified  to return a user-friendly error message when a certificate issue is detected

---
IssueHunt bounty: $20.00