### PR TITLE
security: enforce RESET_PASSWORD_CODE_LIVES on reset tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to Gogs are documented in this file.
 - _Security:_ Stored XSS in Jupyter notebook (`.ipynb`) preview through `data:text/html` URIs that bypassed the sanitizer. [#8326](https://github.com/gogs/gogs/pull/8326) - [GHSA-3w28-36p9-w929](https://github.com/gogs/gogs/security/advisories/GHSA-3w28-36p9-w929)
 - _Security:_ Stored XSS in the milestone dropdown on the new issue page via crafted milestone names. [#8325](https://github.com/gogs/gogs/pull/8325) - [GHSA-vcm5-gvmp-78mp](https://github.com/gogs/gogs/security/advisories/GHSA-vcm5-gvmp-78mp)
 - _Security:_ Write-level collaborators could change admin-only repository settings (issue tracker, wiki, mirror sync) via API. [#8327](https://github.com/gogs/gogs/pull/8327) - [GHSA-268j-37xf-pp52](https://github.com/gogs/gogs/security/advisories/GHSA-268j-37xf-pp52)
+- _Security:_ Password reset tokens stayed valid for the account-activation lifetime, ignoring `[auth] RESET_PASSWORD_CODE_LIVES`. [#PR](https://github.com/gogs/gogs/pull/PR) - [GHSA-5c3f-6486-3g7g](https://github.com/gogs/gogs/security/advisories/GHSA-5c3f-6486-3g7g)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ All notable changes to Gogs are documented in this file.
 - _Security:_ Stored XSS in Jupyter notebook (`.ipynb`) preview through `data:text/html` URIs that bypassed the sanitizer. [#8326](https://github.com/gogs/gogs/pull/8326) - [GHSA-3w28-36p9-w929](https://github.com/gogs/gogs/security/advisories/GHSA-3w28-36p9-w929)
 - _Security:_ Stored XSS in the milestone dropdown on the new issue page via crafted milestone names. [#8325](https://github.com/gogs/gogs/pull/8325) - [GHSA-vcm5-gvmp-78mp](https://github.com/gogs/gogs/security/advisories/GHSA-vcm5-gvmp-78mp)
 - _Security:_ Write-level collaborators could change admin-only repository settings (issue tracker, wiki, mirror sync) via API. [#8327](https://github.com/gogs/gogs/pull/8327) - [GHSA-268j-37xf-pp52](https://github.com/gogs/gogs/security/advisories/GHSA-268j-37xf-pp52)
-- _Security:_ Password reset tokens stayed valid for the account-activation lifetime, ignoring `[auth] RESET_PASSWORD_CODE_LIVES`. [#PR](https://github.com/gogs/gogs/pull/PR) - [GHSA-5c3f-6486-3g7g](https://github.com/gogs/gogs/security/advisories/GHSA-5c3f-6486-3g7g)
+- _Security:_ Password reset tokens stayed valid for the account-activation lifetime, ignoring `[auth] RESET_PASSWORD_CODE_LIVES`. [#8328](https://github.com/gogs/gogs/pull/8328) - [GHSA-5c3f-6486-3g7g](https://github.com/gogs/gogs/security/advisories/GHSA-5c3f-6486-3g7g)
 
 ### Removed
 

--- a/internal/database/issue_mail.go
+++ b/internal/database/issue_mail.go
@@ -45,6 +45,16 @@ func (mu mailerUser) GenerateEmailActivateCode(email string) string {
 	)
 }
 
+func (mu mailerUser) GenerateEmailResetPasswordCode(email string) string {
+	return userx.GenerateResetPasswordCode(
+		mu.user.ID,
+		email,
+		mu.user.Name,
+		mu.user.Password,
+		mu.user.Rands,
+	)
+}
+
 func NewMailerUser(u *User) email.User {
 	return mailerUser{u}
 }

--- a/internal/email/email.go
+++ b/internal/email/email.go
@@ -184,6 +184,7 @@ type User interface {
 	DisplayName() string
 	Email() string
 	GenerateEmailActivateCode(string) string
+	GenerateEmailResetPasswordCode(string) string
 }
 
 type Repository interface {
@@ -225,7 +226,7 @@ func SendActivateAccountMail(t Translator, u User) error {
 }
 
 func SendResetPasswordMail(t Translator, u User) error {
-	return SendUserMail(t, u, tmplAuthResetPassword, u.GenerateEmailActivateCode(u.Email()), t.Tr("mail.reset_password"), "reset password")
+	return SendUserMail(t, u, tmplAuthResetPassword, u.GenerateEmailResetPasswordCode(u.Email()), t.Tr("mail.reset_password"), "reset password")
 }
 
 func SendActivateEmailMail(t Translator, u User, email string) error {

--- a/internal/email/email_test.go
+++ b/internal/email/email_test.go
@@ -118,7 +118,8 @@ func resetTemplateCache(t *testing.T) {
 // testDoer satisfies the User interface for fields the issue templates touch.
 type testDoer struct{}
 
-func (testDoer) ID() int64                               { return 1 }
-func (testDoer) DisplayName() string                     { return "alice" }
-func (testDoer) Email() string                           { return "alice@example.test" }
-func (testDoer) GenerateEmailActivateCode(string) string { return "abc" }
+func (testDoer) ID() int64                                    { return 1 }
+func (testDoer) DisplayName() string                          { return "alice" }
+func (testDoer) Email() string                                { return "alice@example.test" }
+func (testDoer) GenerateEmailActivateCode(string) string      { return "abc" }
+func (testDoer) GenerateEmailResetPasswordCode(string) string { return "abc" }

--- a/internal/userx/userx.go
+++ b/internal/userx/userx.go
@@ -39,8 +39,7 @@ func GenerateActivateCode(userID int64, email, name, password, rands string) str
 
 // GenerateResetPasswordCode generates a password-reset code based on user
 // information and the given email. The token's lifetime is bound to
-// [conf.AuthOpts.ResetPasswordCodeLives] so the configured reset window is the
-// one actually enforced at verification time.
+// [conf.AuthOpts.ResetPasswordCodeLives].
 func GenerateResetPasswordCode(userID int64, email, name, password, rands string) string {
 	return generateTimeLimitedUserCode(userID, email, name, password, rands, conf.Auth.ResetPasswordCodeLives)
 }

--- a/internal/userx/userx.go
+++ b/internal/userx/userx.go
@@ -34,9 +34,21 @@ func DashboardURLPath(name string, isOrganization bool) string {
 // GenerateActivateCode generates an activate code based on user information and
 // the given email.
 func GenerateActivateCode(userID int64, email, name, password, rands string) string {
+	return generateTimeLimitedUserCode(userID, email, name, password, rands, conf.Auth.ActivateCodeLives)
+}
+
+// GenerateResetPasswordCode generates a password-reset code based on user
+// information and the given email. The token's lifetime is bound to
+// [conf.AuthOpts.ResetPasswordCodeLives] so the configured reset window is the
+// one actually enforced at verification time.
+func GenerateResetPasswordCode(userID int64, email, name, password, rands string) string {
+	return generateTimeLimitedUserCode(userID, email, name, password, rands, conf.Auth.ResetPasswordCodeLives)
+}
+
+func generateTimeLimitedUserCode(userID int64, email, name, password, rands string, minutes int) string {
 	code := tool.CreateTimeLimitCode(
 		fmt.Sprintf("%d%s%s%s%s", userID, email, strings.ToLower(name), password, rands),
-		conf.Auth.ActivateCodeLives,
+		minutes,
 		nil,
 	)
 


### PR DESCRIPTION
Password reset tokens were generated with `conf.Auth.ActivateCodeLives` instead of `conf.Auth.ResetPasswordCodeLives`. The lifetime is baked into the token at generation and re-extracted at verification, so the configured reset window was advertised in the email but never enforced.

This change introduces `GenerateResetPasswordCode` in `internal/userx` and routes `SendResetPasswordMail` through it via a new `GenerateEmailResetPasswordCode` method on the `email.User` interface. The verifier needs no change because it reads the embedded lifetime from the token itself.

Advisory: [GHSA-5c3f-6486-3g7g](https://github.com/gogs/gogs/security/advisories/GHSA-5c3f-6486-3g7g)

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/122a6135-fbc2-48f1-a253-d415650435c9/pull/8328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->