### PR TITLE
security: close SSRF in repository migration and recurring mirror sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to Gogs are documented in this file.
 - _Security:_ SSRF via mirror address update bypassing clone address validation. [#8225](https://github.com/gogs/gogs/pull/8225) - [GHSA-wv27-2vqp-j7g5](https://github.com/gogs/gogs/security/advisories/GHSA-wv27-2vqp-j7g5)
 - _Security:_ Open redirect on login and other post-action flows via the `redirect_to` query parameter. [#8322](https://github.com/gogs/gogs/pull/8322) - [GHSA-xxhq-69mf-w8cr](https://github.com/gogs/gogs/security/advisories/GHSA-xxhq-69mf-w8cr)
 - _Security:_ Privilege escalation to repository owner via collaboration access mode update. [#8227](https://github.com/gogs/gogs/pull/8227) - [GHSA-4565-r4x7-hg8j](https://github.com/gogs/gogs/security/advisories/GHSA-4565-r4x7-hg8j)
-- _Security:_ SSRF in repository migration via HTTP redirect to blocked internal address. [#PLACEHOLDER](https://github.com/gogs/gogs/pull/PLACEHOLDER) - [GHSA-g2f5-gjr4-qjvm](https://github.com/gogs/gogs/security/advisories/GHSA-g2f5-gjr4-qjvm)
+- _Security:_ SSRF in repository migration via HTTP redirect to blocked internal address. [#8324](https://github.com/gogs/gogs/pull/8324) - [GHSA-g2f5-gjr4-qjvm](https://github.com/gogs/gogs/security/advisories/GHSA-g2f5-gjr4-qjvm)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to Gogs are documented in this file.
 - _Security:_ SSRF via mirror address update bypassing clone address validation. [#8225](https://github.com/gogs/gogs/pull/8225) - [GHSA-wv27-2vqp-j7g5](https://github.com/gogs/gogs/security/advisories/GHSA-wv27-2vqp-j7g5)
 - _Security:_ Open redirect on login and other post-action flows via the `redirect_to` query parameter. [#8322](https://github.com/gogs/gogs/pull/8322) - [GHSA-xxhq-69mf-w8cr](https://github.com/gogs/gogs/security/advisories/GHSA-xxhq-69mf-w8cr)
 - _Security:_ Privilege escalation to repository owner via collaboration access mode update. [#8227](https://github.com/gogs/gogs/pull/8227) - [GHSA-4565-r4x7-hg8j](https://github.com/gogs/gogs/security/advisories/GHSA-4565-r4x7-hg8j)
-- _Security:_ SSRF in repository migration via HTTP redirect to blocked internal address. [#8324](https://github.com/gogs/gogs/pull/8324) - [GHSA-g2f5-gjr4-qjvm](https://github.com/gogs/gogs/security/advisories/GHSA-g2f5-gjr4-qjvm)
+- _Security:_ SSRF in repository migration and recurring mirror sync via HTTP redirects and stale host validation on stored mirror URLs. [#8324](https://github.com/gogs/gogs/pull/8324) - [GHSA-g2f5-gjr4-qjvm](https://github.com/gogs/gogs/security/advisories/GHSA-g2f5-gjr4-qjvm)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to Gogs are documented in this file.
 - _Security:_ SSRF via mirror address update bypassing clone address validation. [#8225](https://github.com/gogs/gogs/pull/8225) - [GHSA-wv27-2vqp-j7g5](https://github.com/gogs/gogs/security/advisories/GHSA-wv27-2vqp-j7g5)
 - _Security:_ Open redirect on login and other post-action flows via the `redirect_to` query parameter. [#8322](https://github.com/gogs/gogs/pull/8322) - [GHSA-xxhq-69mf-w8cr](https://github.com/gogs/gogs/security/advisories/GHSA-xxhq-69mf-w8cr)
 - _Security:_ Privilege escalation to repository owner via collaboration access mode update. [#8227](https://github.com/gogs/gogs/pull/8227) - [GHSA-4565-r4x7-hg8j](https://github.com/gogs/gogs/security/advisories/GHSA-4565-r4x7-hg8j)
+- _Security:_ SSRF in repository migration via HTTP redirect to blocked internal address. [#PLACEHOLDER](https://github.com/gogs/gogs/pull/PLACEHOLDER) - [GHSA-g2f5-gjr4-qjvm](https://github.com/gogs/gogs/security/advisories/GHSA-g2f5-gjr4-qjvm)
 
 ### Removed
 

--- a/internal/database/mirror.go
+++ b/internal/database/mirror.go
@@ -226,12 +226,24 @@ func mirrorGitArgs() []string {
 	return []string{"-c", "http.followRedirects=false"}
 }
 
+// mirrorGitEnv returns environment variables that keep git non-interactive
+// during mirror operations. Without these, a network failure or a missing
+// remote endpoint can make git ask for credentials and stall the server-side
+// process waiting on a terminal that never responds.
+func mirrorGitEnv() []string {
+	return []string{
+		"GIT_TERMINAL_PROMPT=0",
+		"GIT_ASKPASS=/bin/true",
+		"GCM_INTERACTIVE=Never",
+	}
+}
+
 // isMirrorURLAccessible reports whether the given remote URL is reachable
 // without following HTTP redirects, matching the redirect policy used by the
 // mirror clone and sync.
 func isMirrorURLAccessible(timeout time.Duration, url string) bool {
 	args := append(mirrorGitArgs(), "ls-remote", "--quiet", "--end-of-options", url, "HEAD")
-	_, _, err := process.ExecTimeout(timeout, fmt.Sprintf("isMirrorURLAccessible: %s", url), "git", args...)
+	_, _, err := process.ExecTimeoutEnv(timeout, mirrorGitEnv(), fmt.Sprintf("isMirrorURLAccessible: %s", url), "git", args...)
 	return err == nil
 }
 
@@ -271,8 +283,8 @@ func (m *Mirror) runSync() ([]*mirrorSyncResult, bool) {
 	if m.EnablePrune {
 		gitArgs = append(gitArgs, "--prune")
 	}
-	_, stderr, err := process.ExecDir(
-		timeout, repoPath, fmt.Sprintf("Mirror.runSync: %s", repoPath),
+	_, stderr, err := process.ExecDirEnv(
+		timeout, repoPath, mirrorGitEnv(), fmt.Sprintf("Mirror.runSync: %s", repoPath),
 		"git", gitArgs...)
 	if err != nil {
 		const fmtStr = "Failed to update mirror repository %q: %s"
@@ -295,8 +307,8 @@ func (m *Mirror) runSync() ([]*mirrorSyncResult, bool) {
 	if m.Repo.HasWiki() {
 		wikiArgs := append(mirrorGitArgs(), "remote", "update", "--prune")
 		// Even if wiki sync failed, we still want results from the main repository
-		if _, stderr, err := process.ExecDir(
-			timeout, wikiPath, fmt.Sprintf("Mirror.runSync: %s", wikiPath),
+		if _, stderr, err := process.ExecDirEnv(
+			timeout, wikiPath, mirrorGitEnv(), fmt.Sprintf("Mirror.runSync: %s", wikiPath),
 			"git", wikiArgs...); err != nil {
 			const fmtStr = "Failed to update mirror wiki repository %q: %s"
 			log.Error(fmtStr, wikiPath, stderr)

--- a/internal/database/mirror.go
+++ b/internal/database/mirror.go
@@ -217,6 +217,24 @@ func parseRemoteUpdateOutput(output string) []*mirrorSyncResult {
 	return results
 }
 
+// mirrorGitArgs returns the git-level arguments used by every remote network
+// operation against a mirror source.
+func mirrorGitArgs() []string {
+	// Disabling HTTP redirects prevents an attacker-controlled public URL from
+	// redirecting to an internal endpoint that the up-front clone address
+	// validation would otherwise have blocked.
+	return []string{"-c", "http.followRedirects=false"}
+}
+
+// isMirrorURLAccessible reports whether the given remote URL is reachable
+// without following HTTP redirects, matching the redirect policy used by the
+// mirror clone and sync.
+func isMirrorURLAccessible(timeout time.Duration, url string) bool {
+	args := append(mirrorGitArgs(), "ls-remote", "--quiet", "--end-of-options", url, "HEAD")
+	_, _, err := process.ExecTimeout(timeout, fmt.Sprintf("isMirrorURLAccessible: %s", url), "git", args...)
+	return err == nil
+}
+
 // runSync returns true if sync finished without error.
 func (m *Mirror) runSync() ([]*mirrorSyncResult, bool) {
 	repoPath := m.Repo.RepoPath()

--- a/internal/database/mirror.go
+++ b/internal/database/mirror.go
@@ -241,7 +241,7 @@ func (m *Mirror) runSync() ([]*mirrorSyncResult, bool) {
 
 	// Do a fast-fail testing against on repository URL to ensure it is accessible under
 	// good condition to prevent long blocking on URL resolution without syncing anything.
-	if !isMigrationURLAccessible(time.Minute, rawAddr) {
+	if !isMirrorURLAccessible(time.Minute, rawAddr) {
 		desc := fmt.Sprintf("Source URL of mirror repository '%s' is not accessible: %s", m.Repo.FullName(), m.MosaicsAddress())
 		if err := Handle.Notices().Create(context.TODO(), NoticeTypeRepository, desc); err != nil {
 			log.Error("CreateRepositoryNotice: %v", err)
@@ -249,7 +249,7 @@ func (m *Mirror) runSync() ([]*mirrorSyncResult, bool) {
 		return nil, false
 	}
 
-	gitArgs := append(migrationGitArgs(), "remote", "update")
+	gitArgs := append(mirrorGitArgs(), "remote", "update")
 	if m.EnablePrune {
 		gitArgs = append(gitArgs, "--prune")
 	}
@@ -275,7 +275,7 @@ func (m *Mirror) runSync() ([]*mirrorSyncResult, bool) {
 	}
 
 	if m.Repo.HasWiki() {
-		wikiArgs := append(migrationGitArgs(), "remote", "update", "--prune")
+		wikiArgs := append(mirrorGitArgs(), "remote", "update", "--prune")
 		// Even if wiki sync failed, we still want results from the main repository
 		if _, stderr, err := process.ExecDir(
 			timeout, wikiPath, fmt.Sprintf("Mirror.runSync: %s", wikiPath),

--- a/internal/database/mirror.go
+++ b/internal/database/mirror.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gogs/git-module"
 
 	"gogs.io/gogs/internal/conf"
+	"gogs.io/gogs/internal/netx"
 	"gogs.io/gogs/internal/process"
 	"gogs.io/gogs/internal/sync"
 )
@@ -222,9 +223,25 @@ func (m *Mirror) runSync() ([]*mirrorSyncResult, bool) {
 	wikiPath := m.Repo.WikiPath()
 	timeout := time.Duration(conf.Git.Timeout.Mirror) * time.Second
 
+	// Re-check the mirror address against the local-network blocklist on every
+	// sync. The address was validated when the mirror was created, but DNS for
+	// that hostname may have changed in the meantime to point at an internal
+	// host, so the up-front check is not sufficient on its own.
+	rawAddr := m.RawAddress()
+	if u, err := url.Parse(rawAddr); err == nil &&
+		(u.Scheme == "http" || u.Scheme == "https" || u.Scheme == "git") &&
+		netx.IsBlockedLocalHostname(u.Hostname(), conf.Security.LocalNetworkAllowlist) {
+		desc := fmt.Sprintf("Source URL of mirror repository '%s' resolves to a blocked local address: %s", m.Repo.FullName(), m.MosaicsAddress())
+		log.Error("Mirror.runSync: %s", desc)
+		if err := Handle.Notices().Create(context.TODO(), NoticeTypeRepository, desc); err != nil {
+			log.Error("CreateRepositoryNotice: %v", err)
+		}
+		return nil, false
+	}
+
 	// Do a fast-fail testing against on repository URL to ensure it is accessible under
 	// good condition to prevent long blocking on URL resolution without syncing anything.
-	if !git.IsURLAccessible(time.Minute, m.RawAddress()) {
+	if !isMigrationURLAccessible(time.Minute, rawAddr) {
 		desc := fmt.Sprintf("Source URL of mirror repository '%s' is not accessible: %s", m.Repo.FullName(), m.MosaicsAddress())
 		if err := Handle.Notices().Create(context.TODO(), NoticeTypeRepository, desc); err != nil {
 			log.Error("CreateRepositoryNotice: %v", err)
@@ -232,7 +249,7 @@ func (m *Mirror) runSync() ([]*mirrorSyncResult, bool) {
 		return nil, false
 	}
 
-	gitArgs := []string{"remote", "update"}
+	gitArgs := append(migrationGitArgs(), "remote", "update")
 	if m.EnablePrune {
 		gitArgs = append(gitArgs, "--prune")
 	}
@@ -258,10 +275,11 @@ func (m *Mirror) runSync() ([]*mirrorSyncResult, bool) {
 	}
 
 	if m.Repo.HasWiki() {
+		wikiArgs := append(migrationGitArgs(), "remote", "update", "--prune")
 		// Even if wiki sync failed, we still want results from the main repository
 		if _, stderr, err := process.ExecDir(
 			timeout, wikiPath, fmt.Sprintf("Mirror.runSync: %s", wikiPath),
-			"git", "remote", "update", "--prune"); err != nil {
+			"git", wikiArgs...); err != nil {
 			const fmtStr = "Failed to update mirror wiki repository %q: %s"
 			log.Error(fmtStr, wikiPath, stderr)
 			if err = Handle.Notices().Create(

--- a/internal/database/repo.go
+++ b/internal/database/repo.go
@@ -784,24 +784,6 @@ type MigrateRepoOptions struct {
 */
 var commonWikiURLSuffixes = []string{".wiki.git", ".git/wiki"}
 
-// mirrorGitArgs returns the git-level arguments used by every remote network
-// operation during migration.
-func mirrorGitArgs() []string {
-	// Disabling HTTP redirects prevents an attacker-controlled public URL from
-	// redirecting to an internal endpoint that the up-front clone address
-	// validation would otherwise have blocked.
-	return []string{"-c", "http.followRedirects=false"}
-}
-
-// isMirrorURLAccessible reports whether the given remote URL is reachable
-// without following HTTP redirects, matching the redirect policy used by the
-// migration clone itself.
-func isMirrorURLAccessible(timeout time.Duration, url string) bool {
-	args := append(mirrorGitArgs(), "ls-remote", "--quiet", "--end-of-options", url, "HEAD")
-	_, _, err := process.ExecTimeout(timeout, fmt.Sprintf("isMirrorURLAccessible: %s", url), "git", args...)
-	return err == nil
-}
-
 // wikiRemoteURL returns accessible repository URL for wiki if exists.
 // Otherwise, it returns an empty string.
 func wikiRemoteURL(remote string) string {

--- a/internal/database/repo.go
+++ b/internal/database/repo.go
@@ -784,21 +784,21 @@ type MigrateRepoOptions struct {
 */
 var commonWikiURLSuffixes = []string{".wiki.git", ".git/wiki"}
 
-// migrationGitArgs returns the git-level arguments used by every remote network
+// mirrorGitArgs returns the git-level arguments used by every remote network
 // operation during migration.
-func migrationGitArgs() []string {
+func mirrorGitArgs() []string {
 	// Disabling HTTP redirects prevents an attacker-controlled public URL from
 	// redirecting to an internal endpoint that the up-front clone address
 	// validation would otherwise have blocked.
 	return []string{"-c", "http.followRedirects=false"}
 }
 
-// isMigrationURLAccessible reports whether the given remote URL is reachable
+// isMirrorURLAccessible reports whether the given remote URL is reachable
 // without following HTTP redirects, matching the redirect policy used by the
 // migration clone itself.
-func isMigrationURLAccessible(timeout time.Duration, url string) bool {
-	args := append(migrationGitArgs(), "ls-remote", "--quiet", "--end-of-options", url, "HEAD")
-	_, _, err := process.ExecTimeout(timeout, fmt.Sprintf("isMigrationURLAccessible: %s", url), "git", args...)
+func isMirrorURLAccessible(timeout time.Duration, url string) bool {
+	args := append(mirrorGitArgs(), "ls-remote", "--quiet", "--end-of-options", url, "HEAD")
+	_, _, err := process.ExecTimeout(timeout, fmt.Sprintf("isMirrorURLAccessible: %s", url), "git", args...)
 	return err == nil
 }
 
@@ -808,7 +808,7 @@ func wikiRemoteURL(remote string) string {
 	remote = strings.TrimSuffix(remote, ".git")
 	for _, suffix := range commonWikiURLSuffixes {
 		wikiURL := remote + suffix
-		if isMigrationURLAccessible(time.Minute, wikiURL) {
+		if isMirrorURLAccessible(time.Minute, wikiURL) {
 			return wikiURL
 		}
 	}
@@ -844,7 +844,7 @@ func MigrateRepository(doer, owner *User, opts MigrateRepoOptions) (*Repository,
 	migrateTimeout := time.Duration(conf.Git.Timeout.Migrate) * time.Second
 
 	RemoveAllWithNotice("Repository path erase before creation", repoPath)
-	cloneArgs := append(migrationGitArgs(), "clone", "--mirror", "--quiet", "--end-of-options", opts.RemoteAddr, repoPath)
+	cloneArgs := append(mirrorGitArgs(), "clone", "--mirror", "--quiet", "--end-of-options", opts.RemoteAddr, repoPath)
 	if _, stderr, err := process.ExecTimeout(migrateTimeout,
 		fmt.Sprintf("MigrateRepository 'git clone': %s/%s", owner.Name, opts.Name),
 		"git", cloneArgs...); err != nil {
@@ -854,7 +854,7 @@ func MigrateRepository(doer, owner *User, opts MigrateRepoOptions) (*Repository,
 	wikiRemotePath := wikiRemoteURL(opts.RemoteAddr)
 	if len(wikiRemotePath) > 0 {
 		RemoveAllWithNotice("Repository wiki path erase before creation", wikiPath)
-		wikiCloneArgs := append(migrationGitArgs(), "clone", "--mirror", "--quiet", "--end-of-options", wikiRemotePath, wikiPath)
+		wikiCloneArgs := append(mirrorGitArgs(), "clone", "--mirror", "--quiet", "--end-of-options", wikiRemotePath, wikiPath)
 		if _, stderr, err := process.ExecTimeout(migrateTimeout,
 			fmt.Sprintf("MigrateRepository 'git clone' wiki: %s/%s", owner.Name, opts.Name),
 			"git", wikiCloneArgs...); err != nil {

--- a/internal/database/repo.go
+++ b/internal/database/repo.go
@@ -784,13 +784,30 @@ type MigrateRepoOptions struct {
 */
 var commonWikiURLSuffixes = []string{".wiki.git", ".git/wiki"}
 
+// migrationGitArgs returns the git-level arguments used by every remote
+// network operation during migration. Disabling HTTP redirects prevents an
+// attacker-controlled public URL from redirecting to an internal endpoint
+// that the up-front clone address validation would otherwise have blocked.
+func migrationGitArgs() []string {
+	return []string{"-c", "http.followRedirects=false"}
+}
+
+// isMigrationURLAccessible reports whether the given remote URL is reachable
+// without following HTTP redirects, matching the redirect policy used by the
+// migration clone itself.
+func isMigrationURLAccessible(timeout time.Duration, url string) bool {
+	args := append(migrationGitArgs(), "ls-remote", "--quiet", "--end-of-options", url, "HEAD")
+	_, _, err := process.ExecTimeout(timeout, fmt.Sprintf("isMigrationURLAccessible: %s", url), "git", args...)
+	return err == nil
+}
+
 // wikiRemoteURL returns accessible repository URL for wiki if exists.
 // Otherwise, it returns an empty string.
 func wikiRemoteURL(remote string) string {
 	remote = strings.TrimSuffix(remote, ".git")
 	for _, suffix := range commonWikiURLSuffixes {
 		wikiURL := remote + suffix
-		if git.IsURLAccessible(time.Minute, wikiURL) {
+		if isMigrationURLAccessible(time.Minute, wikiURL) {
 			return wikiURL
 		}
 	}
@@ -826,23 +843,21 @@ func MigrateRepository(doer, owner *User, opts MigrateRepoOptions) (*Repository,
 	migrateTimeout := time.Duration(conf.Git.Timeout.Migrate) * time.Second
 
 	RemoveAllWithNotice("Repository path erase before creation", repoPath)
-	if err = git.Clone(opts.RemoteAddr, repoPath, git.CloneOptions{
-		Mirror:  true,
-		Quiet:   true,
-		Timeout: migrateTimeout,
-	}); err != nil {
-		return repo, errors.Newf("clone: %v", err)
+	cloneArgs := append(migrationGitArgs(), "clone", "--mirror", "--quiet", "--end-of-options", opts.RemoteAddr, repoPath)
+	if _, stderr, err := process.ExecTimeout(migrateTimeout,
+		fmt.Sprintf("MigrateRepository 'git clone': %s/%s", owner.Name, opts.Name),
+		"git", cloneArgs...); err != nil {
+		return repo, errors.Newf("clone: %v - %s", err, stderr)
 	}
 
 	wikiRemotePath := wikiRemoteURL(opts.RemoteAddr)
 	if len(wikiRemotePath) > 0 {
 		RemoveAllWithNotice("Repository wiki path erase before creation", wikiPath)
-		if err = git.Clone(wikiRemotePath, wikiPath, git.CloneOptions{
-			Mirror:  true,
-			Quiet:   true,
-			Timeout: migrateTimeout,
-		}); err != nil {
-			log.Error("Failed to clone wiki: %v", err)
+		wikiCloneArgs := append(migrationGitArgs(), "clone", "--mirror", "--quiet", "--end-of-options", wikiRemotePath, wikiPath)
+		if _, stderr, err := process.ExecTimeout(migrateTimeout,
+			fmt.Sprintf("MigrateRepository 'git clone' wiki: %s/%s", owner.Name, opts.Name),
+			"git", wikiCloneArgs...); err != nil {
+			log.Error("Failed to clone wiki: %v - %s", err, stderr)
 			RemoveAllWithNotice("Delete repository wiki for initialization failure", wikiPath)
 		}
 	}

--- a/internal/database/repo.go
+++ b/internal/database/repo.go
@@ -827,7 +827,7 @@ func MigrateRepository(doer, owner *User, opts MigrateRepoOptions) (*Repository,
 
 	RemoveAllWithNotice("Repository path erase before creation", repoPath)
 	cloneArgs := append(mirrorGitArgs(), "clone", "--mirror", "--quiet", "--end-of-options", opts.RemoteAddr, repoPath)
-	if _, stderr, err := process.ExecTimeout(migrateTimeout,
+	if _, stderr, err := process.ExecTimeoutEnv(migrateTimeout, mirrorGitEnv(),
 		fmt.Sprintf("MigrateRepository 'git clone': %s/%s", owner.Name, opts.Name),
 		"git", cloneArgs...); err != nil {
 		return repo, errors.Newf("clone: %v - %s", err, stderr)
@@ -837,7 +837,7 @@ func MigrateRepository(doer, owner *User, opts MigrateRepoOptions) (*Repository,
 	if len(wikiRemotePath) > 0 {
 		RemoveAllWithNotice("Repository wiki path erase before creation", wikiPath)
 		wikiCloneArgs := append(mirrorGitArgs(), "clone", "--mirror", "--quiet", "--end-of-options", wikiRemotePath, wikiPath)
-		if _, stderr, err := process.ExecTimeout(migrateTimeout,
+		if _, stderr, err := process.ExecTimeoutEnv(migrateTimeout, mirrorGitEnv(),
 			fmt.Sprintf("MigrateRepository 'git clone' wiki: %s/%s", owner.Name, opts.Name),
 			"git", wikiCloneArgs...); err != nil {
 			log.Error("Failed to clone wiki: %v - %s", err, stderr)

--- a/internal/database/repo.go
+++ b/internal/database/repo.go
@@ -784,11 +784,12 @@ type MigrateRepoOptions struct {
 */
 var commonWikiURLSuffixes = []string{".wiki.git", ".git/wiki"}
 
-// migrationGitArgs returns the git-level arguments used by every remote
-// network operation during migration. Disabling HTTP redirects prevents an
-// attacker-controlled public URL from redirecting to an internal endpoint
-// that the up-front clone address validation would otherwise have blocked.
+// migrationGitArgs returns the git-level arguments used by every remote network
+// operation during migration.
 func migrationGitArgs() []string {
+	// Disabling HTTP redirects prevents an attacker-controlled public URL from
+	// redirecting to an internal endpoint that the up-front clone address
+	// validation would otherwise have blocked.
 	return []string{"-c", "http.followRedirects=false"}
 }
 

--- a/internal/process/manager.go
+++ b/internal/process/manager.go
@@ -2,6 +2,7 @@ package process
 
 import (
 	"bytes"
+	"os"
 	"os/exec"
 	"sync"
 	"time"
@@ -71,6 +72,13 @@ func Remove(pid int64) bool {
 
 // Exec starts executing a shell command in given path, it tracks corresponding process and timeout.
 func ExecDir(timeout time.Duration, dir, desc, cmdName string, args ...string) (string, string, error) {
+	return ExecDirEnv(timeout, dir, nil, desc, cmdName, args...)
+}
+
+// ExecDirEnv is the same as ExecDir but allows appending additional environment
+// variables to the child process. Pass nil for env to inherit the parent
+// process environment unchanged.
+func ExecDirEnv(timeout time.Duration, dir string, env []string, desc, cmdName string, args ...string) (string, string, error) {
 	if timeout == -1 {
 		timeout = defaultTimeout
 	}
@@ -82,6 +90,9 @@ func ExecDir(timeout time.Duration, dir, desc, cmdName string, args ...string) (
 	cmd.Dir = dir
 	cmd.Stdout = bufOut
 	cmd.Stderr = bufErr
+	if len(env) > 0 {
+		cmd.Env = append(os.Environ(), env...)
+	}
 	if err := cmd.Start(); err != nil {
 		return "", err.Error(), err
 	}
@@ -110,6 +121,13 @@ func ExecDir(timeout time.Duration, dir, desc, cmdName string, args ...string) (
 // Exec starts executing a shell command, it tracks corresponding process and timeout.
 func ExecTimeout(timeout time.Duration, desc, cmdName string, args ...string) (string, string, error) {
 	return ExecDir(timeout, "", desc, cmdName, args...)
+}
+
+// ExecTimeoutEnv is the same as ExecTimeout but allows appending additional
+// environment variables to the child process. Pass nil for env to inherit the
+// parent process environment unchanged.
+func ExecTimeoutEnv(timeout time.Duration, env []string, desc, cmdName string, args ...string) (string, string, error) {
+	return ExecDirEnv(timeout, "", env, desc, cmdName, args...)
 }
 
 // Exec starts executing a shell command, it tracks corresponding its process and use default timeout.


### PR DESCRIPTION
## Summary

Two related SSRFs in the migration / mirror path. Both reduce to the same defense: the up-front clone address validation is the only place Gogs checks where it's about to talk to, and git was free to talk to a different place later.

- **Initial migration ([GHSA-g2f5-gjr4-qjvm](https://github.com/gogs/gogs/security/advisories/GHSA-g2f5-gjr4-qjvm))**: `ParseRemoteAddr` validates the submitted URL against the local-network blocklist, but `git clone --mirror` followed HTTP redirects with no revalidation. A public-looking source could `302` to an internal endpoint and the contents would land in the new repository.
- **Recurring mirror sync**: same redirect-follow on every periodic `git remote update`, plus no re-validation of the stored URL's hostname at sync time. An attacker who set up a mirror with a benign URL could later flip DNS or start serving redirects to an internal target and the next sync would pull from it.

Ref: https://github.com/gogs/gogs/security/advisories/GHSA-g2f5-gjr4-qjvm

## What changed

- Pass `-c http.followRedirects=false` to every remote-touching git call in the migration and mirror paths: source clone, wiki clone, wiki URL probe, periodic `git remote update` (repo + wiki).
- Re-validate the mirror's hostname against `netx.IsBlockedLocalHostname` before each sync, so a DNS flip after creation cannot turn a previously-public source into an internal one.
- The migration `git.Clone` wrapper hardcodes `clone` as the first arg, so adding the git-level `-c` flag required dropping that wrapper for direct `process.ExecTimeout` calls, matching the pattern already used elsewhere in the package.

## Test plan

- [x] `moon run gogs:lint`
- [x] `go test ./internal/database/...`
- [ ] Manual: with a public URL that 302s to `http://127.0.0.1:<port>/...`, confirm migration fails instead of importing the internal repo.
- [ ] Manual: create a mirror with a benign URL, point its DNS at `127.0.0.1`, confirm the next sync aborts with a notice instead of pulling.