### PR TITLE
Fix repository wiki markdown links

### DIFF
--- a/internal/markup/markdown.go
+++ b/internal/markup/markdown.go
@@ -42,11 +42,33 @@ func isLink(link []byte) bool {
 func (r *MarkdownRenderer) Link(out *bytes.Buffer, link, title, content []byte) {
 	if len(link) > 0 && !isLink(link) {
 		if link[0] != '#' {
-			link = []byte(path.Join(r.urlPrefix, string(link)))
+			if wikiLink, ok := repoWikiLink(link, r.urlPrefix); ok {
+				link = wikiLink
+			} else {
+				link = []byte(path.Join(r.urlPrefix, string(link)))
+			}
 		}
 	}
 
 	r.Renderer.Link(out, link, title, content)
+}
+
+func repoWikiLink(link []byte, urlPrefix string) ([]byte, bool) {
+	linkString := string(link)
+	if linkString != "wiki" && !strings.HasPrefix(linkString, "wiki/") {
+		return nil, false
+	}
+
+	sourceIndex := strings.Index(urlPrefix, "/src/")
+	if sourceIndex < 0 {
+		return nil, false
+	}
+
+	repoLink := urlPrefix[:sourceIndex]
+	if repoLink == "" {
+		return nil, false
+	}
+	return []byte(path.Join(repoLink, linkString)), true
 }
 
 // AutoLink defines how auto-detected links should be processed to produce corresponding HTML elements.

--- a/internal/markup/markdown_test.go
+++ b/internal/markup/markdown_test.go
@@ -70,3 +70,17 @@ func Test_Markdown(t *testing.T) {
 		})
 	}
 }
+
+func Test_MarkdownRepoSourceWikiLinks(t *testing.T) {
+	metas := map[string]string{"repoLink": "/alice/project"}
+
+	t.Run("wiki link from repository source markdown", func(t *testing.T) {
+		html := Markdown("[Home](wiki/Home)", "/alice/project/src/main", metas)
+		assert.Contains(t, string(html), `href="/alice/project/wiki/Home"`)
+	})
+
+	t.Run("repository source link remains unchanged", func(t *testing.T) {
+		html := Markdown("[Guide](docs/guide.md)", "/alice/project/src/main", metas)
+		assert.Contains(t, string(html), `href="/alice/project/src/main/docs/guide.md"`)
+	})
+}


### PR DESCRIPTION
## Describe the pull request

Fix repository markdown links that intentionally point to wiki pages, for example `wiki/Home`, so they resolve to the repository wiki instead of being treated as source-relative repository paths.

The change keeps normal source-relative links under the repository source path and adds focused regression coverage for wiki links rendered from repository markdown.

Link to the issue: https://github.com/gogs/gogs/issues/2851

## Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [x] I have added test cases to cover the new code or have provided the test plan. (if applicable)
- [ ] I have added an entry to [CHANGELOG](https://github.com/gogs/gogs/blob/main/CHANGELOG.md). (if applicable)

## Test plan

- `GOMODCACHE=/private/tmp/gogs-2851-gomodcache GOCACHE=/private/tmp/gogs-2851-gocache GOPROXY=https://goproxy.cn,direct GOSUMDB=off go test -timeout 90s ./internal/markup -run Test_MarkdownRepoSourceWikiLinks -count=1 -v`
- `GOMODCACHE=/private/tmp/gogs-2851-gomodcache GOCACHE=/private/tmp/gogs-2851-gocache GOPROXY=https://goproxy.cn,direct GOSUMDB=off go test -timeout 120s ./internal/markup -count=1`
- `git diff --check HEAD~1..HEAD`
