### PR TITLE
web: align components with React 19 and fix accessibility findings

### DIFF
--- a/web/src/components/DiffFileTree.tsx
+++ b/web/src/components/DiffFileTree.tsx
@@ -11,7 +11,7 @@ import { FileTree, useFileTree, useFileTreeSearch } from "@pierre/trees/react";
 import {
   type CSSProperties,
   type ReactNode,
-  forwardRef,
+  type Ref,
   useCallback,
   useEffect,
   useImperativeHandle,
@@ -31,6 +31,7 @@ interface Props {
   header?: ReactNode;
   className?: string;
   style?: CSSProperties;
+  ref?: Ref<DiffFileTreeHandle>;
 }
 
 // Pierre's FileTree renders into a shadow root. We can inject CSS via the
@@ -122,10 +123,7 @@ function collectDirectoryPaths(paths: readonly string[]): string[] {
   return Array.from(dirs);
 }
 
-export const DiffFileTree = forwardRef<DiffFileTreeHandle, Props>(function DiffFileTreeImpl(
-  { items, onSelectItem, searchOpen = true, header, className, style },
-  ref,
-) {
+export function DiffFileTree({ items, onSelectItem, searchOpen = true, header, className, style, ref }: Props) {
   const { paths, gitStatus, pathToItemId } = useMemo(() => {
     const collectedPaths: string[] = [];
     const status: GitStatusEntry[] = [];
@@ -303,4 +301,4 @@ export const DiffFileTree = forwardRef<DiffFileTreeHandle, Props>(function DiffF
       />
     </div>
   );
-});
+}

--- a/web/src/components/DiffSearch.tsx
+++ b/web/src/components/DiffSearch.tsx
@@ -153,10 +153,7 @@ export function DiffSearch<L>({ items, viewRef }: Props<L>) {
   }, []);
 
   return (
-    <div
-      role="search"
-      className="flex h-7 items-center gap-1 rounded-md border border-(--color-border) bg-(--color-background) px-1 focus-within:border-(--color-ring) focus-within:ring-2 focus-within:ring-(--color-ring)/30"
-    >
+    <search className="flex h-7 items-center gap-1 rounded-md border border-(--color-border) bg-(--color-background) px-1 focus-within:border-(--color-ring) focus-within:ring-2 focus-within:ring-(--color-ring)/30">
       <Search className="ml-1 size-3.5 text-(--color-muted-foreground)" aria-hidden />
       <input
         ref={inputRef}
@@ -199,6 +196,6 @@ export function DiffSearch<L>({ items, viewRef }: Props<L>) {
       >
         <ChevronDown className="size-3.5" aria-hidden />
       </button>
-    </div>
+    </search>
   );
 }

--- a/web/src/components/DiffToolbar.tsx
+++ b/web/src/components/DiffToolbar.tsx
@@ -7,7 +7,7 @@ import {
   PanelLeftOpen,
   SlidersHorizontal,
 } from "lucide-react";
-import { type ReactNode, forwardRef } from "react";
+import { type ReactNode, type Ref } from "react";
 import { Trans, useTranslation } from "react-i18next";
 
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -195,13 +195,17 @@ export function DiffToolbar({
   );
 }
 
-const ToolbarButton = forwardRef<
-  HTMLButtonElement,
-  {
-    icon: typeof SlidersHorizontal;
-    label: string;
-  } & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "type">
->(function ToolbarButton({ icon: Icon, label, className, ...rest }, ref) {
+function ToolbarButton({
+  icon: Icon,
+  label,
+  className,
+  ref,
+  ...rest
+}: {
+  icon: typeof SlidersHorizontal;
+  label: string;
+  ref?: Ref<HTMLButtonElement>;
+} & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "type">) {
   return (
     <button
       ref={ref}
@@ -217,7 +221,7 @@ const ToolbarButton = forwardRef<
       <ChevronDown className="size-3 text-(--color-muted-foreground)" aria-hidden />
     </button>
   );
-});
+}
 
 function SegmentButton({ active, onClick, children }: { active: boolean; onClick: () => void; children: ReactNode }) {
   return (

--- a/web/src/components/FileHeaderMenu.tsx
+++ b/web/src/components/FileHeaderMenu.tsx
@@ -1,5 +1,5 @@
 import { Binary, FileCode2, History, Loader2, MoreHorizontal, Pencil, Trash2, UnfoldVertical } from "lucide-react";
-import { type ButtonHTMLAttributes, forwardRef, useState } from "react";
+import { type ButtonHTMLAttributes, type Ref, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -73,7 +73,11 @@ export function FileHeaderMenu({
               </button>
             </li>
           ) : null}
-          {onExpandAllLines ? <li role="separator" className="my-1 h-px bg-(--color-border) lg:hidden" /> : null}
+          {onExpandAllLines ? (
+            <li role="presentation" className="lg:hidden">
+              <hr className="my-1 border-t border-(--color-border)" />
+            </li>
+          ) : null}
           <li>
             <a href={viewFileHref} className="flex items-center gap-2 rounded px-2 py-1.5 hover:bg-(--color-surface)">
               <FileCode2 className="size-3.5 shrink-0" aria-hidden />
@@ -92,7 +96,11 @@ export function FileHeaderMenu({
               <span>{t("repo.view_history")}</span>
             </a>
           </li>
-          {editFileHref || deleteFileHref ? <li role="separator" className="my-1 h-px bg-(--color-border)" /> : null}
+          {editFileHref || deleteFileHref ? (
+            <li role="presentation">
+              <hr className="my-1 border-t border-(--color-border)" />
+            </li>
+          ) : null}
           {editFileHref ? (
             <li>
               <a href={editFileHref} className="flex items-center gap-2 rounded px-2 py-1.5 hover:bg-(--color-surface)">
@@ -114,7 +122,9 @@ export function FileHeaderMenu({
           ) : null}
           {prevFilePath ? (
             <>
-              <li role="separator" className="my-1 h-px bg-(--color-border)" />
+              <li role="presentation">
+                <hr className="my-1 border-t border-(--color-border)" />
+              </li>
               <li className="px-2 py-1.5 text-xs text-(--color-muted-foreground)">
                 {t("repo.renamed_from")} <span className="font-mono">{prevFilePath}</span>
               </li>
@@ -127,18 +137,22 @@ export function FileHeaderMenu({
 }
 
 // Pierre's `renderHeaderMetadata` callback returns the node into a slot inside
-// its rendered header. Radix's `asChild` requires a forwardRef so the popover
-// can attach its trigger refs and ARIA wiring.
+// its rendered header. Radix's `asChild` needs the trigger to accept a ref so
+// the popover can attach its trigger refs and ARIA wiring; on React 19 that is
+// a regular `ref` prop.
 // Pierre's `<diffs-container>` attaches gesture handlers higher up the tree
 // that interpret clicks anywhere inside the file header. Without stopping
 // propagation, clicking the kebab triggers Pierre's header click path,
 // which steals focus and bubbles through to the next focusable navbar link.
 // Stop the events at the source so the menu trigger behaves like a normal
 // button in isolation.
-const MenuTrigger = forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLButtonElement>>(function MenuTrigger(
-  { onPointerDown, onClick, onMouseDown, ...rest },
+function MenuTrigger({
+  onPointerDown,
+  onClick,
+  onMouseDown,
   ref,
-) {
+  ...rest
+}: ButtonHTMLAttributes<HTMLButtonElement> & { ref?: Ref<HTMLButtonElement> }) {
   return (
     <button
       ref={ref}
@@ -161,4 +175,4 @@ const MenuTrigger = forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLButto
       <MoreHorizontal className="size-4" aria-hidden />
     </button>
   );
-});
+}

--- a/web/src/components/ui/button.tsx
+++ b/web/src/components/ui/button.tsx
@@ -5,16 +5,13 @@ import * as React from "react";
 import { buttonVariants } from "@/components/ui/button-variants";
 import { cn } from "@/lib/utils";
 
-interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {
+interface ButtonProps extends React.ComponentProps<"button">, VariantProps<typeof buttonVariants> {
   asChild?: boolean;
 }
 
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : "button";
-    return <Comp ref={ref} className={cn(buttonVariants({ variant, size, className }))} {...props} />;
-  },
-);
-Button.displayName = "Button";
+function Button({ className, variant, size, asChild = false, ...props }: ButtonProps) {
+  const Comp = asChild ? Slot : "button";
+  return <Comp className={cn(buttonVariants({ variant, size, className }))} {...props} />;
+}
 
 export { Button };

--- a/web/src/components/ui/card.tsx
+++ b/web/src/components/ui/card.tsx
@@ -2,49 +2,36 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn(
-      "rounded-lg border border-(--color-border) bg-(--color-card) text-(--color-card-foreground) shadow-xs",
-      className,
-    )}
-    {...props}
-  />
-));
-Card.displayName = "Card";
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "rounded-lg border border-(--color-border) bg-(--color-card) text-(--color-card-foreground) shadow-xs",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
 
-const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("flex flex-col gap-1.5 px-5 pt-5 sm:px-6 sm:pt-6", className)} {...props} />
-  ),
-);
-CardHeader.displayName = "CardHeader";
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return <div className={cn("flex flex-col gap-1.5 px-5 pt-5 sm:px-6 sm:pt-6", className)} {...props} />;
+}
 
-const CardTitle = React.forwardRef<HTMLHeadingElement, React.HTMLAttributes<HTMLHeadingElement>>(
-  ({ className, ...props }, ref) => (
-    <h2 ref={ref} className={cn("text-xl font-semibold text-(--color-foreground)", className)} {...props} />
-  ),
-);
-CardTitle.displayName = "CardTitle";
+function CardTitle({ className, ...props }: React.ComponentProps<"h2">) {
+  return <h2 className={cn("text-xl font-semibold text-(--color-foreground)", className)} {...props} />;
+}
 
-const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
-  ({ className, ...props }, ref) => (
-    <p ref={ref} className={cn("text-sm text-(--color-muted-foreground)", className)} {...props} />
-  ),
-);
-CardDescription.displayName = "CardDescription";
+function CardDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return <p className={cn("text-sm text-(--color-muted-foreground)", className)} {...props} />;
+}
 
-const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => <div ref={ref} className={cn("px-5 py-5 sm:px-6 sm:py-6", className)} {...props} />,
-);
-CardContent.displayName = "CardContent";
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return <div className={cn("px-5 py-5 sm:px-6 sm:py-6", className)} {...props} />;
+}
 
