### PR TITLE
ssh: remove support for DSA public keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to Gogs are documented in this file.
 - Support for `memcache` as the cache adapter. Stay on 0.14 for continued usage. [#8270](https://github.com/gogs/gogs/pull/8270)
 - The `/debug`, `/debug/pprof/*`, `/debug/profile/*`, and `/urlmap.json` endpoints. [#8271](https://github.com/gogs/gogs/pull/8271)
 - CSRF protection and the `[session] CSRF_COOKIE_NAME` configuration option. [#8300](https://github.com/gogs/gogs/pull/8300)
-- Support for DSA public keys. The `DSA` entry under `[ssh.minimum_key_sizes]` is no longer recognized.
+- Support for DSA public keys. The `DSA` entry under `[ssh.minimum_key_sizes]` is no longer recognized. [#8313](https://github.com/gogs/gogs/pull/8313)
 
 ## 0.14.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to Gogs are documented in this file.
 - Support for `memcache` as the cache adapter. Stay on 0.14 for continued usage. [#8270](https://github.com/gogs/gogs/pull/8270)
 - The `/debug`, `/debug/pprof/*`, `/debug/profile/*`, and `/urlmap.json` endpoints. [#8271](https://github.com/gogs/gogs/pull/8271)
 - CSRF protection and the `[session] CSRF_COOKIE_NAME` configuration option. [#8300](https://github.com/gogs/gogs/pull/8300)
+- Support for DSA public keys. The `DSA` entry under `[ssh.minimum_key_sizes]` is no longer recognized.
 
 ## 0.14.2
 

--- a/conf/app.ini
+++ b/conf/app.ini
@@ -91,7 +91,6 @@ SSH_SERVER_ALGORITHMS = rsa, ecdsa, ed25519
 ED25519 = 256
 ECDSA   = 256
 RSA     = 2048
-DSA     = 1024
 
 [repository]
 ; The root path for storing managed repositories, default is "~/gogs-repositories"

--- a/internal/database/ssh_key.go
+++ b/internal/database/ssh_key.go
@@ -237,17 +237,6 @@ func SSHNativeParsePublicKey(keyLine string) (string, int, error) {
 
 	// The ssh library can parse the key, so next we find out what key exactly we have.
 	switch pkey.Type() {
-	case ssh.KeyAlgoDSA:
-		rawPub := struct {
-			Name       string
-			P, Q, G, Y *big.Int
-		}{}
-		if err := ssh.Unmarshal(pkey.Marshal(), &rawPub); err != nil {
-			return "", 0, err
-		}
-		// as per https://bugzilla.mindrot.org/show_bug.cgi?id=1647 we should never
-		// see dsa keys != 1024 bit, but as it seems to work, we will not check here
-		return "dsa", rawPub.P.BitLen(), nil // use P as per crypto/dsa/dsa.go (is L)
 	case ssh.KeyAlgoRSA:
 		rawPub := struct {
 			Name string

--- a/internal/database/ssh_key_test.go
+++ b/internal/database/ssh_key_test.go
@@ -16,18 +16,6 @@ func TestSSHParsePublicKey(t *testing.T) {
 		expLength int
 	}{
 		{
-			name:      "dsa-1024",
-			content:   "ssh-dss AAAAB3NzaC1kc3MAAACBAOChCC7lf6Uo9n7BmZ6M8St19PZf4Tn59NriyboW2x/DZuYAz3ibZ2OkQ3S0SqDIa0HXSEJ1zaExQdmbO+Ux/wsytWZmCczWOVsaszBZSl90q8UnWlSH6P+/YA+RWJm5SFtuV9PtGIhyZgoNuz5kBQ7K139wuQsecdKktISwTakzAAAAFQCzKsO2JhNKlL+wwwLGOcLffoAmkwAAAIBpK7/3xvduajLBD/9vASqBQIHrgK2J+wiQnIb/Wzy0UsVmvfn8A+udRbBo+csM8xrSnlnlJnjkJS3qiM5g+eTwsLIV1IdKPEwmwB+VcP53Cw6lSyWyJcvhFb0N6s08NZysLzvj0N+ZC/FnhKTLzIyMtkHf/IrPCwlM+pV/M/96YgAAAIEAqQcGn9CKgzgPaguIZooTAOQdvBLMI5y0bQjOW6734XOpqQGf/Kra90wpoasLKZjSYKNPjE+FRUOrStLrxcNs4BeVKhy2PYTRnybfYVk1/dmKgH6P1YSRONsGKvTsH6c5IyCRG0ncCgYeF8tXppyd642982daopE7zQ/NPAnJfag= nocomment",
-			expType:   "dsa",
-			expLength: 1024,
-		},
-		{
-			name:      "rsa-1024",
-			content:   "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQDAu7tvIvX6ZHrRXuZNfkR3XLHSsuCK9Zn3X58lxBcQzuo5xZgB6vRwwm/QtJuF+zZPtY5hsQILBLmF+BZ5WpKZp1jBeSjH2G7lxet9kbcH+kIVj0tPFEoyKI9wvWqIwC4prx/WVk2wLTJjzBAhyNxfEq7C9CeiX9pQEbEqJfkKCQ== nocomment",
-			expType:   "rsa",
-			expLength: 1024,
-		},
-		{
 			name:      "rsa-2048",
 			content:   "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDMZXh+1OBUwSH9D45wTaxErQIN9IoC9xl7MKJkqvTvv6O5RR9YW/IK9FbfjXgXsppYGhsCZo1hFOOsXHMnfOORqu/xMDx4yPuyvKpw4LePEcg4TDipaDFuxbWOqc/BUZRZcXu41QAWfDLrInwsltWZHSeG7hjhpacl4FrVv9V1pS6Oc5Q1NxxEzTzuNLS/8diZrTm/YAQQ/+B+mzWI3zEtF4miZjjAljWd1LTBPvU23d29DcBmmFahcZ441XZsTeAwGxG/Q6j8NgNXj9WxMeWwxXV2jeAX/EBSpZrCVlCQ1yJswT6xCp8TuBnTiGWYMBNTbOZvPC4e0WI2/yZW/s5F nocomment",
 			expType:   "rsa",


### PR DESCRIPTION
## Summary

- Drop `DSA = 1024` from the default `[ssh.minimum_key_sizes]` in `conf/app.ini`, so DSA public keys are rejected at upload with "key type is not allowed".
- Remove the unreachable `case ssh.KeyAlgoDSA:` branch from `SSHNativeParsePublicKey`. `golang.org/x/crypto/ssh` stopped recognizing `ssh-dss` in v0.31.0, and this repo is pinned to v0.49.0, so `ssh.ParsePublicKey` errors out before the switch is reached.
- Drop the `dsa-1024` and `rsa-1024` fixtures from `TestSSHParsePublicKey`. The `rsa-2048` fixture still covers the RSA branch, and the default config requires `RSA >= 2048` anyway.

DSA has been considered weak for years. OpenSSH disabled it by default in 7.0 (2015) and removed support entirely in 9.8 (2024).

## Test plan

- [x] `go test ./internal/database/ -run TestSSHParsePublicKey`
- [x] `moon run gogs:lint` (0 issues)