### PR TITLE
security: verify content hash on LFS dedupe shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to Gogs are documented in this file.
 - _Security:_ Stored XSS in Jupyter notebook (`.ipynb`) preview through raw HTML in markdown cells. [#8330](https://github.com/gogs/gogs/pull/8330) - [GHSA-6vxv-wg6j-5qwp](https://github.com/gogs/gogs/security/advisories/GHSA-6vxv-wg6j-5qwp)
 - _Security:_ Read-only Git HTTP access could be confused with write access during repository pushes. [#8331](https://github.com/gogs/gogs/pull/8331) - [GHSA-wmfg-5p4h-5fw3](https://github.com/gogs/gogs/security/advisories/GHSA-wmfg-5p4h-5fw3)
 - _Security:_ Arbitrary file write outside the repository working tree via crafted upload filename routed through a committed directory symlink. [#8332](https://github.com/gogs/gogs/pull/8332) - [GHSA-89mr-xqfv-758m](https://github.com/gogs/gogs/security/advisories/GHSA-89mr-xqfv-758m)
+- _Security:_ Cross-repository disclosure of Git LFS object contents by binding a known OID to another repository without proving possession of the bytes. [#PR](https://github.com/gogs/gogs/pull/PR) - [GHSA-6p9m-q3jp-47h4](https://github.com/gogs/gogs/security/advisories/GHSA-6p9m-q3jp-47h4)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ All notable changes to Gogs are documented in this file.
 - _Security:_ Stored XSS in Jupyter notebook (`.ipynb`) preview through raw HTML in markdown cells. [#8330](https://github.com/gogs/gogs/pull/8330) - [GHSA-6vxv-wg6j-5qwp](https://github.com/gogs/gogs/security/advisories/GHSA-6vxv-wg6j-5qwp)
 - _Security:_ Read-only Git HTTP access could be confused with write access during repository pushes. [#8331](https://github.com/gogs/gogs/pull/8331) - [GHSA-wmfg-5p4h-5fw3](https://github.com/gogs/gogs/security/advisories/GHSA-wmfg-5p4h-5fw3)
 - _Security:_ Arbitrary file write outside the repository working tree via crafted upload filename routed through a committed directory symlink. [#8332](https://github.com/gogs/gogs/pull/8332) - [GHSA-89mr-xqfv-758m](https://github.com/gogs/gogs/security/advisories/GHSA-89mr-xqfv-758m)
-- _Security:_ Cross-repository disclosure of Git LFS object contents by binding a known OID to another repository without proving possession of the bytes. [#PR](https://github.com/gogs/gogs/pull/PR) - [GHSA-6p9m-q3jp-47h4](https://github.com/gogs/gogs/security/advisories/GHSA-6p9m-q3jp-47h4)
+- _Security:_ Cross-repository disclosure of Git LFS object contents by binding a known OID to another repository without proving possession of the bytes. [#8333](https://github.com/gogs/gogs/pull/8333) - [GHSA-6p9m-q3jp-47h4](https://github.com/gogs/gogs/security/advisories/GHSA-6p9m-q3jp-47h4)
 
 ### Removed
 

--- a/internal/lfsx/storage.go
+++ b/internal/lfsx/storage.go
@@ -74,10 +74,18 @@ func (s *LocalStorage) Upload(oid OID, rc io.ReadCloser) (int64, error) {
 		return 0, errors.Wrap(err, "create directories")
 	}
 
-	// If the object file already exists, skip the upload and return the
-	// existing file's size.
+	// If the object file already exists, the client must still prove it has
+	// the original bytes by hashing the request body. Otherwise any caller
+	// with write access to one repository could bind an OID owned by another
+	// repository to their own and download the original content.
 	if fi, err := os.Stat(fpath); err == nil {
-		_, _ = io.Copy(io.Discard, rc)
+		hash := sha256.New()
+		if _, err := io.Copy(hash, rc); err != nil {
+			return 0, errors.Wrap(err, "read request body")
+		}
+		if computed := hex.EncodeToString(hash.Sum(nil)); computed != string(oid) {
+			return 0, ErrOIDMismatch
+		}
 		return fi.Size(), nil
 	}
 

--- a/internal/lfsx/storage_test.go
+++ b/internal/lfsx/storage_test.go
@@ -79,10 +79,22 @@ func TestLocalStorage_Upload(t *testing.T) {
 		assert.False(t, osx.IsFile(s.storagePath(oid)))
 	})
 
-	t.Run("duplicate upload returns existing size", func(t *testing.T) {
-		written, err := s.Upload(helloWorldOID, io.NopCloser(strings.NewReader("should be ignored")))
+	t.Run("duplicate upload with matching content returns existing size", func(t *testing.T) {
+		written, err := s.Upload(helloWorldOID, io.NopCloser(strings.NewReader("Hello world!")))
 		require.NoError(t, err)
 		assert.Equal(t, int64(12), written)
+
+		// Verify original content is preserved.
+		var buf bytes.Buffer
+		err = s.Download(helloWorldOID, &buf)
+		require.NoError(t, err)
+		assert.Equal(t, "Hello world!", buf.String())
+	})
+
+	t.Run("duplicate upload with mismatched content is rejected", func(t *testing.T) {
+		written, err := s.Upload(helloWorldOID, io.NopCloser(strings.NewReader("different bytes")))
+		assert.Equal(t, int64(0), written)
+		assert.Equal(t, ErrOIDMismatch, err)
 
 		// Verify original content is preserved.
 		var buf bytes.Buffer


### PR DESCRIPTION
## Describe the pull request

The LFS upload handler took a shortcut when the on-disk object file already existed. It accepted the request, recorded the per-repository binding, and returned the existing file's size without checking that the request body actually hashed to the claimed OID.

A user with write access to one repository could bind their repository to an OID belonging to a private repository by sending a PUT containing any bytes, then read the original content back through their own download endpoint.

The dedupe path now hashes the request body and rejects the upload with `ErrOIDMismatch` when the content does not match the claimed OID, mirroring the verification the new-file path has always performed. Legitimate LFS client retries continue to work because they always replay the original bytes.

Refs [GHSA-6p9m-q3jp-47h4](https://github.com/gogs/gogs/security/advisories/GHSA-6p9m-q3jp-47h4).

## Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [x] I have added test cases to cover the new code.
- [x] I have added an entry to [CHANGELOG](https://github.com/gogs/gogs/blob/main/CHANGELOG.md).

## Test plan

1. As one user, upload an LFS object to repository `a/private` so a file at `<lfs-root>/<oid[0]>/<oid[1]>/<oid>` exists.
2. As a different user with write access only to `b/scratch`, send `PUT /b/scratch.git/info/lfs/objects/basic/<oid>` with arbitrary bytes.
3. Before this change: response is `200 OK` and the user can subsequently download the original `a/private` bytes via `GET /b/scratch.git/info/lfs/objects/basic/<oid>`.
4. After this change: response is `400 Bad Request` with `content hash does not match OID` and no per-repository binding is created for `b/scratch`.
5. A legitimate retry of the same upload with the original bytes still succeeds and reuses the existing on-disk object.