### PR TITLE
Show merge commit label on commit page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to Gogs are documented in this file.
 
 ### Fixed
 
+- Commit pages now show when the viewed commit is a merge commit. [#8339](https://github.com/gogs/gogs/pull/8339)
 - _Security:_ The "remember me" auto-login cookie was derived from database columns, so an attacker with a database dump could forge a valid cookie for any user. The auto-login cookie path has been removed entirely. Persistence is now provided by the server-issued session cookie. [#8289](https://github.com/gogs/gogs/pull/8289) - [GHSA-4pph-25p3-pw73](https://github.com/gogs/gogs/security/advisories/GHSA-4pph-25p3-pw73)
 
 ### Removed

--- a/conf/locale/locale_en-US.ini
+++ b/conf/locale/locale_en-US.ini
@@ -533,6 +533,7 @@ copy_file_path = Copy file path
 copy_full_sha = Copy full SHA
 renamed_from = Renamed from
 authored = authored
+merge_commit = Merge commit
 parents = parents
 diff_label = diff
 patch_label = patch

--- a/web/src/pages/repo/Commit.tsx
+++ b/web/src/pages/repo/Commit.tsx
@@ -187,6 +187,7 @@ function CommitBody({ body }: { body: string }) {
 export function RepoCommit() {
   const data = useLoaderData({ from: "/$owner/$repo/commit/$sha" });
   const { sha, subject, body, author, parents, patch } = data;
+  const isMergeCommit = parents.length > 1;
   const { owner, repo } = useParams({ from: "/$owner/$repo/commit/$sha" });
   const search: RepoCommitSearch = useSearch({ from: "/$owner/$repo/commit/$sha" });
   const navigate = useNavigate({ from: "/$owner/$repo/commit/$sha" });
@@ -718,7 +719,16 @@ export function RepoCommit() {
 
       <section className="mx-auto w-full max-w-7xl px-4 pt-6 pb-4 sm:px-6">
         <div className="flex flex-wrap items-start justify-between gap-x-4 gap-y-2">
-          <h2 className="min-w-0 flex-1 text-xl font-semibold break-words text-(--color-foreground)">{subject}</h2>
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <h2 className="min-w-0 flex-1 text-xl font-semibold break-words text-(--color-foreground)">{subject}</h2>
+              {isMergeCommit ? (
+                <span className="inline-flex items-center rounded-full border border-(--color-border) bg-(--color-surface) px-2 py-0.5 text-xs font-medium text-(--color-muted-foreground)">
+                  {t("repo.merge_commit")}
+                </span>
+              ) : null}
+            </div>
+          </div>
           <div className="basis-full sm:basis-auto">
             <a
               href={browseFilesHref}


### PR DESCRIPTION
Closes #2696

This reintroduces the merge-commit signal on the current single-commit page without reviving the old handler/template path from #8261.

Changes:
- detect merge commits from the active route data when a commit has more than one parent
- show a compact `Merge commit` badge next to the commit subject
- add the new label to `conf/locale/locale_en-US.ini`

Checks:
- `pnpm --dir web run build`
- `pnpm --dir web run lint`
- `git diff --check`

IssueHunt: https://issuehunt.io/repos/16752620/issues/2696