### PR TITLE
security: harden same-site URL check against redirect bypass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to Gogs are documented in this file.
 - _Security:_ Missing authorization check on the attachment download endpoint allowed anyone who knew (or guessed) an attachment UUID to download files belonging to private repositories. [#8320](https://github.com/gogs/gogs/pull/8320) - [GHSA-p9f5-h3rx-j5qw](https://github.com/gogs/gogs/security/advisories/GHSA-p9f5-h3rx-j5qw)
 - _Security:_ Organization team and member management actions accepted GET requests, allowing a logged-in owner to be tricked into adding an attacker to the Owners team via a crafted link. [#8321](https://github.com/gogs/gogs/pull/8321) - [GHSA-pwx3-qcgw-vh7h](https://github.com/gogs/gogs/security/advisories/GHSA-pwx3-qcgw-vh7h)
 - _Security:_ SSRF via mirror address update bypassing clone address validation. [#8225](https://github.com/gogs/gogs/pull/8225) - [GHSA-wv27-2vqp-j7g5](https://github.com/gogs/gogs/security/advisories/GHSA-wv27-2vqp-j7g5)
+- _Security:_ Open redirect on login and other post-action flows via the `redirect_to` query parameter. [#PR](https://github.com/gogs/gogs/pull/PR) - [GHSA-xxhq-69mf-w8cr](https://github.com/gogs/gogs/security/advisories/GHSA-xxhq-69mf-w8cr)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to Gogs are documented in this file.
 - _Security:_ Missing authorization check on the attachment download endpoint allowed anyone who knew (or guessed) an attachment UUID to download files belonging to private repositories. [#8320](https://github.com/gogs/gogs/pull/8320) - [GHSA-p9f5-h3rx-j5qw](https://github.com/gogs/gogs/security/advisories/GHSA-p9f5-h3rx-j5qw)
 - _Security:_ Organization team and member management actions accepted GET requests, allowing a logged-in owner to be tricked into adding an attacker to the Owners team via a crafted link. [#8321](https://github.com/gogs/gogs/pull/8321) - [GHSA-pwx3-qcgw-vh7h](https://github.com/gogs/gogs/security/advisories/GHSA-pwx3-qcgw-vh7h)
 - _Security:_ SSRF via mirror address update bypassing clone address validation. [#8225](https://github.com/gogs/gogs/pull/8225) - [GHSA-wv27-2vqp-j7g5](https://github.com/gogs/gogs/security/advisories/GHSA-wv27-2vqp-j7g5)
-- _Security:_ Open redirect on login and other post-action flows via the `redirect_to` query parameter. [#PR](https://github.com/gogs/gogs/pull/PR) - [GHSA-xxhq-69mf-w8cr](https://github.com/gogs/gogs/security/advisories/GHSA-xxhq-69mf-w8cr)
+- _Security:_ Open redirect on login and other post-action flows via the `redirect_to` query parameter. [#8322](https://github.com/gogs/gogs/pull/8322) - [GHSA-xxhq-69mf-w8cr](https://github.com/gogs/gogs/security/advisories/GHSA-xxhq-69mf-w8cr)
 
 ### Removed
 

--- a/internal/urlx/urlx.go
+++ b/internal/urlx/urlx.go
@@ -3,14 +3,7 @@ package urlx
 import "strings"
 
 // IsSameSite returns true if the URL path belongs to the same site.
-//
-// Browsers normalize backslashes (including percent-encoded ones) to forward
-// slashes on the Location header, so inputs like "/a/../\example.com" become
-// "/a/..//example.com" and then resolve to the cross-origin "//example.com".
-// Mirror that normalization, then require a single leading "/" with no "//"
-// runs that traversal could later expose.
 func IsSameSite(rawURL string) bool {
-	r := strings.NewReplacer(`\`, "/", "%5C", "/", "%5c", "/")
-	p := r.Replace(rawURL)
+	p := strings.NewReplacer(`\`, "/", "%5C", "/", "%5c", "/").Replace(rawURL)
 	return strings.HasPrefix(p, "/") && !strings.Contains(p, "//")
 }

--- a/internal/urlx/urlx.go
+++ b/internal/urlx/urlx.go
@@ -4,6 +4,9 @@ import "strings"
 
 // IsSameSite returns true if the URL path belongs to the same site.
 func IsSameSite(rawURL string) bool {
-	p := strings.NewReplacer(`\`, "/", "%5C", "/", "%5c", "/").Replace(rawURL)
+	p := strings.NewReplacer(
+		`\`, "/", "%5C", "/", "%5c", "/",
+		"\t", "", "\n", "", "\r", "",
+	).Replace(rawURL)
 	return strings.HasPrefix(p, "/") && !strings.Contains(p, "//")
 }

--- a/internal/urlx/urlx.go
+++ b/internal/urlx/urlx.go
@@ -1,6 +1,33 @@
 package urlx
 
+import (
+	"net/url"
+	"path"
+	"strings"
+)
+
 // IsSameSite returns true if the URL path belongs to the same site.
-func IsSameSite(url string) bool {
-	return len(url) >= 2 && url[0] == '/' && url[1] != '/' && url[1] != '\\'
+//
+// Browsers normalize backslashes to forward slashes before resolving a URL,
+// so any backslash in the input could turn what looks like a same-site path
+// into a protocol-relative cross-origin URL (e.g. "/a/../\example.com" becomes
+// "//example.com" after normalization). Reject backslashes outright and parse
+// the input to ensure it has no scheme or host, then resolve "." and ".."
+// segments so traversal cannot escape the leading "/".
+func IsSameSite(rawURL string) bool {
+	if len(rawURL) < 2 || rawURL[0] != '/' || rawURL[1] == '/' {
+		return false
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	if u.Scheme != "" || u.Host != "" {
+		return false
+	}
+	if strings.ContainsRune(rawURL, '\\') || strings.ContainsRune(u.Path, '\\') {
+		return false
+	}
+	cleaned := path.Clean(u.Path)
+	return strings.HasPrefix(cleaned, "/") && !strings.HasPrefix(cleaned, "//")
 }

--- a/internal/urlx/urlx.go
+++ b/internal/urlx/urlx.go
@@ -1,23 +1,16 @@
 package urlx
 
-import (
-	"net/url"
-	"strings"
-)
+import "strings"
 
 // IsSameSite returns true if the URL path belongs to the same site.
 //
-// Browsers normalize backslashes to forward slashes on the Location header,
-// so inputs like "/a/../\example.com" become "/a/..//example.com" and then
-// resolve to the cross-origin "//example.com". Apply the same backslash
-// normalization first, then require the result to parse as a relative URL
-// (no scheme, no host) whose path starts with a single "/" and contains no
-// "//" runs that traversal could later expose.
+// Browsers normalize backslashes (including percent-encoded ones) to forward
+// slashes on the Location header, so inputs like "/a/../\example.com" become
+// "/a/..//example.com" and then resolve to the cross-origin "//example.com".
+// Mirror that normalization, then require a single leading "/" with no "//"
+// runs that traversal could later expose.
 func IsSameSite(rawURL string) bool {
-	u, err := url.Parse(strings.ReplaceAll(rawURL, `\`, "/"))
-	if err != nil || u.Scheme != "" || u.Host != "" {
-		return false
-	}
-	p := strings.ReplaceAll(u.Path, `\`, "/")
+	r := strings.NewReplacer(`\`, "/", "%5C", "/", "%5c", "/")
+	p := r.Replace(rawURL)
 	return strings.HasPrefix(p, "/") && !strings.Contains(p, "//")
 }

--- a/internal/urlx/urlx.go
+++ b/internal/urlx/urlx.go
@@ -2,32 +2,22 @@ package urlx
 
 import (
 	"net/url"
-	"path"
 	"strings"
 )
 
 // IsSameSite returns true if the URL path belongs to the same site.
 //
-// Browsers normalize backslashes to forward slashes before resolving a URL,
-// so any backslash in the input could turn what looks like a same-site path
-// into a protocol-relative cross-origin URL (e.g. "/a/../\example.com" becomes
-// "//example.com" after normalization). Reject backslashes outright and parse
-// the input to ensure it has no scheme or host, then resolve "." and ".."
-// segments so traversal cannot escape the leading "/".
+// Browsers normalize backslashes to forward slashes on the Location header,
+// so inputs like "/a/../\example.com" become "/a/..//example.com" and then
+// resolve to the cross-origin "//example.com". Apply the same backslash
+// normalization first, then require the result to parse as a relative URL
+// (no scheme, no host) whose path starts with a single "/" and contains no
+// "//" runs that traversal could later expose.
 func IsSameSite(rawURL string) bool {
-	if len(rawURL) < 2 || rawURL[0] != '/' || rawURL[1] == '/' {
+	u, err := url.Parse(strings.ReplaceAll(rawURL, `\`, "/"))
+	if err != nil || u.Scheme != "" || u.Host != "" {
 		return false
 	}
-	u, err := url.Parse(rawURL)
-	if err != nil {
-		return false
-	}
-	if u.Scheme != "" || u.Host != "" {
-		return false
-	}
-	if strings.ContainsRune(rawURL, '\\') || strings.ContainsRune(u.Path, '\\') {
-		return false
-	}
-	cleaned := path.Clean(u.Path)
-	return strings.HasPrefix(cleaned, "/") && !strings.HasPrefix(cleaned, "//")
+	p := strings.ReplaceAll(u.Path, `\`, "/")
+	return strings.HasPrefix(p, "/") && !strings.Contains(p, "//")
 }

--- a/internal/urlx/urlx_test.go
+++ b/internal/urlx/urlx_test.go
@@ -15,9 +15,19 @@ func TestIsSameSite(t *testing.T) {
 		{url: "http://github.com", want: false},
 		{url: "https://github.com", want: false},
 		{url: "/\\github.com", want: false},
+		{url: "/a/../\\example.com", want: false},
+		{url: "/\\\\example.com", want: false},
+		{url: "/%5Cexample.com", want: false},
+		{url: "/a/..%5Cexample.com", want: false},
+		{url: "/a/../%5Cexample.com", want: false},
+		{url: "", want: false},
+		{url: "/", want: false},
+		{url: "javascript:alert(1)", want: false},
 
 		{url: "/admin", want: true},
 		{url: "/user/repo", want: true},
+		{url: "/user/repo?key=value", want: true},
+		{url: "/user/repo#anchor", want: true},
 	}
 
 	for _, test := range tests {

--- a/internal/urlx/urlx_test.go
+++ b/internal/urlx/urlx_test.go
@@ -14,20 +14,22 @@ func TestIsSameSite(t *testing.T) {
 		{url: "//github.com", want: false},
 		{url: "http://github.com", want: false},
 		{url: "https://github.com", want: false},
-		{url: "/\\github.com", want: false},
-		{url: "/a/../\\example.com", want: false},
-		{url: "/\\\\example.com", want: false},
-		{url: "/%5Cexample.com", want: false},
-		{url: "/a/..%5Cexample.com", want: false},
-		{url: "/a/../%5Cexample.com", want: false},
 		{url: "", want: false},
-		{url: "/", want: false},
 		{url: "javascript:alert(1)", want: false},
 
+		{url: "/", want: true},
 		{url: "/admin", want: true},
 		{url: "/user/repo", want: true},
 		{url: "/user/repo?key=value", want: true},
 		{url: "/user/repo#anchor", want: true},
+
+		// Backslash bypasses: browsers normalize `\` to `/` on Location headers.
+		{url: "/\\github.com", want: false},
+		{url: "/a/../\\example.com", want: false},
+		{url: "/\\\\example.com", want: false},
+		// Percent-encoded backslashes decode after url.Parse, so they're caught too.
+		{url: "/%5Cexample.com", want: false},
+		{url: "/a/../%5Cexample.com", want: false},
 	}
 
 	for _, test := range tests {

--- a/internal/urlx/urlx_test.go
+++ b/internal/urlx/urlx_test.go
@@ -27,9 +27,16 @@ func TestIsSameSite(t *testing.T) {
 		{url: "/\\github.com", want: false},
 		{url: "/a/../\\example.com", want: false},
 		{url: "/\\\\example.com", want: false},
-		// Percent-encoded backslashes decode after url.Parse, so they're caught too.
+		// Percent-encoded backslashes decode after c.Query, so they're caught too.
 		{url: "/%5Cexample.com", want: false},
+		{url: "/%5cexample.com", want: false},
 		{url: "/a/../%5Cexample.com", want: false},
+
+		// Whitespace bypasses: browsers strip tab/CR/LF before resolving.
+		{url: "/\t/example.com", want: false},
+		{url: "/\n/example.com", want: false},
+		{url: "/\r/example.com", want: false},
+		{url: "/\texample.com", want: true},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Summary

Harden the same-site URL validation used by `redirect_to` flows so it cannot be tricked into approving cross-origin destinations.

## Test plan

- [x] `go test ./internal/urlx/...`
- [x] `moon run gogs:lint`
- [x] New test cases cover the reported bypass and several variants.

Refs [GHSA-xxhq-69mf-w8cr](https://github.com/gogs/gogs/security/advisories/GHSA-xxhq-69mf-w8cr).