### PR TITLE
repo: match invalid object errors case-insensitively

### DIFF
--- a/internal/route/repo/pull.go
+++ b/internal/route/repo/pull.go
@@ -230,7 +230,7 @@ func PrepareViewPullInfo(c *context.Context, issue *database.Issue) *gitx.PullRe
 	baseRepoPath := database.RepoPath(repo.Owner.Name, repo.Name)
 	prMeta, err := gitx.Module.PullRequestMeta(headGitRepo.Path(), baseRepoPath, pull.HeadBranch, pull.BaseBranch)
 	if err != nil {
-		if strings.Contains(err.Error(), "fatal: Not a valid object name") {
+		if isGitNotValidObjectNameError(err) {
 			c.Data["IsPullReuqestBroken"] = true
 			c.Data["BaseTarget"] = "deleted"
 			c.Data["NumCommits"] = 0
@@ -244,6 +244,13 @@ func PrepareViewPullInfo(c *context.Context, issue *database.Issue) *gitx.PullRe
 	c.Data["NumCommits"] = len(prMeta.Commits)
 	c.Data["NumFiles"] = prMeta.NumFiles
 	return prMeta
+}
+
+func isGitNotValidObjectNameError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "not a valid object name")
 }
 
 func ViewPullCommits(c *context.Context) {

--- a/internal/route/repo/pull_test.go
+++ b/internal/route/repo/pull_test.go
@@ -1,0 +1,41 @@
+package repo
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsGitNotValidObjectNameError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil",
+			want: false,
+		},
+		{
+			name: "current Git error",
+			err:  errors.New("fatal: Not a valid object name feature-branch"),
+			want: true,
+		},
+		{
+			name: "lowercase Git error",
+			err:  errors.New("fatal: not a valid object name feature-branch"),
+			want: true,
+		},
+		{
+			name: "unrelated Git error",
+			err:  errors.New("fatal: ambiguous argument feature-branch"),
+			want: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, isGitNotValidObjectNameError(test.err))
+		})
+	}
+}


### PR DESCRIPTION
## Describe the pull request

Git is changing the capitalization of the `fatal: Not a valid object name` error message. Gogs currently matches that message case-sensitively when detecting broken pull requests whose base branch was deleted. This makes the match case-insensitive and adds coverage for both the current and upcoming Git messages.

Link to the issue: https://github.com/gogs/gogs/issues/8190

## Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [x] I have added test cases to cover the new code or have provided the test plan. (if applicable)
- [x] I have added an entry to [CHANGELOG](https://github.com/gogs/gogs/blob/main/CHANGELOG.md). (if applicable)

## Test plan

- `go test ./internal/route/repo`
