### PR TITLE
security: walk full upload path for symlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to Gogs are documented in this file.
 - _Security:_ Password reset tokens stayed valid for the account-activation lifetime, ignoring `[auth] RESET_PASSWORD_CODE_LIVES`. [#8328](https://github.com/gogs/gogs/pull/8328) - [GHSA-5c3f-6486-3g7g](https://github.com/gogs/gogs/security/advisories/GHSA-5c3f-6486-3g7g)
 - _Security:_ Stored XSS in Jupyter notebook (`.ipynb`) preview through raw HTML in markdown cells. [#8330](https://github.com/gogs/gogs/pull/8330) - [GHSA-6vxv-wg6j-5qwp](https://github.com/gogs/gogs/security/advisories/GHSA-6vxv-wg6j-5qwp)
 - _Security:_ Read-only Git HTTP access could be confused with write access during repository pushes. [#8331](https://github.com/gogs/gogs/pull/8331) - [GHSA-wmfg-5p4h-5fw3](https://github.com/gogs/gogs/security/advisories/GHSA-wmfg-5p4h-5fw3)
+- _Security:_ Arbitrary file write outside the repository working tree via crafted upload filename routed through a committed directory symlink. [#PR](https://github.com/gogs/gogs/pull/PR) - [GHSA-89mr-xqfv-758m](https://github.com/gogs/gogs/security/advisories/GHSA-89mr-xqfv-758m)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to Gogs are documented in this file.
 - _Security:_ Password reset tokens stayed valid for the account-activation lifetime, ignoring `[auth] RESET_PASSWORD_CODE_LIVES`. [#8328](https://github.com/gogs/gogs/pull/8328) - [GHSA-5c3f-6486-3g7g](https://github.com/gogs/gogs/security/advisories/GHSA-5c3f-6486-3g7g)
 - _Security:_ Stored XSS in Jupyter notebook (`.ipynb`) preview through raw HTML in markdown cells. [#8330](https://github.com/gogs/gogs/pull/8330) - [GHSA-6vxv-wg6j-5qwp](https://github.com/gogs/gogs/security/advisories/GHSA-6vxv-wg6j-5qwp)
 - _Security:_ Read-only Git HTTP access could be confused with write access during repository pushes. [#8331](https://github.com/gogs/gogs/pull/8331) - [GHSA-wmfg-5p4h-5fw3](https://github.com/gogs/gogs/security/advisories/GHSA-wmfg-5p4h-5fw3)
-- _Security:_ Arbitrary file write outside the repository working tree via crafted upload filename routed through a committed directory symlink. [#PR](https://github.com/gogs/gogs/pull/PR) - [GHSA-89mr-xqfv-758m](https://github.com/gogs/gogs/security/advisories/GHSA-89mr-xqfv-758m)
+- _Security:_ Arbitrary file write outside the repository working tree via crafted upload filename routed through a committed directory symlink. [#8332](https://github.com/gogs/gogs/pull/8332) - [GHSA-89mr-xqfv-758m](https://github.com/gogs/gogs/security/advisories/GHSA-89mr-xqfv-758m)
 
 ### Removed
 

--- a/internal/database/repo_editor.go
+++ b/internal/database/repo_editor.go
@@ -601,10 +601,8 @@ func (r *Repository) UploadRepoFiles(doer *User, opts UploadRepoFileOptions) err
 
 		targetPath := path.Join(dirPath, upload.Name)
 
-		// 🚨 SECURITY: Prevent writes that escape the working tree by following a
-		// symlink at any component of the target path, including parent directories
-		// committed as symlinks. Checking only the leaf misses parent-symlink
-		// redirection through paths like "hijack/authorized_keys".
+		// 🚨 SECURITY: Prevent touching files in surprising places, reject operations
+		// that involve symlinks.
 		if hasSymlinkInPath(localPath, path.Join(opts.TreePath, upload.Name)) {
 			return errors.Newf("cannot overwrite symbolic link: %s", upload.Name)
 		}

--- a/internal/database/repo_editor.go
+++ b/internal/database/repo_editor.go
@@ -601,9 +601,11 @@ func (r *Repository) UploadRepoFiles(doer *User, opts UploadRepoFileOptions) err
 
 		targetPath := path.Join(dirPath, upload.Name)
 
-		// 🚨 SECURITY: Prevent updating files in surprising place, check if the target
-		// is a symlink.
-		if osx.IsSymlink(targetPath) {
+		// 🚨 SECURITY: Prevent writes that escape the working tree by following a
+		// symlink at any component of the target path, including parent directories
+		// committed as symlinks. Checking only the leaf misses parent-symlink
+		// redirection through paths like "hijack/authorized_keys".
+		if hasSymlinkInPath(localPath, path.Join(opts.TreePath, upload.Name)) {
 			return errors.Newf("cannot overwrite symbolic link: %s", upload.Name)
 		}
 


### PR DESCRIPTION
## Describe the pull request

The repository file upload handler only checked whether the leaf of the target path was a symlink before writing. If a sibling commit had placed a directory symlink in the tree, a crafted upload filename could redirect the write through that symlink to anywhere the Gogs process could write.

The check is now consistent with the sibling edit and delete handlers, which lstat every component of the path.

Refs [GHSA-89mr-xqfv-758m](https://github.com/gogs/gogs/security/advisories/GHSA-89mr-xqfv-758m).

## Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [x] I have added an entry to [CHANGELOG](https://github.com/gogs/gogs/blob/main/CHANGELOG.md).

## Test plan

1. As a user with write access, commit a directory symlink to the repository (for example `ln -s /tmp/elsewhere hijack` followed by `git push`).
2. Upload a file via `POST /:owner/:repo/upload-file` with a multipart filename whose parsed value contains a path separator pointing into the symlinked directory (for example `hijack/payload`).
3. Commit the upload via `POST /:owner/:repo/_upload/:branch/`.
4. Before this change: the file lands outside the working tree at the symlink target.
5. After this change: the commit is rejected with `cannot overwrite symbolic link: <name>` and no file is written outside the working tree.