### PR TITLE
api: update contents on existing target branch

### DIFF
--- a/internal/route/api/v1/repo_contents.go
+++ b/internal/route/api/v1/repo_contents.go
@@ -186,6 +186,14 @@ func putContents(c *context.APIContext, r putContentsRequest) {
 	if r.Branch == "" {
 		r.Branch = c.Repo.Repository.DefaultBranch
 	}
+	oldBranch, newBranch := putContentsBranches(
+		c.Repo.Repository.DefaultBranch,
+		r.Branch,
+		func(branch string) bool {
+			_, err := c.Repo.Repository.GetBranch(branch)
+			return err == nil
+		},
+	)
 
 	// 🚨 SECURITY: Prevent path traversal.
 	treePath := pathx.Clean(c.Params("*"))
@@ -193,8 +201,8 @@ func putContents(c *context.APIContext, r putContentsRequest) {
 	err = c.Repo.Repository.UpdateRepoFile(
 		c.User,
 		database.UpdateRepoFileOptions{
-			OldBranch:   c.Repo.Repository.DefaultBranch,
-			NewBranch:   r.Branch,
+			OldBranch:   oldBranch,
+			NewBranch:   newBranch,
 			OldTreeName: treePath,
 			NewTreeName: treePath,
 			Message:     r.Message,
@@ -244,4 +252,16 @@ func putContents(c *context.APIContext, r putContentsRequest) {
 			"commit":  apiCommit,
 		},
 	)
+}
+
+func putContentsBranches(defaultBranch, targetBranch string, branchExists func(string) bool) (oldBranch, newBranch string) {
+	if targetBranch == "" {
+		targetBranch = defaultBranch
+	}
+
+	oldBranch = defaultBranch
+	if branchExists(targetBranch) {
+		oldBranch = targetBranch
+	}
+	return oldBranch, targetBranch
 }

--- a/internal/route/api/v1/repo_contents_test.go
+++ b/internal/route/api/v1/repo_contents_test.go
@@ -1,0 +1,48 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPutContentsBranches(t *testing.T) {
+	tests := []struct {
+		name          string
+		targetBranch  string
+		existing      map[string]bool
+		wantOldBranch string
+		wantNewBranch string
+	}{
+		{
+			name:          "empty target uses default branch",
+			existing:      map[string]bool{"main": true},
+			wantOldBranch: "main",
+			wantNewBranch: "main",
+		},
+		{
+			name:          "existing target updates target branch",
+			targetBranch:  "release",
+			existing:      map[string]bool{"main": true, "release": true},
+			wantOldBranch: "release",
+			wantNewBranch: "release",
+		},
+		{
+			name:          "missing target creates from default branch",
+			targetBranch:  "feature",
+			existing:      map[string]bool{"main": true},
+			wantOldBranch: "main",
+			wantNewBranch: "feature",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			oldBranch, newBranch := putContentsBranches("main", test.targetBranch, func(branch string) bool {
+				return test.existing[branch]
+			})
+
+			assert.Equal(t, test.wantOldBranch, oldBranch)
+			assert.Equal(t, test.wantNewBranch, newBranch)
+		})
+	}
+}


### PR DESCRIPTION
## Describe the pull request

The contents API treats the request `branch` as the target branch. When that target branch already exists and is not the default branch, a second PUT currently passes it as `NewBranch` from the default branch and fails with `branch already exists`. This updates the branch selection so existing target branches are updated in place, while missing target branches are still created from the default branch.

Link to the issue: https://github.com/gogs/gogs/issues/8189

## Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [x] I have added test cases to cover the new code or have provided the test plan. (if applicable)
- [x] I have added an entry to [CHANGELOG](https://github.com/gogs/gogs/blob/main/CHANGELOG.md). (if applicable)

## Test plan

- `go test ./internal/route/api/v1`
