### PR TITLE
fix: surface 5xx errors in the SPA boot and route loaders

### DIFF
--- a/cmd/gogs/internal/web/recovery.go
+++ b/cmd/gogs/internal/web/recovery.go
@@ -1,0 +1,110 @@
+package web
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"os"
+	"runtime"
+
+	"charm.land/log/v2"
+	"github.com/flamego/flamego"
+	"github.com/flamego/flamego/inject"
+)
+
+// recovery is a copy of [flamego.Recovery] except always responses in plain
+// text.
+func recovery() flamego.Handler {
+	var (
+		dunno     = []byte("???")
+		centerDot = []byte("·")
+		dot       = []byte(".")
+		slash     = []byte("/")
+	)
+
+	// source returns a space-trimmed slice of the n'th line.
+	source := func(lines [][]byte, n int) []byte {
+		n-- // In a stack trace, lines are 1-indexed but our array is 0-indexed
+		if n < 0 || n >= len(lines) {
+			return dunno
+		}
+		return bytes.TrimSpace(lines[n])
+	}
+
+	// function returns, if possible, the name of the function containing the PC.
+	function := func(pc uintptr) []byte {
+		fn := runtime.FuncForPC(pc)
+		if fn == nil {
+			return dunno
+		}
+		name := []byte(fn.Name())
+		// The name includes the path name to the package, which is unnecessary since
+		// the file name is already included. Plus, it has center dots. That is, we see:
+		//	runtime/debug.*T·ptrmethod
+		// and want:
+		//	*T.ptrmethod
+		// Also the package path might contains dot (e.g. code.google.com/...), so first
+		// eliminate the path prefix.
+		if lastSlash := bytes.LastIndex(name, slash); lastSlash >= 0 {
+			name = name[lastSlash+1:]
+		}
+		if period := bytes.Index(name, dot); period >= 0 {
+			name = name[period+1:]
+		}
+		name = bytes.ReplaceAll(name, centerDot, dot)
+		return name
+	}
+
+	// stack returns a nicely formated stack frame, skipping skip frames
+	stack := func(skip int) []byte {
+		buf := new(bytes.Buffer)
+		// As we loop, we open files and read them. These variables record the currently
+		// loaded file.
+		var lines [][]byte
+		var lastFile string
+		for i := skip; ; i++ { // Skip the expected number of frames
+			pc, file, line, ok := runtime.Caller(i)
+			if !ok {
+				break
+			}
+			// Print this much at least.  If we can't find the source, it won't show.
+			_, _ = fmt.Fprintf(buf, "%s:%d (0x%x)\n", file, line, pc)
+			if file != lastFile {
+				data, err := os.ReadFile(file)
+				if err != nil {
+					continue
+				}
+				lines = bytes.Split(data, []byte{'\n'})
+				lastFile = file
+			}
+			_, _ = fmt.Fprintf(buf, "\t%s: %s\n", function(pc), source(lines, line))
+		}
+		return buf.Bytes()
+	}
+
+	return flamego.LoggerInvoker(func(c flamego.Context, logger *log.Logger) {
+		defer func() {
+			if err := recover(); err != nil {
+				stack := bytes.TrimRight(stack(3), "\n")
+				logger.Error(fmt.Sprintf("PANIC: %s\n%s", err, stack))
+
+				val := c.Value(inject.InterfaceOf((*http.ResponseWriter)(nil)))
+				w := val.Interface().(http.ResponseWriter)
+
+				// Respond with panic message only in development mode
+				var body []byte
+				if flamego.Env() == flamego.EnvTypeDev {
+					body = []byte(fmt.Sprintf("PANIC: %s\n%s", err, stack))
+				} else {
+					body = []byte(http.StatusText(http.StatusInternalServerError))
+				}
+
+				w.Header().Set("Content-Type", "text/plain")
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write(body)
+			}
+		}()
+
+		c.Next()
+	})
+}

--- a/cmd/gogs/internal/web/recovery.go
+++ b/cmd/gogs/internal/web/recovery.go
@@ -12,7 +12,7 @@ import (
 	"github.com/flamego/flamego/inject"
 )
 
