### PR TITLE
security: require token auth for org metadata and team list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to Gogs are documented in this file.
 - _Security:_ Cross-repository disclosure of Git LFS object contents by binding a known OID to another repository without proving possession of the bytes. [#8333](https://github.com/gogs/gogs/pull/8333) - [GHSA-6p9m-q3jp-47h4](https://github.com/gogs/gogs/security/advisories/GHSA-6p9m-q3jp-47h4)
 - _Security:_ Remote code execution via path traversal in organization names accepted through the API. [#8334](https://github.com/gogs/gogs/pull/8334) - [GHSA-c39w-43gm-34h5](https://github.com/gogs/gogs/security/advisories/GHSA-c39w-43gm-34h5)
 - _Security:_ Stalled SSH handshakes pinned a file descriptor and goroutine indefinitely. The built-in SSH server now drops connections that do not complete the handshake within 15 seconds. [#8335](https://github.com/gogs/gogs/pull/8335) - [GHSA-xp79-5mx3-jx52](https://github.com/gogs/gogs/security/advisories/GHSA-xp79-5mx3-jx52)
+- _Security:_ Organization metadata and team list endpoints were reachable without authentication. [#PR](https://github.com/gogs/gogs/pull/PR) - [GHSA-744x-3838-5r56](https://github.com/gogs/gogs/security/advisories/GHSA-744x-3838-5r56)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ All notable changes to Gogs are documented in this file.
 - _Security:_ Cross-repository disclosure of Git LFS object contents by binding a known OID to another repository without proving possession of the bytes. [#8333](https://github.com/gogs/gogs/pull/8333) - [GHSA-6p9m-q3jp-47h4](https://github.com/gogs/gogs/security/advisories/GHSA-6p9m-q3jp-47h4)
 - _Security:_ Remote code execution via path traversal in organization names accepted through the API. [#8334](https://github.com/gogs/gogs/pull/8334) - [GHSA-c39w-43gm-34h5](https://github.com/gogs/gogs/security/advisories/GHSA-c39w-43gm-34h5)
 - _Security:_ Stalled SSH handshakes pinned a file descriptor and goroutine indefinitely. The built-in SSH server now drops connections that do not complete the handshake within 15 seconds. [#8335](https://github.com/gogs/gogs/pull/8335) - [GHSA-xp79-5mx3-jx52](https://github.com/gogs/gogs/security/advisories/GHSA-xp79-5mx3-jx52)
-- _Security:_ Organization metadata and team list endpoints were reachable without authentication. [#PR](https://github.com/gogs/gogs/pull/PR) - [GHSA-744x-3838-5r56](https://github.com/gogs/gogs/security/advisories/GHSA-744x-3838-5r56)
+- _Security:_ Organization metadata and team list endpoints were reachable without authentication. [#8336](https://github.com/gogs/gogs/pull/8336) - [GHSA-744x-3838-5r56](https://github.com/gogs/gogs/security/advisories/GHSA-744x-3838-5r56)
 
 ### Removed
 

--- a/internal/route/api/v1/api.go
+++ b/internal/route/api/v1/api.go
@@ -382,7 +382,7 @@ func RegisterRoutes(m *macaron.Macaron) {
 				Get(getOrg).
 				Patch(bind(editOrgRequest{}), editOrg)
 			m.Get("/teams", listTeams)
-		}, orgAssignment(true))
+		}, reqToken(), orgAssignment(true))
 
 		m.Group("/admin", func() {
 			m.Group("/users", func() {


### PR DESCRIPTION
## Describe the pull request

The `/api/v1/orgs/:orgname` route group missed the `reqToken()` middleware that every other authenticated API group already applies. As a result, `GET /api/v1/orgs/:orgname`, `PATCH /api/v1/orgs/:orgname`, and `GET /api/v1/orgs/:orgname/teams` were reachable without authentication. The team list endpoint in particular leaked team names, descriptions, and permission levels to any unauthenticated caller, useful for mapping organizational structure and planning privilege escalation.

Refs [GHSA-744x-3838-5r56](https://github.com/gogs/gogs/security/advisories/GHSA-744x-3838-5r56).

## Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [x] I have added an entry to [CHANGELOG](https://github.com/gogs/gogs/blob/main/CHANGELOG.md).

## Test plan

1. Create an organization with at least one custom team.
2. Without authentication, run `curl -i http://localhost:3000/api/v1/orgs/<org>/teams`.
3. Before this change: `200 OK` with the team list in the body.
4. After this change: `401 Unauthorized`.
5. Repeat with a valid `Authorization: token <token>` header and confirm the team list is still returned.
6. Repeat steps 3 and 5 against `GET /api/v1/orgs/<org>` and confirm the same gating.