### PR TITLE
security: reject path traversal in owner and repository names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to Gogs are documented in this file.
 - _Security:_ Read-only Git HTTP access could be confused with write access during repository pushes. [#8331](https://github.com/gogs/gogs/pull/8331) - [GHSA-wmfg-5p4h-5fw3](https://github.com/gogs/gogs/security/advisories/GHSA-wmfg-5p4h-5fw3)
 - _Security:_ Arbitrary file write outside the repository working tree via crafted upload filename routed through a committed directory symlink. [#8332](https://github.com/gogs/gogs/pull/8332) - [GHSA-89mr-xqfv-758m](https://github.com/gogs/gogs/security/advisories/GHSA-89mr-xqfv-758m)
 - _Security:_ Cross-repository disclosure of Git LFS object contents by binding a known OID to another repository without proving possession of the bytes. [#8333](https://github.com/gogs/gogs/pull/8333) - [GHSA-6p9m-q3jp-47h4](https://github.com/gogs/gogs/security/advisories/GHSA-6p9m-q3jp-47h4)
+- _Security:_ Remote code execution via path traversal in organization names accepted through the API. [#PR](https://github.com/gogs/gogs/pull/PR) - [GHSA-c39w-43gm-34h5](https://github.com/gogs/gogs/security/advisories/GHSA-c39w-43gm-34h5)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ All notable changes to Gogs are documented in this file.
 - _Security:_ Read-only Git HTTP access could be confused with write access during repository pushes. [#8331](https://github.com/gogs/gogs/pull/8331) - [GHSA-wmfg-5p4h-5fw3](https://github.com/gogs/gogs/security/advisories/GHSA-wmfg-5p4h-5fw3)
 - _Security:_ Arbitrary file write outside the repository working tree via crafted upload filename routed through a committed directory symlink. [#8332](https://github.com/gogs/gogs/pull/8332) - [GHSA-89mr-xqfv-758m](https://github.com/gogs/gogs/security/advisories/GHSA-89mr-xqfv-758m)
 - _Security:_ Cross-repository disclosure of Git LFS object contents by binding a known OID to another repository without proving possession of the bytes. [#8333](https://github.com/gogs/gogs/pull/8333) - [GHSA-6p9m-q3jp-47h4](https://github.com/gogs/gogs/security/advisories/GHSA-6p9m-q3jp-47h4)
-- _Security:_ Remote code execution via path traversal in organization names accepted through the API. [#PR](https://github.com/gogs/gogs/pull/PR) - [GHSA-c39w-43gm-34h5](https://github.com/gogs/gogs/security/advisories/GHSA-c39w-43gm-34h5)
+- _Security:_ Remote code execution via path traversal in organization names accepted through the API. [#8334](https://github.com/gogs/gogs/pull/8334) - [GHSA-c39w-43gm-34h5](https://github.com/gogs/gogs/security/advisories/GHSA-c39w-43gm-34h5)
 
 ### Removed
 

--- a/internal/repox/repox.go
+++ b/internal/repox/repox.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"gogs.io/gogs/internal/conf"
+	"gogs.io/gogs/internal/pathx"
 )
 
 // CloneLink represents different types of clone URLs of repository.
@@ -49,13 +50,15 @@ func CompareCommitsPath(owner, repo, oldCommitID, newCommitID string) string {
 
 // UserPath returns the absolute path for storing user repositories.
 func UserPath(user string) string {
-	return filepath.Join(conf.Repository.Root, strings.ToLower(user))
+	// 🚨 SECURITY: Prevent path traversal in user name.
+	return filepath.Join(conf.Repository.Root, pathx.Clean(strings.ToLower(user)))
 }
 
 // RepositoryPath returns the absolute path using given user and repository
 // name.
 func RepositoryPath(owner, repo string) string {
-	return filepath.Join(UserPath(owner), strings.ToLower(repo)+".git")
+	// 🚨 SECURITY: Prevent path traversal in repository name.
+	return filepath.Join(UserPath(owner), pathx.Clean(strings.ToLower(repo))+".git")
 }
 
 // RepositoryLocalPath returns the absolute path of the repository local copy

--- a/internal/route/api/v1/org.go
+++ b/internal/route/api/v1/org.go
@@ -9,7 +9,7 @@ import (
 )
 
 type createOrgRequest struct {
-	UserName    string `json:"username" binding:"Required"`
+	UserName    string `json:"username" binding:"Required;AlphaDashDot;MaxSize(35)"`
 	FullName    string `json:"full_name"`
 	Description string `json:"description"`
 	Website     string `json:"website"`


### PR DESCRIPTION
## Describe the pull request

The organization creation API accepted any non-empty string for the username, including path traversal sequences like `../../../tmp/x`. Owner and repository names flow into filesystem paths via `repox.UserPath` and `repox.RepositoryPath`, so a traversal name made the server place git directories at attacker-chosen locations and ultimately allowed remote code execution through planted hooks.

This change adds two independent layers:

1. The API `createOrgRequest.UserName` field now goes through the same `AlphaDashDot;MaxSize(35)` binding the web form has always used, rejecting traversal characters before any handler logic runs.
2. `repox.UserPath` and `repox.RepositoryPath` run their inputs through `pathx.Clean`, so even if a name with a traversal slips past a future caller, the resulting filesystem path is contained within the repository root.

Refs [GHSA-c39w-43gm-34h5](https://github.com/gogs/gogs/security/advisories/GHSA-c39w-43gm-34h5).

## Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [x] I have added an entry to [CHANGELOG](https://github.com/gogs/gogs/blob/main/CHANGELOG.md).

## Test plan

1. As any signed-in user, send `POST /api/v1/orgs` (or `POST /api/v1/admin/users/:user/orgs`) with `{"username": "../../../tmp/poc", ...}`.
2. Before this change: response is `201 Created` and the organization directory is written under `/tmp/poc`, enabling the hook overwrite path described in the advisory.
3. After this change: response is `422 Unprocessable Entity` with an `AlphaDashDot` validation error, no filesystem entry is created.
4. Repeat with `{"username": "foo/bar"}` and confirm the same rejection.
5. Confirm normal organization creation (`{"username": "good-org_1"}`) still returns `201 Created`.