### PR TITLE
web: enable @pierre/diffs worker pool to fix blank flashes on fast diff scroll

### DIFF
--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -1,3 +1,4 @@
+import { WorkerPoolContextProvider } from "@pierre/diffs/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Outlet, RouterProvider, createRootRouteWithContext, createRoute, createRouter } from "@tanstack/react-router";
 import { Toaster } from "sonner";
@@ -61,14 +62,26 @@ declare module "@tanstack/react-router" {
 
 const queryClient = new QueryClient();
 
+// Pierre's worker pool is a process-wide singleton (refcounted by mount). Hold
+// it at the app root so it stays warm across navigations: the diff renderer
+// uses workers to tokenize files via Shiki/Oniguruma off the main thread, and
+// without a live pool every file falls back to a sync main-thread path that
+// returns `undefined` until highlighting resolves, painting blanks on fast
+// scroll over large diffs.
+const diffWorkerPoolOptions = {
+  workerFactory: () => new Worker(new URL("@pierre/diffs/worker/worker.js", import.meta.url), { type: "module" }),
+};
+
 export function AppRouter({ user }: { user: UserInfo | null }) {
   const router = makeRouter({ user, queryClient });
   return (
     <QueryClientProvider client={queryClient}>
-      <TooltipProvider delayDuration={300}>
-        <RouterProvider router={router} />
-        <Toaster position="bottom-right" closeButton richColors />
-      </TooltipProvider>
+      <WorkerPoolContextProvider poolOptions={diffWorkerPoolOptions} highlighterOptions={{}}>
+        <TooltipProvider delayDuration={300}>
+          <RouterProvider router={router} />
+          <Toaster position="bottom-right" closeButton richColors />
+        </TooltipProvider>
+      </WorkerPoolContextProvider>
     </QueryClientProvider>
   );
 }


### PR DESCRIPTION
## Summary

- Without a \`WorkerPoolContextProvider\`, \`@pierre/diffs\` falls back to a synchronous main-thread highlighting path that returns no AST until Shiki resolves (\`DiffHunksRenderer.renderDiff\`). On large diffs, fast-scrolling triggers Pierre to recycle \`<diffs-container>\` elements faster than the main-thread highlighter can rehydrate them, leaving blank rows.
- Mount the provider once at the app root. Pierre's pool is a refcounted singleton and workers spawn lazily on the first \`CodeView\` render, so pages without a diff pay no runtime cost.
- Verified against [diffshub.com](https://diffshub.com), which wires the same worker pool via the vanilla \`<diffs-container>\` web component and does not blank on 100k+ diffs.

## Test plan

- [ ] Open a commit page on a large diff (7k+ lines, ideally one mixing several languages).
- [ ] Flick-scroll the diff body as fast as the trackpad allows.
- [ ] Confirm rows stay rendered (plain text first, syntax colors arrive a frame later) instead of going blank.
- [ ] Navigate to a non-diff page (landing, profile, repo home) and confirm no Pierre worker is spawned (DevTools > Application > Service Workers / Performance > "Workers" lane stays empty).
- [ ] Navigate back to a diff page and confirm workers spin up on first paint, then stay warm on subsequent diff visits.