### PR TITLE
修复 SQLite 下关闭工单时邮件通知导致请求卡死的问题

### DIFF
--- a/internal/database/comment.go
+++ b/internal/database/comment.go
@@ -176,7 +176,7 @@ func (c *Comment) mailParticipants(e Engine, opType ActionType, issue *Issue) (e
 	case ActionReopenIssue:
 		issue.Content = fmt.Sprintf("Reopened #%d", issue.Index)
 	}
-	if err = mailIssueCommentToParticipants(issue, c.Poster, mentions); err != nil {
+	if err = mailIssueCommentToParticipants(e, issue, c.Poster, mentions); err != nil {
 		log.Error("mailIssueCommentToParticipants: %v", err)
 	}
 

--- a/internal/database/issue.go
+++ b/internal/database/issue.go
@@ -1009,10 +1009,11 @@ func Issues(opts *IssuesOptions) ([]*Issue, error) {
 	return issues, nil
 }
 
-// GetParticipantsByIssueID returns all users who are participated in comments of an issue.
-func GetParticipantsByIssueID(issueID int64) ([]*User, error) {
+// getParticipantsByIssueID returns all users who participated in comments of an issue
+// using the given engine/session.
+func getParticipantsByIssueID(e Engine, issueID int64) ([]*User, error) {
 	userIDs := make([]int64, 0, 5)
-	if err := x.Table("comment").Cols("poster_id").
+	if err := e.Table("comment").Cols("poster_id").
 		Where("issue_id = ?", issueID).
 		Distinct("poster_id").
 		Find(&userIDs); err != nil {
@@ -1023,7 +1024,12 @@ func GetParticipantsByIssueID(issueID int64) ([]*User, error) {
 	}
 
 	users := make([]*User, 0, len(userIDs))
-	return users, x.In("id", userIDs).Find(&users)
+	return users, e.In("id", userIDs).Find(&users)
+}
+
+// GetParticipantsByIssueID returns all users who are participated in comments of an issue.
+func GetParticipantsByIssueID(issueID int64) ([]*User, error) {
+	return getParticipantsByIssueID(x, issueID)
 }
 
 // .___                             ____ ___

--- a/internal/database/issue_mail.go
+++ b/internal/database/issue_mail.go
@@ -105,7 +105,7 @@ func NewMailerIssue(issue *Issue) email.Issue {
 // This functions sends two list of emails:
 // 1. Repository watchers, users who participated in comments and the assignee.
 // 2. Users who are not in 1. but get mentioned in current issue/comment.
-func mailIssueCommentToParticipants(issue *Issue, doer *User, mentions []string) error {
+func mailIssueCommentToParticipants(e Engine, issue *Issue, doer *User, mentions []string) error {
 	ctx := context.TODO()
 
 	if !conf.User.EnableEmailNotification {
@@ -116,7 +116,7 @@ func mailIssueCommentToParticipants(issue *Issue, doer *User, mentions []string)
 	if err != nil {
 		return errors.Newf("GetWatchers [repo_id: %d]: %v", issue.RepoID, err)
 	}
-	participants, err := GetParticipantsByIssueID(issue.ID)
+	participants, err := getParticipantsByIssueID(e, issue.ID)
 	if err != nil {
 		return errors.Newf("GetParticipantsByIssueID [issue_id: %d]: %v", issue.ID, err)
 	}
@@ -194,7 +194,7 @@ func (issue *Issue) MailParticipants() (err error) {
 		return errors.Newf("UpdateIssueMentions [%d]: %v", issue.ID, err)
 	}
 
-	if err = mailIssueCommentToParticipants(issue, issue.Poster, mentions); err != nil {
+	if err = mailIssueCommentToParticipants(x, issue, issue.Poster, mentions); err != nil {
 		log.Error("mailIssueCommentToParticipants: %v", err)
 	}
 


### PR DESCRIPTION
- 修复关闭工单时邮件通知导致的 SQLite 锁等待问题。
- 原因是事务内写评论后，又用全局连接查询参与者。
- 现在改为复用当前事务 Engine 查询，避免请求卡死。