### PR TITLE
security: authorize Git HTTP by routed action, not client-supplied service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to Gogs are documented in this file.
 - _Security:_ Write-level collaborators could change admin-only repository settings (issue tracker, wiki, mirror sync) via API. [#8327](https://github.com/gogs/gogs/pull/8327) - [GHSA-268j-37xf-pp52](https://github.com/gogs/gogs/security/advisories/GHSA-268j-37xf-pp52)
 - _Security:_ Password reset tokens stayed valid for the account-activation lifetime, ignoring `[auth] RESET_PASSWORD_CODE_LIVES`. [#8328](https://github.com/gogs/gogs/pull/8328) - [GHSA-5c3f-6486-3g7g](https://github.com/gogs/gogs/security/advisories/GHSA-5c3f-6486-3g7g)
 - _Security:_ Stored XSS in Jupyter notebook (`.ipynb`) preview through raw HTML in markdown cells. [#8330](https://github.com/gogs/gogs/pull/8330) - [GHSA-6vxv-wg6j-5qwp](https://github.com/gogs/gogs/security/advisories/GHSA-6vxv-wg6j-5qwp)
+- _Security:_ Read-only Git HTTP access could be confused with write access during repository pushes. [#PR](https://github.com/gogs/gogs/pull/PR) - [GHSA-wmfg-5p4h-5fw3](https://github.com/gogs/gogs/security/advisories/GHSA-wmfg-5p4h-5fw3)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ All notable changes to Gogs are documented in this file.
 - _Security:_ Write-level collaborators could change admin-only repository settings (issue tracker, wiki, mirror sync) via API. [#8327](https://github.com/gogs/gogs/pull/8327) - [GHSA-268j-37xf-pp52](https://github.com/gogs/gogs/security/advisories/GHSA-268j-37xf-pp52)
 - _Security:_ Password reset tokens stayed valid for the account-activation lifetime, ignoring `[auth] RESET_PASSWORD_CODE_LIVES`. [#8328](https://github.com/gogs/gogs/pull/8328) - [GHSA-5c3f-6486-3g7g](https://github.com/gogs/gogs/security/advisories/GHSA-5c3f-6486-3g7g)
 - _Security:_ Stored XSS in Jupyter notebook (`.ipynb`) preview through raw HTML in markdown cells. [#8330](https://github.com/gogs/gogs/pull/8330) - [GHSA-6vxv-wg6j-5qwp](https://github.com/gogs/gogs/security/advisories/GHSA-6vxv-wg6j-5qwp)
-- _Security:_ Read-only Git HTTP access could be confused with write access during repository pushes. [#PR](https://github.com/gogs/gogs/pull/PR) - [GHSA-wmfg-5p4h-5fw3](https://github.com/gogs/gogs/security/advisories/GHSA-wmfg-5p4h-5fw3)
+- _Security:_ Read-only Git HTTP access could be confused with write access during repository pushes. [#8331](https://github.com/gogs/gogs/pull/8331) - [GHSA-wmfg-5p4h-5fw3](https://github.com/gogs/gogs/security/advisories/GHSA-wmfg-5p4h-5fw3)
 
 ### Removed
 

--- a/internal/route/repo/http.go
+++ b/internal/route/repo/http.go
@@ -61,8 +61,14 @@ func gitHTTPActionFromPath(urlPath, subpath, owner, repo string) string {
 	return ""
 }
 
-func gitHTTPIsPull(method, action string) bool {
-	return method == http.MethodGet || action == "git-upload-pack"
+func gitHTTPIsPull(method, action, service string) bool {
+	if method != http.MethodGet {
+		return action == "git-upload-pack"
+	}
+	if action == "info/refs" {
+		return service != "git-receive-pack"
+	}
+	return true
 }
 
 func HTTPContexter(store Store) macaron.Handler {
@@ -81,7 +87,7 @@ func HTTPContexter(store Store) macaron.Handler {
 		repoName = strings.TrimSuffix(repoName, ".wiki")
 
 		action := gitHTTPAction(c)
-		isPull := gitHTTPIsPull(c.Req.Method, action)
+		isPull := gitHTTPIsPull(c.Req.Method, action, c.Query("service"))
 
 		owner, err := store.GetUserByUsername(c.Req.Context(), ownerName)
 		if err != nil {

--- a/internal/route/repo/http.go
+++ b/internal/route/repo/http.go
@@ -61,6 +61,10 @@ func gitHTTPActionFromPath(urlPath, subpath, owner, repo string) string {
 	return ""
 }
 
+func gitHTTPIsPull(method, action string) bool {
+	return method == http.MethodGet || action == "git-upload-pack"
+}
+
 func HTTPContexter(store Store) macaron.Handler {
 	return func(c *macaron.Context) {
 		if len(conf.HTTP.AccessControlAllowOrigin) > 0 {
@@ -76,9 +80,8 @@ func HTTPContexter(store Store) macaron.Handler {
 		repoName := strings.TrimSuffix(c.Params(":reponame"), ".git")
 		repoName = strings.TrimSuffix(repoName, ".wiki")
 
-		isPull := c.Query("service") == "git-upload-pack" ||
-			strings.HasSuffix(c.Req.URL.Path, "git-upload-pack") ||
-			c.Req.Method == "GET"
+		action := gitHTTPAction(c)
+		isPull := gitHTTPIsPull(c.Req.Method, action)
 
 		owner, err := store.GetUserByUsername(c.Req.Context(), ownerName)
 		if err != nil {
@@ -111,7 +114,6 @@ func HTTPContexter(store Store) macaron.Handler {
 		}
 
 		// In case user requested a wrong URL and not intended to access Git objects.
-		action := gitHTTPAction(c)
 		if !strings.Contains(action, "git-") &&
 			!strings.Contains(action, "info/") &&
 			!strings.Contains(action, "HEAD") &&

--- a/internal/route/repo/http.go
+++ b/internal/route/repo/http.go
@@ -61,14 +61,11 @@ func gitHTTPActionFromPath(urlPath, subpath, owner, repo string) string {
 	return ""
 }
 
-func gitHTTPIsPull(method, action, service string) bool {
-	if method != http.MethodGet {
-		return action == "git-upload-pack"
-	}
+func gitHTTPIsPull(c *macaron.Context, action string) bool {
 	if action == "info/refs" {
-		return service != "git-receive-pack"
+		return c.Query("service") != "git-receive-pack"
 	}
-	return true
+	return action != "git-receive-pack"
 }
 
 func HTTPContexter(store Store) macaron.Handler {
@@ -87,7 +84,7 @@ func HTTPContexter(store Store) macaron.Handler {
 		repoName = strings.TrimSuffix(repoName, ".wiki")
 
 		action := gitHTTPAction(c)
-		isPull := gitHTTPIsPull(c.Req.Method, action, c.Query("service"))
+		isPull := gitHTTPIsPull(c, action)
 
 		owner, err := store.GetUserByUsername(c.Req.Context(), ownerName)
 		if err != nil {

--- a/internal/route/repo/http_test.go
+++ b/internal/route/repo/http_test.go
@@ -1,6 +1,7 @@
 package repo
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -69,6 +70,40 @@ func TestGitHTTPActionFromPath(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			got := gitHTTPActionFromPath(tc.urlPath, tc.subpath, tc.owner, tc.repo)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestGitHTTPIsPull(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		action string
+		want   bool
+	}{
+		{
+			name:   "upload pack post is pull",
+			method: http.MethodPost,
+			action: "git-upload-pack",
+			want:   true,
+		},
+		{
+			name:   "receive pack post is push",
+			method: http.MethodPost,
+			action: "git-receive-pack",
+			want:   false,
+		},
+		{
+			name:   "info refs get is pull",
+			method: http.MethodGet,
+			action: "info/refs",
+			want:   true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := gitHTTPIsPull(tc.method, tc.action)
 			assert.Equal(t, tc.want, got)
 		})
 	}

--- a/internal/route/repo/http_test.go
+++ b/internal/route/repo/http_test.go
@@ -1,7 +1,6 @@
 package repo
 
 import (
-	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -70,40 +69,6 @@ func TestGitHTTPActionFromPath(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			got := gitHTTPActionFromPath(tc.urlPath, tc.subpath, tc.owner, tc.repo)
-			assert.Equal(t, tc.want, got)
-		})
-	}
-}
-
-func TestGitHTTPIsPull(t *testing.T) {
-	tests := []struct {
-		name   string
-		method string
-		action string
-		want   bool
-	}{
-		{
-			name:   "upload pack post is pull",
-			method: http.MethodPost,
-			action: "git-upload-pack",
-			want:   true,
-		},
-		{
-			name:   "receive pack post is push",
-			method: http.MethodPost,
-			action: "git-receive-pack",
-			want:   false,
-		},
-		{
-			name:   "info refs get is pull",
-			method: http.MethodGet,
-			action: "info/refs",
-			want:   true,
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := gitHTTPIsPull(tc.method, tc.action)
 			assert.Equal(t, tc.want, got)
 		})
 	}


### PR DESCRIPTION
## Describe the pull request

Gogs' Git smart-HTTP handler decided read vs write from the client-supplied `?service=` query parameter, so a `POST /repo.git/git-receive-pack?service=git-upload-pack` was authorized as a read while the route still executed `git-receive-pack`. A user with read-only access could push.

This branch derives the access mode from the routed action instead:

- `git-receive-pack` (and `info/refs?service=git-receive-pack`) are the only operations that demand write access. `service=` is consulted only on `info/refs`, the one endpoint shared between fetch and push. Everywhere else the RPC path is authoritative.
- The dead `gitHTTPAction(c)` call left over from the old check is removed.

Security advisory: https://github.com/gogs/gogs/security/advisories/GHSA-wmfg-5p4h-5fw3

## Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [x] I have added test cases to cover the new code or have provided the test plan.
- [x] I have added an entry to [CHANGELOG](https://github.com/gogs/gogs/blob/main/CHANGELOG.md).

## Test plan

1. Create two users `victim` and `attacker`.
2. As `victim`, create a private repository and add `attacker` as a read-only collaborator.
3. Run the advisory PoC, which proxies `git push` and rewrites the request to `POST /victim/target.git/git-receive-pack?service=git-upload-pack`.
4. Before this change: push succeeds, `attacker` writes to the read-only repository.
5. After this change: push is rejected with `403 User permission denied`, and the repository remains unchanged.