### PR TITLE
security: time out stalled SSH handshakes after 15s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to Gogs are documented in this file.
 - _Security:_ Arbitrary file write outside the repository working tree via crafted upload filename routed through a committed directory symlink. [#8332](https://github.com/gogs/gogs/pull/8332) - [GHSA-89mr-xqfv-758m](https://github.com/gogs/gogs/security/advisories/GHSA-89mr-xqfv-758m)
 - _Security:_ Cross-repository disclosure of Git LFS object contents by binding a known OID to another repository without proving possession of the bytes. [#8333](https://github.com/gogs/gogs/pull/8333) - [GHSA-6p9m-q3jp-47h4](https://github.com/gogs/gogs/security/advisories/GHSA-6p9m-q3jp-47h4)
 - _Security:_ Remote code execution via path traversal in organization names accepted through the API. [#8334](https://github.com/gogs/gogs/pull/8334) - [GHSA-c39w-43gm-34h5](https://github.com/gogs/gogs/security/advisories/GHSA-c39w-43gm-34h5)
+- _Security:_ Stalled SSH handshakes pinned a file descriptor and goroutine indefinitely. The built-in SSH server now drops connections that do not complete the handshake within 15 seconds. [#PR](https://github.com/gogs/gogs/pull/PR) - [GHSA-xp79-5mx3-jx52](https://github.com/gogs/gogs/security/advisories/GHSA-xp79-5mx3-jx52)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ All notable changes to Gogs are documented in this file.
 - _Security:_ Arbitrary file write outside the repository working tree via crafted upload filename routed through a committed directory symlink. [#8332](https://github.com/gogs/gogs/pull/8332) - [GHSA-89mr-xqfv-758m](https://github.com/gogs/gogs/security/advisories/GHSA-89mr-xqfv-758m)
 - _Security:_ Cross-repository disclosure of Git LFS object contents by binding a known OID to another repository without proving possession of the bytes. [#8333](https://github.com/gogs/gogs/pull/8333) - [GHSA-6p9m-q3jp-47h4](https://github.com/gogs/gogs/security/advisories/GHSA-6p9m-q3jp-47h4)
 - _Security:_ Remote code execution via path traversal in organization names accepted through the API. [#8334](https://github.com/gogs/gogs/pull/8334) - [GHSA-c39w-43gm-34h5](https://github.com/gogs/gogs/security/advisories/GHSA-c39w-43gm-34h5)
-- _Security:_ Stalled SSH handshakes pinned a file descriptor and goroutine indefinitely. The built-in SSH server now drops connections that do not complete the handshake within 15 seconds. [#PR](https://github.com/gogs/gogs/pull/PR) - [GHSA-xp79-5mx3-jx52](https://github.com/gogs/gogs/security/advisories/GHSA-xp79-5mx3-jx52)
+- _Security:_ Stalled SSH handshakes pinned a file descriptor and goroutine indefinitely. The built-in SSH server now drops connections that do not complete the handshake within 15 seconds. [#8335](https://github.com/gogs/gogs/pull/8335) - [GHSA-xp79-5mx3-jx52](https://github.com/gogs/gogs/security/advisories/GHSA-xp79-5mx3-jx52)
 
 ### Removed
 

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -22,12 +22,6 @@ import (
 	"gogs.io/gogs/internal/osx"
 )
 
-// sshHandshakeTimeout bounds how long a freshly accepted SSH connection may
-// stall before completing the protocol handshake. A client that holds the
-// socket open without sending the SSH banner would otherwise pin a file
-// descriptor and goroutine for the lifetime of the process.
-const sshHandshakeTimeout = 15 * time.Second
-
 func cleanCommand(cmd string) string {
 	i := strings.Index(cmd, "git")
 	if i == -1 {
@@ -132,7 +126,7 @@ func listen(config *ssh.ServerConfig, host string, port int) {
 		// For example, user could be asked to trust server key fingerprint and hangs.
 		go func() {
 			log.Trace("SSH: Handshaking for %s", conn.RemoteAddr())
-			if err := conn.SetDeadline(time.Now().Add(sshHandshakeTimeout)); err != nil {
+			if err := conn.SetDeadline(time.Now().Add(15 * time.Second)); err != nil {
 				log.Error("SSH: Failed to set handshake deadline: %v", err)
 				_ = conn.Close()
 				return
@@ -146,7 +140,6 @@ func listen(config *ssh.ServerConfig, host string, port int) {
 				}
 				return
 			}
-			// Clear the handshake deadline now that the session is established.
 			if err := conn.SetDeadline(time.Time{}); err != nil {
 				log.Error("SSH: Failed to clear handshake deadline: %v", err)
 				_ = sConn.Close()

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/sourcegraph/run"
@@ -20,6 +21,12 @@ import (
 	"gogs.io/gogs/internal/database"
 	"gogs.io/gogs/internal/osx"
 )
+
+// sshHandshakeTimeout bounds how long a freshly accepted SSH connection may
+// stall before completing the protocol handshake. A client that holds the
+// socket open without sending the SSH banner would otherwise pin a file
+// descriptor and goroutine for the lifetime of the process.
+const sshHandshakeTimeout = 15 * time.Second
 
 func cleanCommand(cmd string) string {
 	i := strings.Index(cmd, "git")
@@ -125,6 +132,11 @@ func listen(config *ssh.ServerConfig, host string, port int) {
 		// For example, user could be asked to trust server key fingerprint and hangs.
 		go func() {
 			log.Trace("SSH: Handshaking for %s", conn.RemoteAddr())
+			if err := conn.SetDeadline(time.Now().Add(sshHandshakeTimeout)); err != nil {
+				log.Error("SSH: Failed to set handshake deadline: %v", err)
+				_ = conn.Close()
+				return
+			}
 			sConn, chans, reqs, err := ssh.NewServerConn(conn, config)
 			if err != nil {
 				if err == io.EOF || errors.Is(err, syscall.ECONNRESET) {
@@ -132,6 +144,12 @@ func listen(config *ssh.ServerConfig, host string, port int) {
 				} else {
 					log.Error("SSH: Error on handshaking: %v", err)
 				}
+				return
+			}
+			// Clear the handshake deadline now that the session is established.
+			if err := conn.SetDeadline(time.Time{}); err != nil {
+				log.Error("SSH: Failed to clear handshake deadline: %v", err)
+				_ = sConn.Close()
 				return
 			}
 


### PR DESCRIPTION
## Describe the pull request

The built-in SSH server accepted TCP connections and handed them to `ssh.NewServerConn` without setting a read deadline on the underlying socket. A client that connected but never sent the SSH banner held a file descriptor and goroutine open for the lifetime of the process. The deadline is now set to 15 seconds for the handshake and cleared once the session is established.

This bounds per-connection FD lifetime and lets the server recover automatically after a flood stops. It does not by itself prevent a sustained flood from saturating the FD budget while the attack is running.

Refs [GHSA-xp79-5mx3-jx52](https://github.com/gogs/gogs/security/advisories/GHSA-xp79-5mx3-jx52).

## Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [x] I have added an entry to [CHANGELOG](https://github.com/gogs/gogs/blob/main/CHANGELOG.md).

## Test plan

1. Configure Gogs with the built-in SSH server enabled (`[server] START_SSH_SERVER = true`).
2. Open a TCP connection to the SSH port and do not send any data (for example `nc <host> 2222 < /dev/null` while suspending output).
3. Before this change: the connection stays open indefinitely and the corresponding goroutine and FD remain held until the process exits.
4. After this change: the server closes the connection after 15 seconds with a handshake EOF and releases the FD/goroutine.
5. Confirm a legitimate `git clone ssh://...` still completes normally well under 15 seconds.