### PR TITLE
security: harden same-site redirect validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to Gogs are documented in this file.
 
 ### Fixed
 
-- _Security:_ Open redirect on the `/redirect` endpoint and post-action flows via a backslash in the redirect target. [#PR](https://github.com/gogs/gogs/pull/PR) - [GHSA-3g28-2vwg-gxq6](https://github.com/gogs/gogs/security/advisories/GHSA-3g28-2vwg-gxq6)
+- _Security:_ Open redirect on the `/redirect` endpoint and post-action flows via a backslash in the redirect target. [#8391](https://github.com/gogs/gogs/pull/8391) - [GHSA-3g28-2vwg-gxq6](https://github.com/gogs/gogs/security/advisories/GHSA-3g28-2vwg-gxq6)
 - _Security:_ Argument injection through a crafted branch name when creating a pull request allowed an authenticated user with write access to write files to arbitrary paths on the server. [#8390](https://github.com/gogs/gogs/pull/8390) - [GHSA-2grc-qr7q-6m36](https://github.com/gogs/gogs/security/advisories/GHSA-2grc-qr7q-6m36)
 - _Security:_ The "remember me" auto-login cookie was derived from database columns, so an attacker with a database dump could forge a valid cookie for any user. The auto-login cookie path has been removed entirely. Persistence is now provided by the server-issued session cookie. [#8289](https://github.com/gogs/gogs/pull/8289) - [GHSA-4pph-25p3-pw73](https://github.com/gogs/gogs/security/advisories/GHSA-4pph-25p3-pw73)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to Gogs are documented in this file.
 
 ### Fixed
 
+- _Security:_ Open redirect on the `/redirect` endpoint and post-action flows via a backslash in the redirect target. [#PR](https://github.com/gogs/gogs/pull/PR) - [GHSA-3g28-2vwg-gxq6](https://github.com/gogs/gogs/security/advisories/GHSA-3g28-2vwg-gxq6)
 - _Security:_ Argument injection through a crafted branch name when creating a pull request allowed an authenticated user with write access to write files to arbitrary paths on the server. [#8390](https://github.com/gogs/gogs/pull/8390) - [GHSA-2grc-qr7q-6m36](https://github.com/gogs/gogs/security/advisories/GHSA-2grc-qr7q-6m36)
 - _Security:_ The "remember me" auto-login cookie was derived from database columns, so an attacker with a database dump could forge a valid cookie for any user. The auto-login cookie path has been removed entirely. Persistence is now provided by the server-issued session cookie. [#8289](https://github.com/gogs/gogs/pull/8289) - [GHSA-4pph-25p3-pw73](https://github.com/gogs/gogs/security/advisories/GHSA-4pph-25p3-pw73)
 

--- a/internal/urlx/urlx.go
+++ b/internal/urlx/urlx.go
@@ -2,11 +2,17 @@ package urlx
 
 import "strings"
 
-// IsSameSite returns true if the URL path belongs to the same site.
+// IsSameSite returns true if the raw URL is a relative path that belongs to the
+// same site, so a caller can safely redirect to it verbatim.
+//
+// The check is deliberately strict: any character that a browser would rewrite
+// while resolving the Location header (a backslash in raw or percent-encoded
+// form, or stripped whitespace) makes the URL not same-site, because the string
+// that reaches the browser differs from the one validated here.
 func IsSameSite(rawURL string) bool {
-	p := strings.NewReplacer(
-		`\`, "/", "%5C", "/", "%5c", "/",
-		"\t", "", "\n", "", "\r", "",
-	).Replace(rawURL)
-	return strings.HasPrefix(p, "/") && !strings.Contains(p, "//")
+	if strings.ContainsAny(rawURL, "\\\t\n\r") ||
+		strings.Contains(rawURL, "%5C") || strings.Contains(rawURL, "%5c") {
+		return false
+	}
+	return strings.HasPrefix(rawURL, "/") && !strings.Contains(rawURL, "//")
 }

--- a/internal/urlx/urlx.go
+++ b/internal/urlx/urlx.go
@@ -2,13 +2,7 @@ package urlx
 
 import "strings"
 
-// IsSameSite returns true if the raw URL is a relative path that belongs to the
-// same site, so a caller can safely redirect to it verbatim.
-//
-// The check is deliberately strict: any character that a browser would rewrite
-// while resolving the Location header (a backslash in raw or percent-encoded
-// form, or stripped whitespace) makes the URL not same-site, because the string
-// that reaches the browser differs from the one validated here.
+// IsSameSite returns true if the URL path belongs to the same site.
 func IsSameSite(rawURL string) bool {
 	if strings.ContainsAny(rawURL, "\\\t\n\r") ||
 		strings.Contains(rawURL, "%5C") || strings.Contains(rawURL, "%5c") {

--- a/internal/urlx/urlx_test.go
+++ b/internal/urlx/urlx_test.go
@@ -23,20 +23,23 @@ func TestIsSameSite(t *testing.T) {
 		{url: "/user/repo?key=value", want: true},
 		{url: "/user/repo#anchor", want: true},
 
-		// Backslash bypasses: browsers normalize `\` to `/` on Location headers.
+		// Backslash bypasses: browsers normalize `\` to `/` on Location headers,
+		// so any backslash makes the URL not same-site.
 		{url: "/\\github.com", want: false},
 		{url: "/a/../\\example.com", want: false},
 		{url: "/\\\\example.com", want: false},
-		// Percent-encoded backslashes decode after c.Query, so they're caught too.
+		{url: "/path\\segment", want: false},
+		// Percent-encoded backslashes survive c.Query and reach the browser raw.
 		{url: "/%5Cexample.com", want: false},
 		{url: "/%5cexample.com", want: false},
 		{url: "/a/../%5Cexample.com", want: false},
 
-		// Whitespace bypasses: browsers strip tab/CR/LF before resolving.
+		// Whitespace bypasses: browsers strip tab/CR/LF before resolving, so any
+		// occurrence makes the URL not same-site.
 		{url: "/\t/example.com", want: false},
 		{url: "/\n/example.com", want: false},
 		{url: "/\r/example.com", want: false},
-		{url: "/\texample.com", want: true},
+		{url: "/\texample.com", want: false},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
`urlx.IsSameSite` previously sanitized its input internally but returned only a boolean, so callers redirected using the raw, unnormalized URL. Certain crafted targets could pass validation while a different string reached the browser, enabling an open redirect.

This makes `IsSameSite` a strict predicate: any target that a browser would rewrite during resolution is treated as not same-site, and all callers fall back to their safe default. No caller changes required.

Fixes [GHSA-3g28-2vwg-gxq6](https://github.com/gogs/gogs/security/advisories/GHSA-3g28-2vwg-gxq6).