### PR TITLE
Fix submodule links with SSH ports

### DIFF
--- a/internal/gitx/submodule.go
+++ b/internal/gitx/submodule.go
@@ -3,6 +3,7 @@ package gitx
 import (
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/gogs/git-module"
@@ -11,6 +12,7 @@ import (
 )
 
 var scpSyntax = lazyregexp.New(`^([a-zA-Z0-9_]+@)?([a-zA-Z0-9._-]+):(.*)$`)
+var scpPortPath = lazyregexp.New(`^([0-9]{1,5})/([^/]+)/(.+)$`)
 
 // InferSubmoduleURL returns the inferred external URL of the submodule at best effort.
 // The `baseURL` should be the URL of the current repository. If the submodule URL looks
@@ -20,6 +22,7 @@ func InferSubmoduleURL(baseURL string, mod *git.Submodule) string {
 	if !strings.HasSuffix(baseURL, "/") {
 		baseURL += "/"
 	}
+	parsedBase, _ := url.Parse(baseURL)
 
 	raw := strings.TrimSuffix(mod.URL, "/")
 	raw = strings.TrimSuffix(raw, ".git")
@@ -36,9 +39,9 @@ func InferSubmoduleURL(baseURL string, mod *git.Submodule) string {
 			return mod.URL
 		}
 		parsed = &url.URL{
-			Scheme: "http",
+			Scheme: "ssh",
 			Host:   match[0][2],
-			Path:   match[0][3],
+			Path:   inferSCPSubmodulePath(parsedBase, match[0][2], match[0][3]),
 		}
 	}
 
@@ -46,10 +49,37 @@ func InferSubmoduleURL(baseURL string, mod *git.Submodule) string {
 	case "http", "https":
 		raw = parsed.String()
 	case "ssh":
-		raw = fmt.Sprintf("http://%s%s", parsed.Hostname(), parsed.Path)
+		raw = inferWebURLForSSHSubmodule(parsedBase, parsed)
 	default:
 		return raw
 	}
 
 	return fmt.Sprintf("%s/commit/%s", raw, mod.Commit)
+}
+
+func inferSCPSubmodulePath(base *url.URL, host, path string) string {
+	if base == nil || !strings.EqualFold(base.Hostname(), host) {
+		return path
+	}
+
+	match := scpPortPath.FindStringSubmatch(path)
+	if len(match) == 0 {
+		return path
+	}
+	port, err := strconv.Atoi(match[1])
+	if err != nil || port < 1 || port > 65535 {
+		return path
+	}
+	return fmt.Sprintf("%s/%s", match[2], match[3])
+}
+
+func inferWebURLForSSHSubmodule(base, submodule *url.URL) string {
+	path := submodule.Path
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	if base != nil && base.Scheme != "" && base.Host != "" && strings.EqualFold(base.Hostname(), submodule.Hostname()) {
+		return fmt.Sprintf("%s://%s%s", base.Scheme, base.Host, path)
+	}
+	return fmt.Sprintf("http://%s%s", submodule.Hostname(), path)
 }

--- a/internal/gitx/submodule_test.go
+++ b/internal/gitx/submodule_test.go
@@ -10,6 +10,7 @@ import (
 func TestInferSubmoduleURL(t *testing.T) {
 	tests := []struct {
 		name      string
+		baseURL   string
 		submodule *git.Submodule
 		expURL    string
 	}{
@@ -30,12 +31,47 @@ func TestInferSubmoduleURL(t *testing.T) {
 			expURL: "http://github.com/gogs/docs-api/commit/6b08f76a5313fa3d26859515b30aa17a5faa2807",
 		},
 		{
+			name:    "same instance SSH URL preserves web base",
+			baseURL: "https://gogs.example.com:8080/user/repo",
+			submodule: &git.Submodule{
+				URL:    "ssh://git@gogs.example.com:22/gogs/docs-api.git",
+				Commit: "6b08f76a5313fa3d26859515b30aa17a5faa2807",
+			},
+			expURL: "https://gogs.example.com:8080/gogs/docs-api/commit/6b08f76a5313fa3d26859515b30aa17a5faa2807",
+		},
+		{
 			name: "SSH URL in SCP syntax",
 			submodule: &git.Submodule{
 				URL:    "git@github.com:gogs/docs-api.git",
 				Commit: "6b08f76a5313fa3d26859515b30aa17a5faa2807",
 			},
 			expURL: "http://github.com/gogs/docs-api/commit/6b08f76a5313fa3d26859515b30aa17a5faa2807",
+		},
+		{
+			name:    "same instance SCP URL with SSH port preserves web base",
+			baseURL: "https://gogs.example.com:8080/user/repo",
+			submodule: &git.Submodule{
+				URL:    "git@gogs.example.com:2222/gogs/docs-api.git",
+				Commit: "6b08f76a5313fa3d26859515b30aa17a5faa2807",
+			},
+			expURL: "https://gogs.example.com:8080/gogs/docs-api/commit/6b08f76a5313fa3d26859515b30aa17a5faa2807",
+		},
+		{
+			name:    "same instance SCP URL keeps numeric namespace when port is ambiguous",
+			baseURL: "https://gogs.example.com:8080/user/repo",
+			submodule: &git.Submodule{
+				URL:    "git@gogs.example.com:2222/repo.git",
+				Commit: "6b08f76a5313fa3d26859515b30aa17a5faa2807",
+			},
+			expURL: "https://gogs.example.com:8080/2222/repo/commit/6b08f76a5313fa3d26859515b30aa17a5faa2807",
+		},
+		{
+			name: "external SCP URL keeps numeric namespace",
+			submodule: &git.Submodule{
+				URL:    "git@example.com:2222/gogs/docs-api.git",
+				Commit: "6b08f76a5313fa3d26859515b30aa17a5faa2807",
+			},
+			expURL: "http://example.com/2222/gogs/docs-api/commit/6b08f76a5313fa3d26859515b30aa17a5faa2807",
 		},
 		{
 			name: "relative path",
@@ -56,7 +92,11 @@ func TestInferSubmoduleURL(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.expURL, InferSubmoduleURL("https://gogs.example.com/user/repo", test.submodule))
+			baseURL := test.baseURL
+			if baseURL == "" {
+				baseURL = "https://gogs.example.com/user/repo"
+			}
+			assert.Equal(t, test.expURL, InferSubmoduleURL(baseURL, test.submodule))
 		})
 	}
 }


### PR DESCRIPTION
## Describe the pull request

Fix same-instance submodule links when the submodule URL uses SSH with an explicit port, including SCP-style URLs with numeric namespace segments.

The change preserves the instance web base while converting matching SSH submodule URLs into repository links, and adds regression coverage for SSH ports and numeric namespace ambiguity.

Link to the issue: https://github.com/gogs/gogs/issues/2953

## Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [x] I have added test cases to cover the new code or have provided the test plan. (if applicable)
- [ ] I have added an entry to [CHANGELOG](https://github.com/gogs/gogs/blob/main/CHANGELOG.md). (if applicable)

## Test plan

- `GOMODCACHE=/private/tmp/gogs-2953-gomodcache GOCACHE=/private/tmp/gogs-2953-gocache GOPROXY=https://goproxy.cn,direct GOSUMDB=off go test ./internal/gitx -run TestInferSubmoduleURL -count=1 -v`
- `GOMODCACHE=/private/tmp/gogs-2953-gomodcache GOCACHE=/private/tmp/gogs-2953-gocache GOPROXY=https://goproxy.cn,direct GOSUMDB=off go test ./internal/gitx -count=1`
- `git diff --check HEAD~1..HEAD`
