### PR TITLE
chore: split server task from moon dev and prod orchestrators

### DIFF
--- a/.moon/tasks.yml
+++ b/.moon/tasks.yml
@@ -1,4 +1,0 @@
-$schema: "https://moonrepo.dev/schemas/tasks.json"
-
-taskOptions:
-  outputStyle: "stream"

--- a/.moon/tasks/all.yml
+++ b/.moon/tasks/all.yml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://moonrepo.dev/schemas/tasks.json
+$schema: "https://moonrepo.dev/schemas/tasks.json"
+
+taskOptions:
+  outputStyle: "stream"
+  runFromWorkspaceRoot: true

--- a/moon.yml
+++ b/moon.yml
@@ -126,21 +126,29 @@ tasks:
       ' .bin/custom/conf/app.ini > .bin/custom/conf/app.ini.tmp \
         && mv .bin/custom/conf/app.ini.tmp .bin/custom/conf/app.ini
 
-  dev:
+  server:
     script: "cd .bin && ./gogs web"
     preset: "server"
     env:
       TTY_FORCE: "1"
+
+  dev:
+    command: "noop"
+    options:
+      runInCI: false
+      persistent: true
     deps:
       - "build"
+      - "server"
       - "web:dev"
       - "portless"
 
   prod:
-    script: "cd .bin && ./gogs web"
-    preset: "server"
-    env:
-      TTY_FORCE: "1"
+    command: "noop"
+    options:
+      runInCI: false
+      persistent: true
     deps:
       - "build-prod"
+      - "server"
       - "portless"

--- a/web/moon.yml
+++ b/web/moon.yml
@@ -26,6 +26,8 @@ tasks:
   dev:
     command: "pnpm run dev"
     preset: "server"
+    options:
+      runFromWorkspaceRoot: false
     deps:
       - "install"
 
@@ -36,6 +38,8 @@ tasks:
       - "@group(configs)"
     outputs:
       - "/public/dist"
+    options:
+      runFromWorkspaceRoot: false
     deps:
       - "install"
 
@@ -44,6 +48,8 @@ tasks:
     inputs:
       - "@group(sources)"
       - "@group(configs)"
+    options:
+      runFromWorkspaceRoot: false
     deps:
       - "install"
       - "format"
@@ -55,5 +61,7 @@ tasks:
       - "@group(configs)"
       - ".prettierrc.*"
       - ".prettierignore"
+    options:
+      runFromWorkspaceRoot: false
     deps:
       - "install"


### PR DESCRIPTION
## Description

Refactors the moon task definitions so the web server invocation lives in a single place.

- Extract the `cd .bin && ./gogs web` invocation into a dedicated `server` task.
- Turn `dev` and `prod` into `noop` orchestrators that depend on `server`, removing the duplicated server script that previously existed in both `dev` and `prod`.
- Set `runFromWorkspaceRoot` on the relevant tasks (`true` at the workspace task-options level, `false` for the `web` project tasks) so each task resolves paths from the correct directory.
- Migrate `.moon/tasks.yml` to `.moon/tasks/all.yml` and add the yaml-language-server schema directive.

## Test plan

- `moon run gogs:dev` starts the server, web dev server, and portless together.
- `moon run gogs:prod` builds and runs the production server with portless.