### PR TITLE
web: rewrite Vite dev proxy host

### DIFF
--- a/cmd/gogs/internal/web/webapp_dev.go
+++ b/cmd/gogs/internal/web/webapp_dev.go
@@ -23,7 +23,7 @@ func mountWebAppRoutes(f *flamego.Flame) error {
 	if err != nil {
 		return errors.Wrap(err, "parse Vite URL")
 	}
-	proxy := httputil.NewSingleHostReverseProxy(viteURL)
+	proxy := newViteReverseProxy(viteURL)
 	proxy.ModifyResponse = func(resp *http.Response) error {
 		if !strings.HasPrefix(resp.Header.Get("Content-Type"), "text/html") {
 			return nil
@@ -59,4 +59,14 @@ func mountWebAppRoutes(f *flamego.Flame) error {
 		proxy.ServeHTTP(w, r)
 	})
 	return nil
+}
+
+func newViteReverseProxy(viteURL *url.URL) *httputil.ReverseProxy {
+	proxy := httputil.NewSingleHostReverseProxy(viteURL)
+	director := proxy.Director
+	proxy.Director = func(req *http.Request) {
+		director(req)
+		req.Host = viteURL.Host
+	}
+	return proxy
 }

--- a/cmd/gogs/internal/web/webapp_dev_test.go
+++ b/cmd/gogs/internal/web/webapp_dev_test.go
@@ -1,0 +1,27 @@
+//go:build !prod
+
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewViteReverseProxy(t *testing.T) {
+	viteURL, err := url.Parse("http://localhost:5173")
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "https://example.test:3000/src/main.tsx", nil)
+	proxy := newViteReverseProxy(viteURL)
+	proxy.Director(req)
+
+	assert.Equal(t, "http", req.URL.Scheme)
+	assert.Equal(t, "localhost:5173", req.URL.Host)
+	assert.Equal(t, "localhost:5173", req.Host)
+	assert.Equal(t, "/src/main.tsx", req.URL.Path)
+}


### PR DESCRIPTION
## Describe the pull request

The Vite dev server rejects requests proxied through Gogs when the browser uses a custom local domain, because the proxied request keeps the external host. This rewrites the upstream `Host` header to the Vite dev server host, so custom local domains work while Vite host validation remains enabled.

Link to the issue: https://github.com/gogs/gogs/issues/8349

## Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [x] I have added test cases to cover the new code or have provided the test plan. (if applicable)
- [x] I have added an entry to [CHANGELOG](https://github.com/gogs/gogs/blob/main/CHANGELOG.md). (if applicable)

## Test plan

- `go test ./cmd/gogs/internal/web`