-const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("flex items-center px-5 pb-5 sm:px-6 sm:pb-6", className)} {...props} />
-  ),
-);
-CardFooter.displayName = "CardFooter";
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return <div className={cn("flex items-center px-5 pb-5 sm:px-6 sm:pb-6", className)} {...props} />;
+}
 
 export { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle };

--- a/web/src/components/ui/input.tsx
+++ b/web/src/components/ui/input.tsx
@@ -2,10 +2,9 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
-  ({ className, type, ...props }, ref) => (
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
     <input
-      ref={ref}
       type={type}
       className={cn(
         "block w-full rounded-md border border-(--color-input) bg-(--color-background) px-3 py-2 text-sm text-(--color-foreground) placeholder:text-(--color-muted-foreground) outline-none transition-colors",
@@ -16,8 +15,7 @@ const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLI
       )}
       {...props}
     />
-  ),
-);
-Input.displayName = "Input";
+  );
+}
 
 export { Input };

--- a/web/src/components/ui/label.tsx
+++ b/web/src/components/ui/label.tsx
@@ -3,19 +3,16 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-const Label = React.forwardRef<
-  React.ElementRef<typeof LabelPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
->(({ className, ...props }, ref) => (
-  <LabelPrimitive.Root
-    ref={ref}
-    className={cn(
-      "block text-sm font-medium text-(--color-foreground) peer-disabled:cursor-not-allowed peer-disabled:opacity-60",
-      className,
-    )}
-    {...props}
-  />
-));
-Label.displayName = LabelPrimitive.Root.displayName;
+function Label({ className, ...props }: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      className={cn(
+        "block text-sm font-medium text-(--color-foreground) peer-disabled:cursor-not-allowed peer-disabled:opacity-60",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
 
 export { Label };

--- a/web/src/components/ui/popover.tsx
+++ b/web/src/components/ui/popover.tsx
@@ -7,24 +7,26 @@ const Popover = PopoverPrimitive.Root;
 const PopoverTrigger = PopoverPrimitive.Trigger;
 const PopoverAnchor = PopoverPrimitive.Anchor;
 
-const PopoverContent = React.forwardRef<
-  React.ElementRef<typeof PopoverPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
-  <PopoverPrimitive.Portal>
-    <PopoverPrimitive.Content
-      ref={ref}
-      align={align}
-      sideOffset={sideOffset}
-      className={cn(
-        "z-50 w-72 rounded-md border border-(--color-border) bg-(--color-popover) p-1 text-(--color-popover-foreground) shadow-md outline-none",
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
-        className,
-      )}
-      {...props}
-    />
-  </PopoverPrimitive.Portal>
-));
-PopoverContent.displayName = PopoverPrimitive.Content.displayName;
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 w-72 rounded-md border border-(--color-border) bg-(--color-popover) p-1 text-(--color-popover-foreground) shadow-md outline-none",
+          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+          className,
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  );
+}
 
 export { Popover, PopoverAnchor, PopoverContent, PopoverTrigger };