-// recovery is a copy of [flamego.Recovery] except always responses in plain
+// recovery is a copy of [flamego.Recovery] except always responds in plain
 // text.
 func recovery() flamego.Handler {
 	var (
@@ -24,7 +24,7 @@ func recovery() flamego.Handler {
 
 	// source returns a space-trimmed slice of the n'th line.
 	source := func(lines [][]byte, n int) []byte {
-		n-- // In a stack trace, lines are 1-indexed but our array is 0-indexed
+		n-- // In a stack trace, lines are 1-indexed but our array is 0-indexed.
 		if n < 0 || n >= len(lines) {
 			return dunno
 		}
@@ -55,14 +55,14 @@ func recovery() flamego.Handler {
 		return name
 	}
 
-	// stack returns a nicely formated stack frame, skipping skip frames
+	// stack returns a nicely formatted stack frame, skipping skip frames.
 	stack := func(skip int) []byte {
 		buf := new(bytes.Buffer)
 		// As we loop, we open files and read them. These variables record the currently
 		// loaded file.
 		var lines [][]byte
 		var lastFile string
-		for i := skip; ; i++ { // Skip the expected number of frames
+		for i := skip; ; i++ { // Skip the expected number of frames.
 			pc, file, line, ok := runtime.Caller(i)
 			if !ok {
 				break

--- a/cmd/gogs/internal/web/web.go
+++ b/cmd/gogs/internal/web/web.go
@@ -682,7 +682,7 @@ func Run(configPath string, portOverride int) error {
 
 func newRoutingHandler() (http.Handler, error) {
 	f := flamego.New()
-	f.Use(flamego.Recovery())
+	f.Use(recovery())
 	f.Use(flamegoInjector)
 	f.Use(captcha.Captchaer(captcha.Options{URLPrefix: "/captcha/"}))
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module gogs.io/gogs
 go 1.26.0
 
 require (
+	charm.land/log/v2 v2.0.0
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/cockroachdb/errors v1.13.0
@@ -66,7 +67,6 @@ require (
 require (
 	bitbucket.org/creachadair/shell v0.0.7 // indirect
 	charm.land/lipgloss/v2 v2.0.1 // indirect
-	charm.land/log/v2 v2.0.0 // indirect
 	filippo.io/edwards25519 v1.1.1 // indirect
 	github.com/Azure/go-ntlmssp v0.1.1 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect

--- a/web/DESIGN.md
+++ b/web/DESIGN.md
@@ -44,7 +44,7 @@ Use these tokens. Don't introduce raw hex values in components.
 - `--color-border`: soft container and divider lines. Used for the navbar bottom border, popover edges, card outlines, mobile-menu separators. Deliberately low-contrast (close to `--color-secondary`) so chrome reads as quiet boundary, not as a hard rule.
 - `--color-input`: input field borders. Similar weight to `--color-border` but kept as a separate token so form fields can drift independently if needed.
 
-**The terminal frame is the exception.** `NotFound.tsx` wraps its faux-CLI output in a heavy outline so it actually looks like a terminal window — that frame uses `border-(--color-foreground)/80` (light) and the regular `--color-border` token (dark) directly, instead of the shared chrome token. Don't reuse this heavy outline elsewhere. If you need to introduce another heavy outline, promote a `--color-frame` token rather than inlining `--color-foreground`.
+**The terminal frame is the exception.** Faux-CLI surfaces (`Landing.tsx`, `NotFound.tsx`, `ServerError.tsx`) wrap their output in a heavy outline so it actually looks like a terminal window. That frame uses `border-(--color-foreground)/80` (light) and the regular `--color-border` token (dark) directly, instead of the shared chrome token.
 
 **Peer-item rule**
 
@@ -56,7 +56,7 @@ The traffic-light cluster in the faux-terminal frame uses one ad-hoc value: the 
 
 ## Surface chrome
 
-The 404 page wraps its content in a faux-terminal frame (rounded border, traffic-light dots, monospace body). Reuse the same frame for any page that represents a Git/CLI state: error pages, command-output stubs, raw diff fallbacks. Don't reuse it for normal content pages.
+The landing and 404/500 pages wrap their content in a faux-terminal frame (rounded border, traffic-light dots, monospace body). Reuse the same frame for any page that represents a Git/CLI state: the landing page, error pages, command-output stubs, raw diff fallbacks. Don't reuse it for normal content pages like settings or repository views.
 
 Strings rendered inside a terminal frame stay in English across all locales, regardless of the active UI language. Real CLI output (`git`, `ls`, `cat`, etc.) doesn't localize. Faux-CLI that does loses authenticity and reads as a translated error page in a costume. Translate the surrounding prose (headings, descriptions, CTAs), but leave command names, prompts, error tokens like `fatal:`, and command output strings untouched.
 

--- a/web/src/lib/user-info.ts
+++ b/web/src/lib/user-info.ts
@@ -1,3 +1,4 @@
+import { loaderResponseError } from "@/lib/loader-error";
 import { subUrl } from "@/lib/url";
 
 export interface UserInfo {
@@ -8,16 +9,10 @@ export interface UserInfo {
 }
 
 export async function fetchUserInfo(): Promise<UserInfo | null> {
-  try {
-    const res = await fetch(subUrl("/api/web/user/info"), { credentials: "same-origin" });
-    if (res.status === 204) return null;
-    if (!res.ok) {
-      console.error(`fetchUserInfo: unexpected status ${res.status}`);
-      return null;
-    }
-    return (await res.json()) as UserInfo;
-  } catch (err) {
-    console.error("fetchUserInfo: request failed", err);
-    return null;
+  const res = await fetch(subUrl("/api/web/user/info"), { credentials: "same-origin" });
+  if (res.status === 204) return null;
+  if (!res.ok) {
+    throw await loaderResponseError(res);
   }
+  return (await res.json()) as UserInfo;
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -6,16 +6,24 @@ import { UserInfoProvider } from "./components/UserInfoProvider";
 import "./index.css";
 import "./lib/i18n";
 import { fetchUserInfo } from "./lib/user-info";
-
-const userInfo = await fetchUserInfo();
+import { ServerError } from "./pages/ServerError";
 
 const root = document.getElementById("root");
 if (root) {
-  createRoot(root).render(
-    <ThemeProvider>
-      <UserInfoProvider value={userInfo}>
-        <App user={userInfo} />
-      </UserInfoProvider>
-    </ThemeProvider>,
-  );
+  try {
+    const userInfo = await fetchUserInfo();
+    createRoot(root).render(
+      <ThemeProvider>
+        <UserInfoProvider value={userInfo}>
+          <App user={userInfo} />
+        </UserInfoProvider>
+      </ThemeProvider>,
+    );
+  } catch (err) {
+    createRoot(root).render(
+      <ThemeProvider>
+        <ServerError error={err} />
+      </ThemeProvider>,
+    );
+  }
 }

--- a/web/src/pages/Landing.tsx
+++ b/web/src/pages/Landing.tsx
@@ -10,8 +10,8 @@ export function Landing() {
   return (
     <main className="flex flex-1 items-center justify-center px-4 py-10 sm:px-6 sm:py-16">
       <div className="w-full max-w-2xl">
-        <div className="rounded-lg border border-(--color-border) bg-(--color-surface)/40 font-mono shadow-xs">
-          <div className="flex items-center gap-1.5 border-b border-(--color-border) px-3 py-2 sm:px-4 sm:py-2.5">
+        <div className="rounded-lg border border-(--color-foreground)/80 bg-(--color-surface)/40 font-mono shadow-xs dark:border-(--color-border)">
+          <div className="flex items-center gap-1.5 border-b border-(--color-foreground)/80 px-3 py-2 sm:px-4 sm:py-2.5 dark:border-(--color-border)">
             <span className="size-2.5 rounded-full bg-(--color-destructive)/70" />
             <span className="size-2.5 rounded-full bg-(--color-warning,oklch(0.795_0.184_86.047))/70" />
             <span className="size-2.5 rounded-full bg-(--color-foreground)/20" />

--- a/web/src/pages/ServerError.tsx
+++ b/web/src/pages/ServerError.tsx
@@ -1,10 +1,9 @@
-import type { ErrorComponentProps } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 
 import { LoaderResponseError } from "@/lib/loader-error";
 import { usePageTitle } from "@/lib/page-title";
 
-export function ServerError({ error }: ErrorComponentProps) {
+export function ServerError({ error }: { error: unknown }) {
   const { t } = useTranslation();
   usePageTitle(t("status.internal_server_error"));
   const path = typeof window === "undefined" ? "/" : window.location.pathname;

--- a/web/src/routes/user.tsx
+++ b/web/src/routes/user.tsx
@@ -32,7 +32,7 @@ export function createUserRoutes(rootRoute: AnyRoute) {
     loader: async (): Promise<SignInPage> => {
       const res = await fetch(subUrl("/api/web/user/sign-in"), { credentials: "same-origin" });
       if (!res.ok) {
-        return { loginSources: [] };
+        throw await loaderResponseError(res);
       }
       return (await res.json()) as SignInPage;
     },
@@ -64,7 +64,7 @@ export function createUserRoutes(rootRoute: AnyRoute) {
         : subUrl("/api/web/user/reset-password");
       const res = await fetch(url, { credentials: "same-origin" });
       if (!res.ok) {
-        return { code, emailEnabled: false, valid: false };
+        throw await loaderResponseError(res);
       }
       const data = (await res.json()) as { emailEnabled: boolean; valid: boolean };
       return { code, emailEnabled: data.emailEnabled, valid: data.valid };
@@ -114,7 +114,10 @@ export function createUserRoutes(rootRoute: AnyRoute) {
         window.location.assign(subUrl("/"));
         return { pending: false };
       }
-      return { pending: res.ok };
+      if (!res.ok) {
+        throw await loaderResponseError(res);
+      }
+      return { pending: true };
     },
     component: MFA,
   });


### PR DESCRIPTION
## Summary

- Backend: replace flamego's HTML recovery handler with a plain-text variant so panics in JSON webapi handlers return a parseable 500 (`text/plain`) instead of an HTML page the loader can't reason about.
- Frontend boot: `fetchUserInfo` previously swallowed every non-2xx (including 5xx) and returned `null`, making the app boot as if the user were anonymous. It now throws on non-2xx (204 still maps to `null` for the anonymous case), and `main.tsx` catches the boot failure and renders `ServerError` directly under `ThemeProvider`.
- Frontend route loaders: the sign-in, reset-password, and MFA loaders silently returned degraded payloads (`{ loginSources: [] }`, `{ valid: false }`, `{ pending: false }`) on any non-OK response. They now throw `loaderResponseError(res)` so the router's `defaultErrorComponent` renders. MFA keeps its legitimate 404 → home-redirect branch.
- `ServerError` prop type loosened from TanStack's `ErrorComponentProps` to `{ error: unknown }` so it can render both inside the router and from the pre-router boot fallback.
- Visual consistency: Landing's terminal card now uses the same `--color-foreground/80` light-mode border as `ServerError`/`NotFound`.

## Test plan

- [ ] Force `getUserSignIn` to panic and confirm `/user/sign-in` renders the ServerError card (was previously rendering an empty sign-in form).
- [ ] Force `/api/web/user/info` to 5xx and confirm the SPA boots into the ServerError card instead of silently rendering as an anonymous user.
- [ ] Force `getUserResetPassword` to 5xx and confirm `/user/reset-password` renders ServerError (was rendering an invalid-code form).
- [ ] Confirm sign-up (already throwing) and repo loaders still surface ServerError as before.
- [ ] Confirm the Landing terminal card border now matches the ServerError card visually in light mode and stays muted in dark mode.
- [ ] Confirm 404 (route not found) still renders inside the router layout with navbar.