### PR TITLE
security: rotate session ID on authentication boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable changes to Gogs are documented in this file.
 - _Security:_ Organization team and member management actions accepted GET requests, allowing a logged-in owner to be tricked into adding an attacker to the Owners team via a crafted link. [#8321](https://github.com/gogs/gogs/pull/8321) - [GHSA-pwx3-qcgw-vh7h](https://github.com/gogs/gogs/security/advisories/GHSA-pwx3-qcgw-vh7h)
 - _Security:_ SSRF via mirror address update bypassing clone address validation. [#8225](https://github.com/gogs/gogs/pull/8225) - [GHSA-wv27-2vqp-j7g5](https://github.com/gogs/gogs/security/advisories/GHSA-wv27-2vqp-j7g5)
 - _Security:_ Open redirect on login and other post-action flows via the `redirect_to` query parameter. [#8322](https://github.com/gogs/gogs/pull/8322) - [GHSA-xxhq-69mf-w8cr](https://github.com/gogs/gogs/security/advisories/GHSA-xxhq-69mf-w8cr)
-- _Security:_ Session fixation on sign-in allowed an attacker who could plant a session cookie on a victim to take over the account once the victim signed in. [#PRNUM](https://github.com/gogs/gogs/pull/PRNUM) - [GHSA-h48f-pxp7-c4mj](https://github.com/gogs/gogs/security/advisories/GHSA-h48f-pxp7-c4mj)
+- _Security:_ Session fixation on sign-in allowed an attacker who could plant a session cookie on a victim to take over the account once the victim signed in. [#8323](https://github.com/gogs/gogs/pull/8323) - [GHSA-h48f-pxp7-c4mj](https://github.com/gogs/gogs/security/advisories/GHSA-h48f-pxp7-c4mj)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to Gogs are documented in this file.
 - _Security:_ Organization team and member management actions accepted GET requests, allowing a logged-in owner to be tricked into adding an attacker to the Owners team via a crafted link. [#8321](https://github.com/gogs/gogs/pull/8321) - [GHSA-pwx3-qcgw-vh7h](https://github.com/gogs/gogs/security/advisories/GHSA-pwx3-qcgw-vh7h)
 - _Security:_ SSRF via mirror address update bypassing clone address validation. [#8225](https://github.com/gogs/gogs/pull/8225) - [GHSA-wv27-2vqp-j7g5](https://github.com/gogs/gogs/security/advisories/GHSA-wv27-2vqp-j7g5)
 - _Security:_ Open redirect on login and other post-action flows via the `redirect_to` query parameter. [#8322](https://github.com/gogs/gogs/pull/8322) - [GHSA-xxhq-69mf-w8cr](https://github.com/gogs/gogs/security/advisories/GHSA-xxhq-69mf-w8cr)
+- _Security:_ Session fixation on sign-in allowed an attacker who could plant a session cookie on a victim to take over the account once the victim signed in. [#PRNUM](https://github.com/gogs/gogs/pull/PRNUM) - [GHSA-h48f-pxp7-c4mj](https://github.com/gogs/gogs/security/advisories/GHSA-h48f-pxp7-c4mj)
 
 ### Removed
 

--- a/cmd/gogs/internal/web/webapi.go
+++ b/cmd/gogs/internal/web/webapi.go
@@ -46,24 +46,67 @@ func flamegoInjector(c flamego.Context) {
 	mc, _ := ctx.Value(webAPIMacaronKey{}).(*macaron.Context)
 	l, _ := ctx.Value(webAPILocaleKey{}).(i18n.Locale)
 	c.Map(user, sess, mc, l)
-	c.MapTo(flamegoSessionAdapter{sess: sess}, (*session.Session)(nil))
+	c.MapTo(&flamegoSessionAdapter{sess: sess, mc: mc}, (*session.Session)(nil))
 }
 
 // flamegoSessionAdapter exposes the underlying Macaron session via the Flamego
 // session interface so the captcha middleware (and any future Flamego-native
 // session consumer) can read/write the same session store the rest of the app
 // uses.
+//
+// rotated, when non-nil, is the freshly issued RawStore returned by
+// macaronsession.Store.RegenerateId. After rotation, reads and writes go to
+// it so the new session ID is what carries the authenticated state into
+// subsequent requests. The Macaron Sessioner middleware will still call
+// Release on the original RawStore at the end of the request, but the cookie
+// already points at the new ID by then, so that orphaned write is harmless.
 type flamegoSessionAdapter struct {
-	sess macaronsession.Store
+	sess    macaronsession.Store
+	mc      *macaron.Context
+	rotated macaronsession.RawStore
 }
 
-func (s flamegoSessionAdapter) ID() string                      { return s.sess.ID() }
-func (s flamegoSessionAdapter) Get(key interface{}) interface{} { return s.sess.Get(key) }
-func (s flamegoSessionAdapter) Set(key, val interface{})        { _ = s.sess.Set(key, val) }
-func (s flamegoSessionAdapter) SetFlash(val interface{})        { _ = s.sess.Set("_flash", val) }
-func (s flamegoSessionAdapter) Delete(key interface{})          { _ = s.sess.Delete(key) }
-func (s flamegoSessionAdapter) Flush()                          { _ = s.sess.Flush() }
-func (s flamegoSessionAdapter) Encode() ([]byte, error)         { return nil, nil }
+func (s *flamegoSessionAdapter) active() macaronsession.RawStore {
+	if s.rotated != nil {
+		return s.rotated
+	}
+	return s.sess
+}
+
+func (s *flamegoSessionAdapter) ID() string                      { return s.active().ID() }
+func (s *flamegoSessionAdapter) Get(key interface{}) interface{} { return s.active().Get(key) }
+func (s *flamegoSessionAdapter) Set(key, val interface{})        { _ = s.active().Set(key, val) }
+func (s *flamegoSessionAdapter) SetFlash(val interface{})        { _ = s.active().Set("_flash", val) }
+func (s *flamegoSessionAdapter) Delete(key interface{})          { _ = s.active().Delete(key) }
+func (s *flamegoSessionAdapter) Flush()                          { _ = s.active().Flush() }
+func (s *flamegoSessionAdapter) Encode() ([]byte, error)         { return nil, nil }
+
+// RegenerateID rotates the underlying Macaron session ID. Subsequent reads
+// and writes through the adapter target the new RawStore, and that store is
+// released so the next request can load it from the provider. Call this on
+// the authentication boundary (sign-in completion) to prevent session
+// fixation.
+func (s *flamegoSessionAdapter) RegenerateID() error {
+	raw, err := s.sess.RegenerateId(s.mc)
+	if err != nil {
+		return errors.Wrap(err, "regenerate session ID")
+	}
+	s.rotated = raw
+	return nil
+}
+
+// releaseRotated releases the rotated RawStore so the authenticated state
+// written through the adapter after RegenerateID is persisted under the new
+// session ID. Safe to call when no rotation happened.
+func (s *flamegoSessionAdapter) releaseRotated() error {
+	if s.rotated == nil {
+		return nil
+	}
+	if err := s.rotated.Release(); err != nil {
+		return errors.Wrap(err, "release rotated session")
+	}
+	return nil
+}
 
 func enforceWebAPIMaxBodySize(c flamego.Context) {
 	r := c.Request().Request

--- a/cmd/gogs/internal/web/webapi.go
+++ b/cmd/gogs/internal/web/webapi.go
@@ -46,23 +46,15 @@ func flamegoInjector(c flamego.Context) {
 	mc, _ := ctx.Value(webAPIMacaronKey{}).(*macaron.Context)
 	l, _ := ctx.Value(webAPILocaleKey{}).(i18n.Locale)
 	c.Map(user, sess, mc, l)
-	c.MapTo(&flamegoSessionAdapter{sess: sess, mc: mc}, (*session.Session)(nil))
+	c.MapTo(&flamegoSessionAdapter{sess: sess}, (*session.Session)(nil))
 }
 
 // flamegoSessionAdapter exposes the underlying Macaron session via the Flamego
 // session interface so the captcha middleware (and any future Flamego-native
 // session consumer) can read/write the same session store the rest of the app
 // uses.
-//
-// rotated, when non-nil, is the freshly issued RawStore returned by
-// macaronsession.Store.RegenerateId. After rotation, reads and writes go to
-// it so the new session ID is what carries the authenticated state into
-// subsequent requests. The Macaron Sessioner middleware will still call
-// Release on the original RawStore at the end of the request, but the cookie
-// already points at the new ID by then, so that orphaned write is harmless.
 type flamegoSessionAdapter struct {
 	sess    macaronsession.Store
-	mc      *macaron.Context
 	rotated macaronsession.RawStore
 }
 
@@ -81,13 +73,8 @@ func (s *flamegoSessionAdapter) Delete(key interface{})          { _ = s.active(
 func (s *flamegoSessionAdapter) Flush()                          { _ = s.active().Flush() }
 func (s *flamegoSessionAdapter) Encode() ([]byte, error)         { return nil, nil }
 
-// RegenerateID rotates the underlying Macaron session ID. Subsequent reads
-// and writes through the adapter target the new RawStore, and that store is
-// released so the next request can load it from the provider. Call this on
-// the authentication boundary (sign-in completion) to prevent session
-// fixation.
-func (s *flamegoSessionAdapter) RegenerateID() error {
-	raw, err := s.sess.RegenerateId(s.mc)
+func (s *flamegoSessionAdapter) RegenerateID(mc *macaron.Context) error {
+	raw, err := s.sess.RegenerateId(mc)
 	if err != nil {
 		return errors.Wrap(err, "regenerate session ID")
 	}
@@ -95,9 +82,6 @@ func (s *flamegoSessionAdapter) RegenerateID() error {
 	return nil
 }
 
-// releaseRotated releases the rotated RawStore so the authenticated state
-// written through the adapter after RegenerateID is persisted under the new
-// session ID. Safe to call when no rotation happened.
 func (s *flamegoSessionAdapter) releaseRotated() error {
 	if s.rotated == nil {
 		return nil

--- a/cmd/gogs/internal/web/webapi_user.go
+++ b/cmd/gogs/internal/web/webapi_user.go
@@ -293,21 +293,12 @@ func postUserSignIn(r *http.Request, sess session.Session, mc *macaron.Context, 
 	return http.StatusOK, &userSignInResponse{}, nil
 }
 
-// completeSignIn finalizes the sign-in session for u: rotates the session ID
-// to prevent fixation, writes the auth session, clears any in-flight MFA
-// state, and sets the login-status cookie. The caller is responsible for
-// navigating to a post-login destination via /redirect?to=.
 func completeSignIn(sess session.Session, mc *macaron.Context, u *database.User) error {
-	// Rotate the session ID on the authentication boundary so a pre-login
-	// session ID that may have been planted on the victim cannot be reused
-	// once the session is authenticated. The adapter routes the subsequent
-	// Set/Delete calls to the new RawStore so the authenticated state lands
-	// under the new session ID.
 	a, ok := sess.(*flamegoSessionAdapter)
 	if !ok {
 		return errors.New("session does not support ID rotation")
 	}
-	if err := a.RegenerateID(); err != nil {
+	if err := a.RegenerateID(mc); err != nil {
 		return err
 	}
 	a.Set("uid", u.ID)

--- a/cmd/gogs/internal/web/webapi_user.go
+++ b/cmd/gogs/internal/web/webapi_user.go
@@ -264,7 +264,7 @@ type userSignInResponse struct {
 	MFA bool `json:"mfa,omitempty"`
 }
 
-func postUserSignIn(r *http.Request, sess macaronsession.Store, mc *macaron.Context, l i18n.Locale, req userSignInRequest) (statusCode int, resp any, err error) {
+func postUserSignIn(r *http.Request, sess session.Session, mc *macaron.Context, l i18n.Locale, req userSignInRequest) (statusCode int, resp any, err error) {
 	u, err := database.Handle.Users().Authenticate(r.Context(), req.Username, req.Password, req.LoginSource)
 	if err != nil {
 		switch {
@@ -282,7 +282,7 @@ func postUserSignIn(r *http.Request, sess macaronsession.Store, mc *macaron.Cont
 	}
 
 	if database.Handle.TwoFactors().IsEnabled(r.Context(), u.ID) {
-		_ = sess.Set("mfaUserID", u.ID)
+		sess.Set("mfaUserID", u.ID)
 		return http.StatusOK, &userSignInResponse{MFA: true}, nil
 	}
 
@@ -297,19 +297,24 @@ func postUserSignIn(r *http.Request, sess macaronsession.Store, mc *macaron.Cont
 // to prevent fixation, writes the auth session, clears any in-flight MFA
 // state, and sets the login-status cookie. The caller is responsible for
 // navigating to a post-login destination via /redirect?to=.
-func completeSignIn(sess macaronsession.Store, mc *macaron.Context, u *database.User) error {
-	// Rotate the session ID on authentication boundary so a pre-login session
-	// ID that may have been planted on the victim cannot be reused once the
-	// session is authenticated.
-	raw, err := sess.RegenerateId(mc)
-	if err != nil {
-		return errors.Wrap(err, "regenerate session ID")
+func completeSignIn(sess session.Session, mc *macaron.Context, u *database.User) error {
+	// Rotate the session ID on the authentication boundary so a pre-login
+	// session ID that may have been planted on the victim cannot be reused
+	// once the session is authenticated. The adapter routes the subsequent
+	// Set/Delete calls to the new RawStore so the authenticated state lands
+	// under the new session ID.
+	a, ok := sess.(*flamegoSessionAdapter)
+	if !ok {
+		return errors.New("session does not support ID rotation")
 	}
-	_ = raw.Set("uid", u.ID)
-	_ = raw.Set("uname", u.Name)
-	_ = raw.Delete("mfaUserID")
-	if err := raw.Release(); err != nil {
-		return errors.Wrap(err, "release session")
+	if err := a.RegenerateID(); err != nil {
+		return err
+	}
+	a.Set("uid", u.ID)
+	a.Set("uname", u.Name)
+	a.Delete("mfaUserID")
+	if err := a.releaseRotated(); err != nil {
+		return err
 	}
 
 	if conf.Security.EnableLoginStatusCookie {
@@ -331,7 +336,7 @@ type userMFARequest struct {
 
 type userMFAResponse struct{}
 
-func postUserMFA(r *http.Request, sess macaronsession.Store, mc *macaron.Context, ca cache.Cache, l i18n.Locale, req userMFARequest) (statusCode int, resp any, err error) {
+func postUserMFA(r *http.Request, sess session.Session, mc *macaron.Context, ca cache.Cache, l i18n.Locale, req userMFARequest) (statusCode int, resp any, err error) {
 	userID, ok := sess.Get("mfaUserID").(int64)
 	if !ok {
 		return http.StatusUnauthorized, &bindingErrorResponse{Error: l.Tr("auth.mfa_session_expired")}, nil
@@ -385,7 +390,7 @@ type userMFARecoveryRequest struct {
 	RecoveryCode string `json:"recoveryCode" validate:"required,len=11"`
 }
 
-func postUserMFARecovery(r *http.Request, sess macaronsession.Store, mc *macaron.Context, l i18n.Locale, req userMFARecoveryRequest) (statusCode int, resp any, err error) {
+func postUserMFARecovery(r *http.Request, sess session.Session, mc *macaron.Context, l i18n.Locale, req userMFARecoveryRequest) (statusCode int, resp any, err error) {
 	userID, ok := sess.Get("mfaUserID").(int64)
 	if !ok {
 		return http.StatusUnauthorized, &bindingErrorResponse{Error: l.Tr("auth.mfa_session_expired")}, nil
@@ -494,7 +499,7 @@ type userActivateCompleteRequest struct {
 	Code string `json:"code" validate:"required"`
 }
 
-func postUserActivateComplete(r *http.Request, sess macaronsession.Store, mc *macaron.Context, l i18n.Locale, req userActivateCompleteRequest) (statusCode int, resp any, err error) {
+func postUserActivateComplete(r *http.Request, sess session.Session, mc *macaron.Context, l i18n.Locale, req userActivateCompleteRequest) (statusCode int, resp any, err error) {
 	target := verifyUserActiveCode(r.Context(), req.Code)
 	if target == nil {
 		return http.StatusBadRequest, &bindingErrorResponse{Error: l.Tr("auth.invalid_code")}, nil

--- a/cmd/gogs/internal/web/webapi_user.go
+++ b/cmd/gogs/internal/web/webapi_user.go
@@ -264,7 +264,7 @@ type userSignInResponse struct {
 	MFA bool `json:"mfa,omitempty"`
 }
 
-func postUserSignIn(r *http.Request, sess session.Session, mc *macaron.Context, l i18n.Locale, req userSignInRequest) (statusCode int, resp any, err error) {
+func postUserSignIn(r *http.Request, sess macaronsession.Store, mc *macaron.Context, l i18n.Locale, req userSignInRequest) (statusCode int, resp any, err error) {
 	u, err := database.Handle.Users().Authenticate(r.Context(), req.Username, req.Password, req.LoginSource)
 	if err != nil {
 		switch {
@@ -282,26 +282,40 @@ func postUserSignIn(r *http.Request, sess session.Session, mc *macaron.Context, 
 	}
 
 	if database.Handle.TwoFactors().IsEnabled(r.Context(), u.ID) {
-		sess.Set("mfaUserID", u.ID)
+		_ = sess.Set("mfaUserID", u.ID)
 		return http.StatusOK, &userSignInResponse{MFA: true}, nil
 	}
 
-	completeSignIn(sess, mc, u)
+	if err := completeSignIn(sess, mc, u); err != nil {
+		log.Error("postUserSignIn: complete sign-in for user %q: %v", u.Name, err)
+		return http.StatusInternalServerError, nil, errors.Wrap(err, "complete sign-in")
+	}
 	return http.StatusOK, &userSignInResponse{}, nil
 }
 
-// completeSignIn finalizes the sign-in session for u: writes the auth session,
-// clears any in-flight MFA state, and sets the login-status cookie. The
-// caller is responsible for navigating to a post-login destination via
-// /redirect?to=.
-func completeSignIn(sess session.Session, mc *macaron.Context, u *database.User) {
-	sess.Set("uid", u.ID)
-	sess.Set("uname", u.Name)
-	sess.Delete("mfaUserID")
+// completeSignIn finalizes the sign-in session for u: rotates the session ID
+// to prevent fixation, writes the auth session, clears any in-flight MFA
+// state, and sets the login-status cookie. The caller is responsible for
+// navigating to a post-login destination via /redirect?to=.
+func completeSignIn(sess macaronsession.Store, mc *macaron.Context, u *database.User) error {
+	// Rotate the session ID on authentication boundary so a pre-login session
+	// ID that may have been planted on the victim cannot be reused once the
+	// session is authenticated.
+	raw, err := sess.RegenerateId(mc)
+	if err != nil {
+		return errors.Wrap(err, "regenerate session ID")
+	}
+	_ = raw.Set("uid", u.ID)
+	_ = raw.Set("uname", u.Name)
+	_ = raw.Delete("mfaUserID")
+	if err := raw.Release(); err != nil {
+		return errors.Wrap(err, "release session")
+	}
 
 	if conf.Security.EnableLoginStatusCookie {
 		mc.SetCookie(conf.Security.LoginStatusCookieName, "true", 0, conf.Server.Subpath)
 	}
+	return nil
 }
 
 func getUserMFA(sess session.Session) (statusCode int, resp any, err error) {
@@ -317,7 +331,7 @@ type userMFARequest struct {
 
 type userMFAResponse struct{}
 
-func postUserMFA(r *http.Request, sess session.Session, mc *macaron.Context, ca cache.Cache, l i18n.Locale, req userMFARequest) (statusCode int, resp any, err error) {
+func postUserMFA(r *http.Request, sess macaronsession.Store, mc *macaron.Context, ca cache.Cache, l i18n.Locale, req userMFARequest) (statusCode int, resp any, err error) {
 	userID, ok := sess.Get("mfaUserID").(int64)
 	if !ok {
 		return http.StatusUnauthorized, &bindingErrorResponse{Error: l.Tr("auth.mfa_session_expired")}, nil
@@ -360,7 +374,10 @@ func postUserMFA(r *http.Request, sess session.Session, mc *macaron.Context, ca 
 		return http.StatusInternalServerError, nil, errors.Wrap(err, "get user by ID")
 	}
 
-	completeSignIn(sess, mc, u)
+	if err := completeSignIn(sess, mc, u); err != nil {
+		log.Error("postUserMFA: complete sign-in for user %q: %v", u.Name, err)
+		return http.StatusInternalServerError, nil, errors.Wrap(err, "complete sign-in")
+	}
 	return http.StatusOK, &userMFAResponse{}, nil
 }
 
@@ -368,7 +385,7 @@ type userMFARecoveryRequest struct {
 	RecoveryCode string `json:"recoveryCode" validate:"required,len=11"`
 }
 
-func postUserMFARecovery(r *http.Request, sess session.Session, mc *macaron.Context, l i18n.Locale, req userMFARecoveryRequest) (statusCode int, resp any, err error) {
+func postUserMFARecovery(r *http.Request, sess macaronsession.Store, mc *macaron.Context, l i18n.Locale, req userMFARecoveryRequest) (statusCode int, resp any, err error) {
 	userID, ok := sess.Get("mfaUserID").(int64)
 	if !ok {
 		return http.StatusUnauthorized, &bindingErrorResponse{Error: l.Tr("auth.mfa_session_expired")}, nil
@@ -391,7 +408,10 @@ func postUserMFARecovery(r *http.Request, sess session.Session, mc *macaron.Cont
 		return http.StatusInternalServerError, nil, errors.Wrap(err, "get user by ID")
 	}
 
-	completeSignIn(sess, mc, u)
+	if err := completeSignIn(sess, mc, u); err != nil {
+		log.Error("postUserMFARecovery: complete sign-in for user %q: %v", u.Name, err)
+		return http.StatusInternalServerError, nil, errors.Wrap(err, "complete sign-in")
+	}
 	return http.StatusOK, &userMFAResponse{}, nil
 }
 
@@ -474,7 +494,7 @@ type userActivateCompleteRequest struct {
 	Code string `json:"code" validate:"required"`
 }
 
-func postUserActivateComplete(r *http.Request, sess session.Session, mc *macaron.Context, l i18n.Locale, req userActivateCompleteRequest) (statusCode int, resp any, err error) {
+func postUserActivateComplete(r *http.Request, sess macaronsession.Store, mc *macaron.Context, l i18n.Locale, req userActivateCompleteRequest) (statusCode int, resp any, err error) {
 	target := verifyUserActiveCode(r.Context(), req.Code)
 	if target == nil {
 		return http.StatusBadRequest, &bindingErrorResponse{Error: l.Tr("auth.invalid_code")}, nil
@@ -494,7 +514,10 @@ func postUserActivateComplete(r *http.Request, sess session.Session, mc *macaron
 	}
 
 	log.Trace("User activated: %s", target.Name)
-	completeSignIn(sess, mc, target)
+	if err := completeSignIn(sess, mc, target); err != nil {
+		log.Error("postUserActivateComplete: complete sign-in for user %q: %v", target.Name, err)
+		return http.StatusInternalServerError, nil, errors.Wrap(err, "complete sign-in")
+	}
 	return http.StatusNoContent, nil, nil
 }
 

--- a/internal/route/install.go
+++ b/internal/route/install.go
@@ -410,9 +410,21 @@ func InstallPost(c *context.Context, f form.Install) {
 			}
 		}
 
-		// Auto-login for admin
-		_ = c.Session.Set("uid", user.ID)
-		_ = c.Session.Set("uname", user.Name)
+		// Auto-login for admin. Rotate the session ID on the authentication
+		// boundary to prevent session fixation.
+		raw, err := c.Session.RegenerateId(c.Context)
+		if err != nil {
+			log.Error("Failed to regenerate session ID: %v", err)
+			c.Error(err, "regenerate session ID")
+			return
+		}
+		_ = raw.Set("uid", user.ID)
+		_ = raw.Set("uname", user.Name)
+		if err = raw.Release(); err != nil {
+			log.Error("Failed to release session: %v", err)
+			c.Error(err, "release session")
+			return
+		}
 	}
 
 	log.Info("First-time run install finished!")

--- a/internal/route/install.go
+++ b/internal/route/install.go
@@ -410,8 +410,7 @@ func InstallPost(c *context.Context, f form.Install) {
 			}
 		}
 
-		// Auto-login for admin. Rotate the session ID on the authentication
-		// boundary to prevent session fixation.
+		// Auto-login for admin.
 		raw, err := c.Session.RegenerateId(c.Context)
 		if err != nil {
 			log.Error("Failed to regenerate session ID: %v", err)


### PR DESCRIPTION
## Summary

- Fixes [GHSA-h48f-pxp7-c4mj](https://github.com/gogs/gogs/security/advisories/GHSA-h48f-pxp7-c4mj). Gogs did not rotate the session ID when a session crossed the authentication boundary, so an attacker who could plant a session cookie on the victim (subdomain XSS, network position, social engineering) could reuse that same cookie to ride the session once the victim signed in.
- `completeSignIn` and the install-time admin auto-login path now call `Session.RegenerateId` before writing `uid`/`uname` and release the new store so the authenticated state lands under a fresh session ID. The pre-login cookie value becomes inert.
- Same fix is applied to the MFA TOTP, MFA recovery, and account-activation completion paths, which all flow through `completeSignIn`.

## Test plan

- [x] `moon run gogs:build` — succeeds
- [x] `moon run gogs:lint` — clean
- [x] `go test ./cmd/gogs/internal/web/... ./internal/route/...` — passes
- [ ] Manual: capture the `i_like_gogs` cookie on the sign-in page while signed out, sign in, confirm `Set-Cookie: i_like_gogs=...` is reissued with a new value and the old value can no longer be used to access an authenticated page.
- [ ] Manual: same check for the MFA TOTP and recovery flows.
- [ ] Manual: same check for the first-time install admin auto-login.