--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -8,72 +8,68 @@ const Select = SelectPrimitive.Root;
 const SelectGroup = SelectPrimitive.Group;
 const SelectValue = SelectPrimitive.Value;
 
-const SelectTrigger = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
->(({ className, children, ...props }, ref) => (
-  <SelectPrimitive.Trigger
-    ref={ref}
-    className={cn(
-      "flex h-10 w-full items-center justify-between rounded-md border border-(--color-input) bg-(--color-background) px-3 py-2 text-sm text-(--color-foreground) outline-none transition-colors",
-      "focus-visible:border-(--color-ring) focus-visible:ring-1 focus-visible:ring-(--color-ring)",
-      "disabled:cursor-not-allowed disabled:opacity-60",
-      "data-[placeholder]:text-(--color-muted-foreground)",
-      className,
-    )}
-    {...props}
-  >
-    {children}
-    <SelectPrimitive.Icon asChild>
-      <ChevronDown className="size-4 text-(--color-muted-foreground)" aria-hidden />
-    </SelectPrimitive.Icon>
-  </SelectPrimitive.Trigger>
-));
-SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
-
-const SelectContent = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
->(({ className, children, position = "popper", ...props }, ref) => (
-  <SelectPrimitive.Portal>
-    <SelectPrimitive.Content
-      ref={ref}
-      position={position}
+function SelectTrigger({ className, children, ...props }: React.ComponentProps<typeof SelectPrimitive.Trigger>) {
+  return (
+    <SelectPrimitive.Trigger
       className={cn(
-        "relative z-50 max-h-(--radix-select-content-available-height) min-w-(--radix-select-trigger-width) overflow-hidden rounded-md border border-(--color-border) bg-(--color-popover) text-(--color-popover-foreground) shadow-md outline-none",
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
-        position === "popper" && "data-[side=bottom]:translate-y-1 data-[side=top]:-translate-y-1",
+        "flex h-10 w-full items-center justify-between rounded-md border border-(--color-input) bg-(--color-background) px-3 py-2 text-sm text-(--color-foreground) outline-none transition-colors",
+        "focus-visible:border-(--color-ring) focus-visible:ring-1 focus-visible:ring-(--color-ring)",
+        "disabled:cursor-not-allowed disabled:opacity-60",
+        "data-[placeholder]:text-(--color-muted-foreground)",
         className,
       )}
       {...props}
     >
-      <SelectPrimitive.Viewport className="p-1">{children}</SelectPrimitive.Viewport>
-    </SelectPrimitive.Content>
-  </SelectPrimitive.Portal>
-));
-SelectContent.displayName = SelectPrimitive.Content.displayName;
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDown className="size-4 text-(--color-muted-foreground)" aria-hidden />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  );
+}
 
