### PR TITLE
docker: stop generating DSA host keys

### DIFF
--- a/docker/s6/openssh/setup
+++ b/docker/s6/openssh/setup
@@ -5,10 +5,6 @@ if ! test -f /data/ssh/ssh_host_rsa_key; then
     ssh-keygen -q -f /data/ssh/ssh_host_rsa_key -N '' -t rsa
 fi
 
-if ! test -f /data/ssh/ssh_host_dsa_key; then
-    ssh-keygen -q -f /data/ssh/ssh_host_dsa_key -N '' -t dsa
-fi
-
 if ! test -f /data/ssh/ssh_host_ecdsa_key; then
     ssh-keygen -q -f /data/ssh/ssh_host_ecdsa_key -N '' -t ecdsa
 fi

--- a/docker/sshd_config
+++ b/docker/sshd_config
@@ -5,7 +5,6 @@ ListenAddress ::
 Protocol 2
 LogLevel INFO
 HostKey /data/ssh/ssh_host_rsa_key
-HostKey /data/ssh/ssh_host_dsa_key
 HostKey /data/ssh/ssh_host_ecdsa_key
 HostKey /data/ssh/ssh_host_ed25519_key
 PermitRootLogin no


### PR DESCRIPTION
## Describe the pull request

Recent OpenSSH versions no longer support DSA host keys. The Docker startup script still tries to generate a DSA host key, and the Docker sshd configuration still asks sshd to load it, which produces startup warnings. This removes the DSA host key generation and loading while keeping RSA, ECDSA, and ED25519 host keys unchanged.

Link to the issue: fixes https://github.com/gogs/gogs/issues/8201

## Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [x] I have added test cases to cover the new code or have provided the test plan. (if applicable)
- [x] I have added an entry to [CHANGELOG](https://github.com/gogs/gogs/blob/main/CHANGELOG.md). (if applicable)

## Test plan

- `bash -lc "tr -d '\r' < docker/s6/openssh/setup | bash -n"`
- `shellcheck` is not installed in my local environment.
