### PR TITLE
repo: enforce forced private in settings

### DIFF
--- a/internal/route/repo/setting.go
+++ b/internal/route/repo/setting.go
@@ -82,11 +82,15 @@ func SettingsPost(c *context.Context, f form.RepoSetting) {
 		repo.Description = f.Description
 		repo.Website = f.Website
 
-		// Visibility of forked repository is forced sync with base repository.
-		if repo.IsFork {
-			f.Private = repo.BaseRepo.IsPrivate
-			f.Unlisted = repo.BaseRepo.IsUnlisted
-		}
+		f.Private, f.Unlisted = normalizeRepoSettingsVisibility(
+			repo.IsFork,
+			repo.BaseRepo != nil && repo.BaseRepo.IsPrivate,
+			repo.BaseRepo != nil && repo.BaseRepo.IsUnlisted,
+			conf.Repository.ForcePrivate,
+			c.User.IsAdmin,
+			f.Private,
+			f.Unlisted,
+		)
 
 		visibilityChanged := repo.IsPrivate != f.Private || repo.IsUnlisted != f.Unlisted
 		repo.IsPrivate = f.Private
@@ -324,6 +328,19 @@ func SettingsPost(c *context.Context, f form.RepoSetting) {
 	default:
 		c.NotFound()
 	}
+}
+
+func normalizeRepoSettingsVisibility(repoIsFork, basePrivate, baseUnlisted, forcePrivate, actorIsAdmin, requestedPrivate, requestedUnlisted bool) (private, unlisted bool) {
+	private = requestedPrivate
+	unlisted = requestedUnlisted
+	if repoIsFork {
+		private = basePrivate
+		unlisted = baseUnlisted
+	}
+	if forcePrivate && !actorIsAdmin {
+		private = true
+	}
+	return private, unlisted
 }
 
 func SettingsAvatar(c *context.Context) {

--- a/internal/route/repo/setting_test.go
+++ b/internal/route/repo/setting_test.go
@@ -1,0 +1,73 @@
+package repo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeRepoSettingsVisibility(t *testing.T) {
+	tests := []struct {
+		name              string
+		repoIsFork        bool
+		basePrivate       bool
+		baseUnlisted      bool
+		forcePrivate      bool
+		actorIsAdmin      bool
+		requestedPrivate  bool
+		requestedUnlisted bool
+		wantPrivate       bool
+		wantUnlisted      bool
+	}{
+		{
+			name:              "regular user cannot make repository public when private is forced",
+			forcePrivate:      true,
+			requestedPrivate:  false,
+			requestedUnlisted: true,
+			wantPrivate:       true,
+			wantUnlisted:      true,
+		},
+		{
+			name:              "site admin can make repository public when private is forced",
+			forcePrivate:      true,
+			actorIsAdmin:      true,
+			requestedPrivate:  false,
+			requestedUnlisted: true,
+			wantPrivate:       false,
+			wantUnlisted:      true,
+		},
+		{
+			name:             "fork visibility follows base repository",
+			repoIsFork:       true,
+			basePrivate:      true,
+			baseUnlisted:     true,
+			requestedPrivate: false,
+			wantPrivate:      true,
+			wantUnlisted:     true,
+		},
+		{
+			name:             "forced private overrides public fork base for regular users",
+			repoIsFork:       true,
+			forcePrivate:     true,
+			requestedPrivate: false,
+			wantPrivate:      true,
+			wantUnlisted:     false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			private, unlisted := normalizeRepoSettingsVisibility(
+				test.repoIsFork,
+				test.basePrivate,
+				test.baseUnlisted,
+				test.forcePrivate,
+				test.actorIsAdmin,
+				test.requestedPrivate,
+				test.requestedUnlisted,
+			)
+
+			assert.Equal(t, test.wantPrivate, private)
+			assert.Equal(t, test.wantUnlisted, unlisted)
+		})
+	}
+}


### PR DESCRIPTION
## Describe the pull request

`FORCE_PRIVATE` already forces new repositories to be created as private, but regular users can still submit the repository settings form with `private` unchecked and make an existing repository public. This updates the settings save path so non-admin users cannot make repositories public while `FORCE_PRIVATE` is enabled. It also keeps the existing fork visibility synchronization behavior and adds tests for the visibility normalization rules.

Link to the issue: https://github.com/gogs/gogs/issues/8186

## Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [x] I have added test cases to cover the new code or have provided the test plan. (if applicable)
- [x] I have added an entry to [CHANGELOG](https://github.com/gogs/gogs/blob/main/CHANGELOG.md). (if applicable)

## Test plan

- `go test ./internal/route/repo`
