### PR TITLE
fix(template): allow title attribute on span in sanitizer policy

### DIFF
--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -33,6 +33,14 @@ var (
 	funcMapOnce sync.Once
 )
 
+// newSanitizePolicy extends the UGC policy to allow the title attribute on
+// span elements, which TimeSince uses for date tooltips.
+func newSanitizePolicy() *bluemonday.Policy {
+	p := bluemonday.UGCPolicy()
+	p.AllowAttrs("title").OnElements("span")
+	return p
+}
+
 // FuncMap returns a list of user-defined template functions.
 func FuncMap() []template.FuncMap {
 	funcMapOnce.Do(func() {
@@ -73,7 +81,7 @@ func FuncMap() []template.FuncMap {
 			"AvatarLink":       tool.AvatarLink,
 			"AppendAvatarSize": tool.AppendAvatarSize,
 			"Safe":             Safe,
-			"Sanitize":         bluemonday.UGCPolicy().Sanitize,
+			"Sanitize":         newSanitizePolicy().Sanitize,
 			"Str2HTML":         Str2HTML,
 			"NewLine2br":       NewLine2br,
 			"TimeSince":        tool.TimeSince,


### PR DESCRIPTION
Fixes #8277

### Problem

The `TimeSince` function generates `<span class="time-since" title="...">` elements to display date tooltips on hover. However, the template sanitizer uses `bluemonday.UGCPolicy()` which strips the `title` attribute from `span` elements. This causes the tooltip to silently disappear in issue views where the output passes through the `Sanitize` template function.

### Solution

Create a custom sanitizer policy that extends `UGCPolicy` with `AllowAttrs("title").OnElements("span")`. This preserves the date tooltip while keeping all other sanitization rules intact.

The `title` attribute on `span` is safe. It carries only the formatted timestamp that `TimeSince` already generates from trusted internal data, not from user input.
