### PR TITLE
security: stop re-parsing sanitized ipynb markdown cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ All notable changes to Gogs are documented in this file.
 - _Security:_ Stored XSS in Jupyter notebook (`.ipynb`) preview through `data:text/html` URIs that bypassed the sanitizer. [#8326](https://github.com/gogs/gogs/pull/8326) - [GHSA-3w28-36p9-w929](https://github.com/gogs/gogs/security/advisories/GHSA-3w28-36p9-w929)
 - _Security:_ Stored XSS in the milestone dropdown on the new issue page via crafted milestone names. [#8325](https://github.com/gogs/gogs/pull/8325) - [GHSA-vcm5-gvmp-78mp](https://github.com/gogs/gogs/security/advisories/GHSA-vcm5-gvmp-78mp)
 - _Security:_ Write-level collaborators could change admin-only repository settings (issue tracker, wiki, mirror sync) via API. [#8327](https://github.com/gogs/gogs/pull/8327) - [GHSA-268j-37xf-pp52](https://github.com/gogs/gogs/security/advisories/GHSA-268j-37xf-pp52)
-- _Security:_ Stored XSS in Jupyter notebook (`.ipynb`) preview where a post-sanitizer re-parse of markdown cells turned escaped HTML back into live tags. [#PR](https://github.com/gogs/gogs/pull/PR) - [GHSA-6vxv-wg6j-5qwp](https://github.com/gogs/gogs/security/advisories/GHSA-6vxv-wg6j-5qwp)
+- _Security:_ Stored XSS in Jupyter notebook (`.ipynb`) preview where a post-sanitizer re-parse of markdown cells turned escaped HTML back into live tags. [#8329](https://github.com/gogs/gogs/pull/8329) - [GHSA-6vxv-wg6j-5qwp](https://github.com/gogs/gogs/security/advisories/GHSA-6vxv-wg6j-5qwp)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to Gogs are documented in this file.
 - _Security:_ Stored XSS in Jupyter notebook (`.ipynb`) preview through `data:text/html` URIs that bypassed the sanitizer. [#8326](https://github.com/gogs/gogs/pull/8326) - [GHSA-3w28-36p9-w929](https://github.com/gogs/gogs/security/advisories/GHSA-3w28-36p9-w929)
 - _Security:_ Stored XSS in the milestone dropdown on the new issue page via crafted milestone names. [#8325](https://github.com/gogs/gogs/pull/8325) - [GHSA-vcm5-gvmp-78mp](https://github.com/gogs/gogs/security/advisories/GHSA-vcm5-gvmp-78mp)
 - _Security:_ Write-level collaborators could change admin-only repository settings (issue tracker, wiki, mirror sync) via API. [#8327](https://github.com/gogs/gogs/pull/8327) - [GHSA-268j-37xf-pp52](https://github.com/gogs/gogs/security/advisories/GHSA-268j-37xf-pp52)
+- _Security:_ Stored XSS in Jupyter notebook (`.ipynb`) preview where a post-sanitizer re-parse of markdown cells turned escaped HTML back into live tags. [#PR](https://github.com/gogs/gogs/pull/PR) - [GHSA-6vxv-wg6j-5qwp](https://github.com/gogs/gogs/security/advisories/GHSA-6vxv-wg6j-5qwp)
 
 ### Removed
 

--- a/templates/repo/view_file.tmpl
+++ b/templates/repo/view_file.tmpl
@@ -57,47 +57,20 @@
 								hljs.highlightBlock(block);
 							});
 
-							// Overwrite image method to append proper prefix to the source URL
-							var renderer = new marked.Renderer();
+							// Resolve relative image sources against the notebook's
+							// directory. The server-side sanitizer has already run
+							// over the response, so we must NOT re-parse the cell
+							// HTML here: doing so would round-trip text through
+							// innerHTML and resurrect escaped tags as live ones.
 							var context = '{{.RawFileLink}}';
 							context = context.substring(0, context.lastIndexOf("/"));
-							renderer.image = function (href, title, text) {
-								return `<img src="${context}/${href}"`
-							};
-							// Reject dangerous URL schemes (javascript:, vbscript:, data:)
-							// before they reach the DOM. marked.js does not sanitize URLs
-							// in its default link renderer.
-							var unsafeURLScheme = /^(?:javascript|vbscript|data):/i;
-							var escapeHTML = function (s) {
-								return String(s).replace(/[&<>"']/g, function (c) {
-									return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c];
-								});
-							};
-							var decodeEntities = function (s) {
-								var el = document.createElement('textarea');
-								el.innerHTML = s;
-								return el.value;
-							};
-							renderer.link = function (href, title, text) {
-								var raw = String(href || '').trim();
-								var normalized;
-								try {
-									normalized = decodeURIComponent(decodeEntities(raw));
-								} catch (e) {
-									normalized = decodeEntities(raw);
+							var absURL = /^[a-z][a-z0-9+.-]*:|^\/\//i;
+							$("#ipython-notebook .nb-markdown-cell img").each(function(i, img) {
+								var src = img.getAttribute("src") || "";
+								if (src === "" || src.charAt(0) === "/" || absURL.test(src)) {
+									return;
 								}
-								normalized = normalized.replace(/[\x00-\x20]/g, '');
-								if (unsafeURLScheme.test(normalized)) {
-									return text;
-								}
-								var out = '<a href="' + escapeHTML(raw) + '"';
-								if (title) {
-									out += ' title="' + escapeHTML(title) + '"';
-								}
-								return out + '>' + text + '</a>';
-							};
-							$("#ipython-notebook .nb-markdown-cell").each(function(i, markdown) {
-								$(markdown).html(marked.parse($(markdown).html(), {renderer: renderer}));
+								img.setAttribute("src", context + "/" + src);
 							});
 						});
 					});


### PR DESCRIPTION
The notebook viewer ran `marked.parse` a second time over each markdown cell's HTML after the server-side sanitizer returned. Round-tripping through jQuery's `.html()` getter and setter decoded the escaped tags the sanitizer had neutralized, materializing live attributes such as `onerror`.

The post-sanitize re-parse is removed. Relative image sources are now resolved by walking the rendered nodes and adjusting `src` directly, the only behavior the second pass actually provided that the server sanitizer does not.

Advisory: [GHSA-6vxv-wg6j-5qwp](https://github.com/gogs/gogs/security/advisories/GHSA-6vxv-wg6j-5qwp)