### PR TITLE
fix: avoid panic on malformed external issue tracker URL format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to Gogs are documented in this file.
 - _Security:_ Reverse proxy authentication header was honored from any remote address, allowing user impersonation when Gogs was reachable directly. The header is now only trusted from addresses listed in `[auth] TRUSTED_PROXY_IPS`. [#8264](https://github.com/gogs/gogs/pull/8264) - [GHSA-w6j9-vw59-27wv](https://github.com/gogs/gogs/security/advisories/GHSA-w6j9-vw59-27wv)
 - _Security:_ Server-side request forgery in webhook deliveries via HTTP redirects to local network addresses. [#8263](https://github.com/gogs/gogs/pull/8263) - [GHSA-c4v7-xg93-qf8g](https://github.com/gogs/gogs/security/advisories/GHSA-c4v7-xg93-qf8g)
 - _Security:_ The "remember me" auto-login cookie was derived from database columns, so an attacker with a database dump could forge a valid cookie for any user. The auto-login cookie path has been removed entirely. Persistence is now provided by the server-issued session cookie. [#8289](https://github.com/gogs/gogs/pull/8289) - [GHSA-4pph-25p3-pw73](https://github.com/gogs/gogs/security/advisories/GHSA-4pph-25p3-pw73)
+- _Security:_ Denial of service when rendering issue references against a malformed external issue tracker URL format. [#PR_PLACEHOLDER](https://github.com/gogs/gogs/pull/PR_PLACEHOLDER) - [GHSA-4j89-2c4f-44c6](https://github.com/gogs/gogs/security/advisories/GHSA-4j89-2c4f-44c6)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to Gogs are documented in this file.
 - _Security:_ Reverse proxy authentication header was honored from any remote address, allowing user impersonation when Gogs was reachable directly. The header is now only trusted from addresses listed in `[auth] TRUSTED_PROXY_IPS`. [#8264](https://github.com/gogs/gogs/pull/8264) - [GHSA-w6j9-vw59-27wv](https://github.com/gogs/gogs/security/advisories/GHSA-w6j9-vw59-27wv)
 - _Security:_ Server-side request forgery in webhook deliveries via HTTP redirects to local network addresses. [#8263](https://github.com/gogs/gogs/pull/8263) - [GHSA-c4v7-xg93-qf8g](https://github.com/gogs/gogs/security/advisories/GHSA-c4v7-xg93-qf8g)
 - _Security:_ The "remember me" auto-login cookie was derived from database columns, so an attacker with a database dump could forge a valid cookie for any user. The auto-login cookie path has been removed entirely. Persistence is now provided by the server-issued session cookie. [#8289](https://github.com/gogs/gogs/pull/8289) - [GHSA-4pph-25p3-pw73](https://github.com/gogs/gogs/security/advisories/GHSA-4pph-25p3-pw73)
-- _Security:_ Denial of service when rendering issue references against a malformed external issue tracker URL format. [#PR_PLACEHOLDER](https://github.com/gogs/gogs/pull/PR_PLACEHOLDER) - [GHSA-4j89-2c4f-44c6](https://github.com/gogs/gogs/security/advisories/GHSA-4j89-2c4f-44c6)
+- _Security:_ Denial of service when rendering issue references against a malformed external issue tracker URL format. [#8312](https://github.com/gogs/gogs/pull/8312) - [GHSA-4j89-2c4f-44c6](https://github.com/gogs/gogs/security/advisories/GHSA-4j89-2c4f-44c6)
 
 ### Removed
 

--- a/internal/markup/markup.go
+++ b/internal/markup/markup.go
@@ -83,31 +83,12 @@ func cutoutVerbosePrefix(prefix string) string {
 }
 
 // expand substitutes "{key}" placeholders in template with values from match.
-// Unclosed "{" sequences are emitted verbatim instead of causing a panic, which
-// is the behavior of github.com/unknwon/com.Expand when given a malformed
-// template such as an external issue tracker URL containing a stray "{".
 func expand(template string, match map[string]string) string {
-	var p []byte
-	for {
-		i := strings.Index(template, "{")
-		if i < 0 {
-			break
-		}
-		p = append(p, template[:i]...)
-		template = template[i+1:]
-		j := strings.Index(template, "}")
-		if j < 0 {
-			// Unclosed placeholder: emit the literal "{" and stop expanding.
-			p = append(p, '{')
-			break
-		}
-		if s, ok := match[template[:j]]; ok {
-			p = append(p, s...)
-		}
-		template = template[j+1:]
+	pairs := make([]string, 0, len(match)*2)
+	for k, v := range match {
+		pairs = append(pairs, "{"+k+"}", v)
 	}
-	p = append(p, template...)
-	return string(p)
+	return strings.NewReplacer(pairs...).Replace(template)
 }
 
 // RenderIssueIndexPattern renders issue indexes to corresponding links.

--- a/internal/markup/markup.go
+++ b/internal/markup/markup.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/unknwon/com"
 	"golang.org/x/net/html"
 
 	"gogs.io/gogs/internal/conf"
@@ -83,6 +82,34 @@ func cutoutVerbosePrefix(prefix string) string {
 	return prefix
 }
 
+// expand substitutes "{key}" placeholders in template with values from match.
+// Unclosed "{" sequences are emitted verbatim instead of causing a panic, which
+// is the behavior of github.com/unknwon/com.Expand when given a malformed
+// template such as an external issue tracker URL containing a stray "{".
+func expand(template string, match map[string]string) string {
+	var p []byte
+	for {
+		i := strings.Index(template, "{")
+		if i < 0 {
+			break
+		}
+		p = append(p, template[:i]...)
+		template = template[i+1:]
+		j := strings.Index(template, "}")
+		if j < 0 {
+			// Unclosed placeholder: emit the literal "{" and stop expanding.
+			p = append(p, '{')
+			break
+		}
+		if s, ok := match[template[:j]]; ok {
+			p = append(p, s...)
+		}
+		template = template[j+1:]
+	}
+	p = append(p, template...)
+	return string(p)
+}
+
 // RenderIssueIndexPattern renders issue indexes to corresponding links.
 func RenderIssueIndexPattern(rawBytes []byte, urlPrefix string, metas map[string]string) []byte {
 	urlPrefix = cutoutVerbosePrefix(urlPrefix)
@@ -108,7 +135,7 @@ func RenderIssueIndexPattern(rawBytes []byte, urlPrefix string, metas map[string
 			} else {
 				metas["index"] = string(m[1:])
 			}
-			link = fmt.Sprintf(`<a href="%s">%s</a>`, com.Expand(metas["format"], metas), m)
+			link = fmt.Sprintf(`<a href="%s">%s</a>`, expand(metas["format"], metas), m)
 		}
 		rawBytes = bytes.Replace(rawBytes, m, []byte(link), 1)
 	}

--- a/internal/markup/markup_test.go
+++ b/internal/markup/markup_test.go
@@ -147,6 +147,20 @@ func Test_RenderIssueIndexPattern(t *testing.T) {
 			}
 		})
 
+		t.Run("malformed format does not panic", func(t *testing.T) {
+			// An external tracker format with an unclosed "{" must not crash the
+			// rendering pipeline. See GHSA-4j89-2c4f-44c6.
+			metas := map[string]string{
+				"format": "https://someurl.com/{user}/{repo}/{",
+				"user":   "someuser",
+				"repo":   "somerepo",
+				"style":  IssueNameStyleNumeric,
+			}
+			assert.NotPanics(t, func() {
+				RenderIssueIndexPattern([]byte("#1 test"), urlPrefix, metas)
+			})
+		})
+
 		t.Run("alphanumeric style", func(t *testing.T) {
 			metas := map[string]string{
 				"format": "https://someurl.com/{user}/{repo}/?b={index}",


### PR DESCRIPTION
## Summary

- Replace the unsafe `com.Expand` call in `RenderIssueIndexPattern` with a local helper that tolerates unbalanced `{` in the format template.
- A malformed external issue tracker URL format would otherwise crash the rendering pipeline, leaving pages that contain issue references unavailable.
- Adds a regression test that exercises the malformed-format path.

Refs [GHSA-4j89-2c4f-44c6](https://github.com/gogs/gogs/security/advisories/GHSA-4j89-2c4f-44c6).

## Test plan

- [x] `moon run gogs:lint`
- [x] `moon run gogs:build`
- [x] `go test -race ./internal/markup/...`