### PR TITLE
chore: update SHA256 checksum link in release issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/dev_release_minor_version.md
+++ b/.github/ISSUE_TEMPLATE/dev_release_minor_version.md
@@ -30,7 +30,7 @@ On the release branch:
 - [ ] Publish a new [GitHub release](https://github.com/gogs/gogs/releases) ⚠️ **on the release branch** ⚠️ with entries from [CHANGELOG](https://github.com/gogs/gogs/blob/main/CHANGELOG.md) for the current minor release.
 - [ ] [Wait for new image tags for the current release](https://github.com/gogs/gogs/actions/workflows/docker.yml?query=event%3Arelease) to be created automatically on both [Docker Hub](https://hub.docker.com/r/gogs/gogs/tags) and [GitHub Container registry](https://github.com/gogs/gogs/pkgs/container/gogs).
 	- Pull down the Docker image and [run through application setup](https://github.com/gogs/gogs/blob/main/docker/README.md) to make sure nothing blows up.
-- [ ] Download all release archives and [generate SHA256 checksum](https://github.com/gogs/gogs/blob/main/docs/dev/release/sha256.sh) for all binaries to the file `checksum_sha256.txt`.
+- [ ] Download all release archives and [generate SHA256 checksum](https://www.notion.so/jcunknwon/Cheatsheet-and-playbooks-c3b053da42114411bd27285cd065b2a6?source=copy_link#1654f105c63f80d4a74ad8821a403f52) for all binaries to the file `checksum_sha256.txt`.
 - [ ] Upload all archives and `checksum_sha256.txt` to https://dl.gogs.io.
 
 ## After release

--- a/.github/ISSUE_TEMPLATE/dev_release_patch_version.md
+++ b/.github/ISSUE_TEMPLATE/dev_release_patch_version.md
@@ -32,7 +32,7 @@ On the release branch:
 	```
 - [ ] [Wait for new image tags for the current release](https://github.com/gogs/gogs/actions/workflows/docker.yml?query=event%3Arelease) to be created automatically on both [Docker Hub](https://hub.docker.com/r/gogs/gogs/tags) and [GitHub Container registry](https://github.com/gogs/gogs/pkgs/container/gogs).
 	- Pull down the Docker image and [run through application setup](https://github.com/gogs/gogs/blob/main/docker/README.md) to make sure nothing blows up.
-- [ ] Download all release archives and [generate SHA256 checksum](https://github.com/gogs/gogs/blob/main/docs/dev/release/sha256.sh) for all binaries to the file `checksum_sha256.txt`.
+- [ ] Download all release archives and [generate SHA256 checksum](https://www.notion.so/jcunknwon/Cheatsheet-and-playbooks-c3b053da42114411bd27285cd065b2a6?source=copy_link#1654f105c63f80d4a74ad8821a403f52) for all binaries to the file `checksum_sha256.txt`.
 - [ ] Upload all archives and `checksum_sha256.txt` to https://dl.gogs.io.
 
 ## After release


### PR DESCRIPTION
## Summary
- Point the SHA256 checksum step in both minor and patch release issue templates to the current playbook location.

## Test plan
- [ ] Open both templates on GitHub and confirm the SHA256 link renders and resolves.