-const SelectItem = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
->(({ className, children, ...props }, ref) => (
-  <SelectPrimitive.Item
-    ref={ref}
-    className={cn(
-      "relative flex w-full cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none",
-      "focus:bg-(--color-surface) data-[disabled]:pointer-events-none data-[disabled]:opacity-60",
-      className,
-    )}
-    {...props}
-  >
-    <span className="absolute left-2 flex size-3.5 items-center justify-center">
-      <SelectPrimitive.ItemIndicator>
-        <Check className="size-4" aria-hidden />
-      </SelectPrimitive.ItemIndicator>
-    </span>
-    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
-  </SelectPrimitive.Item>
-));
-SelectItem.displayName = SelectPrimitive.Item.displayName;
+function SelectContent({
+  className,
+  children,
+  position = "popper",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        position={position}
+        className={cn(
+          "relative z-50 max-h-(--radix-select-content-available-height) min-w-(--radix-select-trigger-width) overflow-hidden rounded-md border border-(--color-border) bg-(--color-popover) text-(--color-popover-foreground) shadow-md outline-none",
+          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+          position === "popper" && "data-[side=bottom]:translate-y-1 data-[side=top]:-translate-y-1",
+          className,
+        )}
+        {...props}
+      >
+        <SelectPrimitive.Viewport className="p-1">{children}</SelectPrimitive.Viewport>
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  );
+}
+
+function SelectItem({ className, children, ...props }: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      className={cn(
+        "relative flex w-full cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none",
+        "focus:bg-(--color-surface) data-[disabled]:pointer-events-none data-[disabled]:opacity-60",
+        className,
+      )}
+      {...props}
+    >
+      <span className="absolute left-2 flex size-3.5 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <Check className="size-4" aria-hidden />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  );
+}
 
 export { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue };

