### PR TITLE
security: restrict ipynb sanitizer to safe image data URIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to Gogs are documented in this file.
 - _Security:_ Privilege escalation to repository owner via collaboration access mode update. [#8227](https://github.com/gogs/gogs/pull/8227) - [GHSA-4565-r4x7-hg8j](https://github.com/gogs/gogs/security/advisories/GHSA-4565-r4x7-hg8j)
 - _Security:_ Remote command execution via pull request rebase merges with crafted branch names. [#8301](https://github.com/gogs/gogs/pull/8301) - [GHSA-qf6p-p7ww-cwr9](https://github.com/gogs/gogs/security/advisories/GHSA-qf6p-p7ww-cwr9)
 - _Security:_ SSRF in repository migration and recurring mirror sync via HTTP redirects and stale host validation on stored mirror URLs. [#8324](https://github.com/gogs/gogs/pull/8324) - [GHSA-g2f5-gjr4-qjvm](https://github.com/gogs/gogs/security/advisories/GHSA-g2f5-gjr4-qjvm)
+- _Security:_ Stored XSS in Jupyter notebook (`.ipynb`) preview through `data:text/html` URIs that bypassed the sanitizer. [#PR_PLACEHOLDER](https://github.com/gogs/gogs/pull/PR_PLACEHOLDER) - [GHSA-3w28-36p9-w929](https://github.com/gogs/gogs/security/advisories/GHSA-3w28-36p9-w929)
 - _Security:_ Stored XSS in the milestone dropdown on the new issue page via crafted milestone names. [#8325](https://github.com/gogs/gogs/pull/8325) - [GHSA-vcm5-gvmp-78mp](https://github.com/gogs/gogs/security/advisories/GHSA-vcm5-gvmp-78mp)
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ All notable changes to Gogs are documented in this file.
 - _Security:_ Privilege escalation to repository owner via collaboration access mode update. [#8227](https://github.com/gogs/gogs/pull/8227) - [GHSA-4565-r4x7-hg8j](https://github.com/gogs/gogs/security/advisories/GHSA-4565-r4x7-hg8j)
 - _Security:_ Remote command execution via pull request rebase merges with crafted branch names. [#8301](https://github.com/gogs/gogs/pull/8301) - [GHSA-qf6p-p7ww-cwr9](https://github.com/gogs/gogs/security/advisories/GHSA-qf6p-p7ww-cwr9)
 - _Security:_ SSRF in repository migration and recurring mirror sync via HTTP redirects and stale host validation on stored mirror URLs. [#8324](https://github.com/gogs/gogs/pull/8324) - [GHSA-g2f5-gjr4-qjvm](https://github.com/gogs/gogs/security/advisories/GHSA-g2f5-gjr4-qjvm)
-- _Security:_ Stored XSS in Jupyter notebook (`.ipynb`) preview through `data:text/html` URIs that bypassed the sanitizer. [#PR_PLACEHOLDER](https://github.com/gogs/gogs/pull/PR_PLACEHOLDER) - [GHSA-3w28-36p9-w929](https://github.com/gogs/gogs/security/advisories/GHSA-3w28-36p9-w929)
+- _Security:_ Stored XSS in Jupyter notebook (`.ipynb`) preview through `data:text/html` URIs that bypassed the sanitizer. [#8326](https://github.com/gogs/gogs/pull/8326) - [GHSA-3w28-36p9-w929](https://github.com/gogs/gogs/security/advisories/GHSA-3w28-36p9-w929)
 - _Security:_ Stored XSS in the milestone dropdown on the new issue page via crafted milestone names. [#8325](https://github.com/gogs/gogs/pull/8325) - [GHSA-vcm5-gvmp-78mp](https://github.com/gogs/gogs/security/advisories/GHSA-vcm5-gvmp-78mp)
 
 ### Removed

--- a/internal/app/api.go
+++ b/internal/app/api.go
@@ -5,13 +5,17 @@ import (
 
 	"github.com/microcosm-cc/bluemonday"
 	"gopkg.in/macaron.v1"
+
+	"gogs.io/gogs/internal/markup"
 )
 
 func ipynbSanitizer() *bluemonday.Policy {
 	p := bluemonday.UGCPolicy()
 	p.AllowAttrs("class", "data-prompt-number").OnElements("div")
 	p.AllowAttrs("class").OnElements("img")
-	p.AllowURLSchemes("data")
+	// Only allow data URIs with safe image MIME types to prevent XSS via
+	// "data:text/html" payloads.
+	p.AllowURLSchemeWithCustomPolicy("data", markup.IsSafeDataURI)
 	return p
 }
 

--- a/internal/markup/sanitizer.go
+++ b/internal/markup/sanitizer.go
@@ -36,15 +36,15 @@ func NewSanitizer() {
 
 		// Only allow data URIs with safe image MIME types to prevent XSS via
 		// "data:text/html" payloads.
-		sanitizer.policy.AllowURLSchemeWithCustomPolicy("data", isSafeDataURI)
+		sanitizer.policy.AllowURLSchemeWithCustomPolicy("data", IsSafeDataURI)
 
 		// Custom URL-Schemes
 		sanitizer.policy.AllowURLSchemes(conf.Markdown.CustomURLSchemes...)
 	})
 }
 
-// isSafeDataURI returns whether the given data URI uses a safe image MIME type.
-func isSafeDataURI(u *url.URL) bool {
+// IsSafeDataURI returns whether the given data URI uses a safe image MIME type.
+func IsSafeDataURI(u *url.URL) bool {
 	// The opaque data of a data URI has the form "mediatype;base64,data" or
 	// "mediatype,data". We only allow common image MIME types.
 	mediatype, _, _ := strings.Cut(u.Opaque, ";")


### PR DESCRIPTION
## Summary

The `/-/api/sanitize_ipynb` endpoint sanitized notebook HTML with a bluemonday policy that allowed any `data:` URI scheme. A crafted `data:text/html` URI passed through unchanged and executed as JavaScript when the rendered notebook was appended to the DOM during `.ipynb` preview.

Switch to `markup.IsSafeDataURI`, the same allowlist already used by the Markdown sanitizer, which restricts data URIs to common image MIME types.

Refs: [GHSA-3w28-36p9-w929](https://github.com/gogs/gogs/security/advisories/GHSA-3w28-36p9-w929)

## Test plan

- [x] `moon run gogs:lint`
- [x] `moon run gogs:build`
- [x] `go test ./internal/markup/ ./internal/app/`
- [ ] Manual: render a notebook containing `<a href="data:text/html,<script>alert(1)</script>">x</a>` and confirm the link no longer carries the data URI.