--- a/web/src/components/ui/sheet.tsx
+++ b/web/src/components/ui/sheet.tsx
@@ -10,20 +10,17 @@ const SheetTrigger = DialogPrimitive.Trigger;
 const SheetClose = DialogPrimitive.Close;
 const SheetPortal = DialogPrimitive.Portal;
 
-const SheetOverlay = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Overlay>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
->(({ className, ...props }, ref) => (
-  <DialogPrimitive.Overlay
-    ref={ref}
-    className={cn(
-      "fixed inset-0 z-50 bg-black/40 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-      className,
-    )}
-    {...props}
-  />
-));
-SheetOverlay.displayName = DialogPrimitive.Overlay.displayName;
+function SheetOverlay({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      className={cn(
+        "fixed inset-0 z-50 bg-black/40 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
 
 const sheetVariants = cva(
   "fixed z-50 bg-(--color-background) shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-200 data-[state=open]:duration-300",
@@ -45,15 +42,15 @@ const sheetVariants = cva(
 );
 
 interface SheetContentProps
-  extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>, VariantProps<typeof sheetVariants> {
+  extends React.ComponentProps<typeof DialogPrimitive.Content>, VariantProps<typeof sheetVariants> {
   hideCloseButton?: boolean;
 }
 
-const SheetContent = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Content>, SheetContentProps>(
-  ({ side = "right", className, children, hideCloseButton, ...props }, ref) => (
+function SheetContent({ side = "right", className, children, hideCloseButton, ...props }: SheetContentProps) {
+  return (
     <SheetPortal>
       <SheetOverlay />
-      <DialogPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
+      <DialogPrimitive.Content className={cn(sheetVariants({ side }), className)} {...props}>
         {children}
         {hideCloseButton ? null : (
           <DialogPrimitive.Close
@@ -65,33 +62,22 @@ const SheetContent = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Co
         )}
       </DialogPrimitive.Content>
     </SheetPortal>
-  ),
-);
-SheetContent.displayName = DialogPrimitive.Content.displayName;
+  );
+}
 
 const SheetHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
   <div className={cn("flex flex-col gap-1.5 border-b border-(--color-border) p-3 text-sm", className)} {...props} />
 );
 SheetHeader.displayName = "SheetHeader";
 
-const SheetTitle = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Title>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
->(({ className, ...props }, ref) => (
-  <DialogPrimitive.Title ref={ref} className={cn("font-semibold text-(--color-foreground)", className)} {...props} />
-));
-SheetTitle.displayName = DialogPrimitive.Title.displayName;
+function SheetTitle({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return <DialogPrimitive.Title className={cn("font-semibold text-(--color-foreground)", className)} {...props} />;
+}
 
-const SheetDescription = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Description>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
->(({ className, ...props }, ref) => (
-  <DialogPrimitive.Description
-    ref={ref}
-    className={cn("text-xs text-(--color-muted-foreground)", className)}
-    {...props}
-  />
-));
-SheetDescription.displayName = DialogPrimitive.Description.displayName;
+function SheetDescription({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description className={cn("text-xs text-(--color-muted-foreground)", className)} {...props} />
+  );
+}
 
 export { Sheet, SheetClose, SheetContent, SheetDescription, SheetHeader, SheetPortal, SheetTitle, SheetTrigger };

--- a/web/src/components/ui/toggle-group.tsx
+++ b/web/src/components/ui/toggle-group.tsx
@@ -12,24 +12,31 @@ const ToggleGroupContext = React.createContext<ToggleVariantProps>({
   size: "default",
 });
 
-const ToggleGroup = React.forwardRef<
-  React.ElementRef<typeof ToggleGroupPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root> & ToggleVariantProps
->(({ className, variant, size, children, ...props }, ref) => (
-  <ToggleGroupPrimitive.Root ref={ref} className={cn("flex items-center justify-center gap-1", className)} {...props}>
-    <ToggleGroupContext.Provider value={{ variant, size }}>{children}</ToggleGroupContext.Provider>
-  </ToggleGroupPrimitive.Root>
-));
-ToggleGroup.displayName = ToggleGroupPrimitive.Root.displayName;
+function ToggleGroup({
+  className,
+  variant,
+  size,
+  children,
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Root> & ToggleVariantProps) {
+  const context = React.useMemo(() => ({ variant, size }), [variant, size]);
+  return (
+    <ToggleGroupPrimitive.Root className={cn("flex items-center justify-center gap-1", className)} {...props}>
+      <ToggleGroupContext.Provider value={context}>{children}</ToggleGroupContext.Provider>
+    </ToggleGroupPrimitive.Root>
+  );
+}
 
-const ToggleGroupItem = React.forwardRef<
-  React.ElementRef<typeof ToggleGroupPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Item> & ToggleVariantProps
->(({ className, children, variant, size, ...props }, ref) => {
-  const context = React.useContext(ToggleGroupContext);
+function ToggleGroupItem({
+  className,
+  children,
+  variant,
+  size,
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Item> & ToggleVariantProps) {
+  const context = React.use(ToggleGroupContext);
   return (
     <ToggleGroupPrimitive.Item
-      ref={ref}
       className={cn(
         toggleVariants({
           variant: context.variant ?? variant,
@@ -42,7 +49,6 @@ const ToggleGroupItem = React.forwardRef<
       {children}
     </ToggleGroupPrimitive.Item>
   );
-});
-ToggleGroupItem.displayName = ToggleGroupPrimitive.Item.displayName;
+}
 
 export { ToggleGroup, ToggleGroupItem };

--- a/web/src/components/ui/tooltip.tsx
+++ b/web/src/components/ui/tooltip.tsx
@@ -7,23 +7,24 @@ const TooltipProvider = TooltipPrimitive.Provider;
 const Tooltip = TooltipPrimitive.Root;
 const TooltipTrigger = TooltipPrimitive.Trigger;
 
-const TooltipContent = React.forwardRef<
-  React.ElementRef<typeof TooltipPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
-  <TooltipPrimitive.Portal>
-    <TooltipPrimitive.Content
-      ref={ref}
-      sideOffset={sideOffset}
-      className={cn(
-        "z-50 overflow-hidden rounded-md bg-(--color-foreground) px-2 py-1 text-xs text-(--color-background) shadow-sm",
-        "data-[state=delayed-open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=delayed-open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=delayed-open]:zoom-in-95",
-        className,
-      )}
-      {...props}
-    />
-  </TooltipPrimitive.Portal>
-));
-TooltipContent.displayName = TooltipPrimitive.Content.displayName;
+function TooltipContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 overflow-hidden rounded-md bg-(--color-foreground) px-2 py-1 text-xs text-(--color-background) shadow-sm",
+          "data-[state=delayed-open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=delayed-open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=delayed-open]:zoom-in-95",
+          className,
+        )}
+        {...props}
+      />
+    </TooltipPrimitive.Portal>
+  );
+}
 
 export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger };

--- a/web/src/lib/theme-context.ts
+++ b/web/src/lib/theme-context.ts
@@ -1,4 +1,4 @@
-import { createContext, useContext } from "react";
+import { createContext, use } from "react";
 
 export type Theme = "light" | "dark" | "system";
 
@@ -10,7 +10,7 @@ export interface ThemeContextValue {
 export const ThemeContext = createContext<ThemeContextValue | null>(null);
 
 export function useTheme(): ThemeContextValue {
-  const ctx = useContext(ThemeContext);
+  const ctx = use(ThemeContext);
   if (!ctx) {
     throw new Error("useTheme must be used inside <ThemeProvider>");
   }

--- a/web/src/lib/use-user-info.ts
+++ b/web/src/lib/use-user-info.ts
@@ -1,10 +1,10 @@
-import { useContext } from "react";
+import { use } from "react";
 
 import type { UserInfo } from "./user-info";
 import { UserInfoContext } from "./user-info-context";
 
 export function useUserInfo(): UserInfo | null {
-  const ctx = useContext(UserInfoContext);
+  const ctx = use(UserInfoContext);
   if (ctx === undefined) {
     throw new Error("useUserInfo must be used within UserInfoProvider");
   }

--- a/web/src/pages/user/ResetPassword.tsx
+++ b/web/src/pages/user/ResetPassword.tsx
@@ -28,6 +28,41 @@ interface ResetPasswordErrorResponse {
 
 const route = getRouteApi("/user/reset-password");
 
+function FormActions({
+  submitLabel,
+  submitTabIndex,
+  submitting,
+  backLabel,
+  backHref,
+}: {
+  submitLabel: string;
+  submitTabIndex: number;
+  submitting: boolean;
+  backLabel: string;
+  backHref: string;
+}) {
+  return (
+    <div className="mt-2 flex flex-col gap-3">
+      <Button type="submit" disabled={submitting} tabIndex={submitTabIndex} className="w-full">
+        {submitLabel}
+      </Button>
+      <Button variant="link" size="inline" asChild className="self-center">
+        <a
+          href={backHref}
+          tabIndex={submitting ? -1 : submitTabIndex + 1}
+          aria-disabled={submitting || undefined}
+          className={submitting ? "pointer-events-none opacity-50" : undefined}
+          onClick={(e) => {
+            if (submitting) e.preventDefault();
+          }}
+        >
+          {backLabel}
+        </a>
+      </Button>
+    </div>
+  );
+}
+
 export function ResetPassword() {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -175,6 +210,9 @@ export function ResetPassword() {
             <FormActions
               submitLabel={submitting ? t("auth.reset_password_email_submitting") : t("auth.send_reset_email")}
               submitTabIndex={3}
+              submitting={submitting}
+              backLabel={t("auth.back_to_sign_in")}
+              backHref={subUrl("/user/sign-in")}
             />
           </div>
         </fieldset>
@@ -247,6 +285,9 @@ export function ResetPassword() {
             <FormActions
               submitLabel={submitting ? t("auth.reset_password_submitting") : t("auth.reset_password_submit")}
               submitTabIndex={5}
+              submitting={submitting}
+              backLabel={t("auth.back_to_sign_in")}
+              backHref={subUrl("/user/sign-in")}
             />
           </div>
         </fieldset>
@@ -262,29 +303,6 @@ export function ResetPassword() {
         className="mb-4 rounded-md border border-(--color-destructive) bg-(--color-destructive)/10 px-3 py-2 text-sm text-(--color-destructive)"
       >
         {formError}
-      </div>
-    );
-  }
-
-  function FormActions({ submitLabel, submitTabIndex }: { submitLabel: string; submitTabIndex: number }) {
-    return (
-      <div className="mt-2 flex flex-col gap-3">
-        <Button type="submit" disabled={submitting} tabIndex={submitTabIndex} className="w-full">
-          {submitLabel}
-        </Button>
-        <Button variant="link" size="inline" asChild className="self-center">
-          <a
-            href={subUrl("/user/sign-in")}
-            tabIndex={submitting ? -1 : submitTabIndex + 1}
-            aria-disabled={submitting || undefined}
-            className={submitting ? "pointer-events-none opacity-50" : undefined}
-            onClick={(e) => {
-              if (submitting) e.preventDefault();
-            }}
-          >
-            {t("auth.back_to_sign_in")}
-          </a>
-        </Button>
       </div>
     );
   }


### PR DESCRIPTION
Cleanup sweep driven by react-doctor (health score 83 → 86). Every change is in `web/`; typecheck, ESLint, and Prettier all pass clean.

## Changes

- **`ResetPassword`**: hoist `FormActions` out of the parent component to module scope, passing `submitting`/`backLabel`/`backHref` as props. Previously it was defined inside `ResetPassword`, so each render minted a new component identity and remounted the submit buttons (the one error-severity finding).
- **`use()` over `useContext`**: `theme-context.ts`, `use-user-info.ts`, `toggle-group.tsx`.
- **`forwardRef` → ref-as-prop**: across the shadcn `ui/` primitives (`button`, `card`, `input`, `label`, `popover`, `select`, `sheet`, `toggle-group`, `tooltip`) plus `DiffFileTree`, `DiffToolbar`, `FileHeaderMenu`. This matches the current shadcn v4 generator on React 19 (verified against upstream `shadcn-ui/ui`), where refs are regular props.
- **`FileHeaderMenu`**: replace `<li role="separator">` dividers with a presentational `<li>` wrapping an `<hr>` (clears `control-has-associated-label` and `no-noninteractive-element-to-interactive-role`).
- **`toggle-group`**: memoize the context provider value so consumers don't re-render on every parent render.
- **`DiffSearch`**: use the native `<search>` element instead of `<div role="search">`.

## Not touched (deliberate)

- The interleaved positive `tabIndex` ordering in the auth forms is intentional keyboard UX, not a mechanical fix.
- Em dashes flagged in `Landing`/`NotFound`/`ServerError` are terminal-prompt graphic separators, allowed by the project UI guidelines.
- `RepoHeader` mutations already sync the cache via `queryClient.setQueryData` one function hop away; the lint rule misses the indirection.
- `ResizableSidebar`'s `role="separator"` is an interactive, focusable resize handle, not a presentational `<hr>`.