### PR TITLE
web: keep content injection working under the React shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to Gogs are documented in this file.
 
 - Docker builds from `main` are now published only as `gogs/gogs:edge`, using the next-generation `Dockerfile.next`. The legacy `Dockerfile` no longer produces `main` builds. The `gogs/gogs:latest` and `gogs/gogs:next-latest` tags now always point to the highest published stable release, never to a back-patch on an older line. [#8278](https://github.com/gogs/gogs/pull/8278)
 - Self-registration is now disabled by default. New instances must set `[auth] DISABLE_REGISTRATION = false` to allow sign-ups. [#8350](https://github.com/gogs/gogs/pull/8350)
+- Custom content injected through `custom/templates/inject/head.tmpl` and `custom/templates/inject/footer.tmpl` continues to appear on every page under the new React-based web interface. Static file overrides under `custom/public/` and email template overrides are also unaffected.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ All notable changes to Gogs are documented in this file.
 
 - Docker builds from `main` are now published only as `gogs/gogs:edge`, using the next-generation `Dockerfile.next`. The legacy `Dockerfile` no longer produces `main` builds. The `gogs/gogs:latest` and `gogs/gogs:next-latest` tags now always point to the highest published stable release, never to a back-patch on an older line. [#8278](https://github.com/gogs/gogs/pull/8278)
 - Self-registration is now disabled by default. New instances must set `[auth] DISABLE_REGISTRATION = false` to allow sign-ups. [#8350](https://github.com/gogs/gogs/pull/8350)
-- Custom content injected through `custom/templates/inject/head.tmpl` and `custom/templates/inject/footer.tmpl` continues to appear on every page under the new React-based web interface. Static file overrides under `custom/public/` and email template overrides are also unaffected.
 
 ### Fixed
 
@@ -18,7 +17,7 @@ All notable changes to Gogs are documented in this file.
 ### Removed
 
 - The web-based first-time install page at `/install`, along with the `[security] INSTALL_LOCK` configuration option. A working `custom/conf/app.ini` is now always required. [#8350](https://github.com/gogs/gogs/pull/8350)
-- Support for customizing pages with Go template files stops being possible.
+- Support for overriding full page templates (e.g., `custom/templates/home.tmpl`), as the web interface no longer renders pages from server-side templates. Content injection through `custom/templates/inject/head.tmpl` and `custom/templates/inject/footer.tmpl`, static file overrides under `custom/public/`, and email template overrides remain supported. [#8392](https://github.com/gogs/gogs/pull/8392)
 - Support for MSSQL as the database backend. [#8173](https://github.com/gogs/gogs/pull/8173)
 - Support for `memcache` as the cache adapter. [#8270](https://github.com/gogs/gogs/pull/8270)
 - The `gogs cert` subcommand. [#8153](https://github.com/gogs/gogs/pull/8153)

--- a/cmd/gogs/internal/web/web.go
+++ b/cmd/gogs/internal/web/web.go
@@ -859,8 +859,22 @@ func renderIndex(index []byte, wc context.WebContext) ([]byte, error) {
 	script := `<script>window.__webContext=` + string(payload) +
 		`;document.documentElement.lang=window.__webContext.lang;</script>`
 
+	customDir := filepath.Join(conf.CustomDir(), "templates")
+	head, err := templates.ReadInjectFile(customDir, "head.tmpl")
+	if err != nil {
+		return nil, errors.Wrap(err, "read head injection")
+	}
+	footer, err := templates.ReadInjectFile(customDir, "footer.tmpl")
+	if err != nil {
+		return nil, errors.Wrap(err, "read footer injection")
+	}
+
 	pairs := []string{
-		"{{.WebContext}}", script,
+		// Append the head injection after the web context script so custom
+		// tags land inside <head>. The footer injection replaces the closing
+		// body tag to land just before </body>.
+		"{{.WebContext}}", script + string(head),
+		"</body>", string(footer) + "</body>",
 	}
 	if wc.SubURL != "" {
 		// Prefix entrypoint paths with the subpath for non-root mounts. Other

--- a/cmd/gogs/internal/web/webapp_render_test.go
+++ b/cmd/gogs/internal/web/webapp_render_test.go
@@ -1,0 +1,32 @@
+package web
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"gogs.io/gogs/internal/context"
+)
+
+func TestRenderIndex_injection(t *testing.T) {
+	customDir := t.TempDir()
+	injectDir := filepath.Join(customDir, "templates", "inject")
+	require.NoError(t, os.MkdirAll(injectDir, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(injectDir, "head.tmpl"), []byte(`<meta name="head-marker">`), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(injectDir, "footer.tmpl"), []byte(`<script>footerMarker()</script>`), 0600))
+	t.Setenv("GOGS_CUSTOM", customDir)
+
+	shell := `<html><head>{{.WebContext}}</head><body><div id="root"></div></body></html>`
+	got, err := renderIndex([]byte(shell), context.WebContext{Lang: "en-US"})
+	require.NoError(t, err)
+
+	out := string(got)
+	assert.Contains(t, out, `<meta name="head-marker">`)
+	assert.Contains(t, out, `<script>footerMarker()</script></body>`)
+	// The head injection lands inside <head>, before </head>.
+	assert.Less(t, strings.Index(out, `<meta name="head-marker">`), strings.Index(out, `</head>`))
+}

--- a/docs/advancing/custom-templates.mdx
+++ b/docs/advancing/custom-templates.mdx
@@ -5,7 +5,9 @@ icon: "paintbrush"
 ---
 
 <Danger>
-  Overriding full HTML page templates under `custom/templates/` is deprecated starting with 0.15.0. The web interface is being rebuilt as a React application that renders pages on the client, so it no longer reads page templates from the `templates/` directory and your copies of them will stop taking effect once the migration is complete. Injecting custom content through `inject/head.tmpl` and `inject/footer.tmpl` and overriding static files under `custom/public/` remain supported.
+  Overriding full HTML page templates such as `custom/templates/home.tmpl` is deprecated starting with 0.15.0. The web interface is being rebuilt as a React application that renders pages on the client, so it no longer reads page templates from the `templates/` directory and your copies of them will stop taking effect once the migration is complete.
+
+  Content injection through `inject/head.tmpl` and `inject/footer.tmpl`, static file overrides under `custom/public/`, and email template overrides all remain fully supported.
 </Danger>
 
 Gogs allows you to customize the appearance and behavior of your instance by overriding HTML templates, replacing static files, and injecting custom content. All customizations are placed under the `custom/` directory and survive code updates.
@@ -68,6 +70,10 @@ The injection points are:
 |---|---|---|
 | `custom/templates/inject/head.tmpl` | Inside `<head>` | Add stylesheets, meta tags, analytics scripts |
 | `custom/templates/inject/footer.tmpl` | Before `</body>` | Add scripts, tracking code, custom footer content |
+
+<Note>
+  The contents of these files are inserted into every page verbatim, so use plain HTML. Go template directives such as `{{.User}}` are not evaluated.
+</Note>
 
 ### Example: custom CSS file
 

--- a/docs/advancing/custom-templates.mdx
+++ b/docs/advancing/custom-templates.mdx
@@ -4,11 +4,11 @@ description: "Override HTML templates, static files, and inject custom content"
 icon: "paintbrush"
 ---
 
-Gogs allows you to customize the appearance and behavior of your instance by overriding HTML templates, replacing static files, and injecting custom content. All customizations are placed under the `custom/` directory and survive code updates.
-
-<Warning>
+<Danger>
   Custom HTML templates are deprecated starting with 0.15.0. The web interface is being rebuilt as a React application, which no longer renders from the `templates/` directory, so template overrides under `custom/templates/` will stop taking effect. Injecting custom content through `head.tmpl` and `footer.tmpl` and overriding static files under `custom/public/` remain supported.
-</Warning>
+</Danger>
+
+Gogs allows you to customize the appearance and behavior of your instance by overriding HTML templates, replacing static files, and injecting custom content. All customizations are placed under the `custom/` directory and survive code updates.
 
 <Warning>
   Be careful when overriding templates and static files, as changes to the upstream Gogs codebase may break your customizations in future releases. Keep track of what you have overridden.

--- a/docs/advancing/custom-templates.mdx
+++ b/docs/advancing/custom-templates.mdx
@@ -5,7 +5,7 @@ icon: "paintbrush"
 ---
 
 <Danger>
-  Custom HTML templates are deprecated starting with 0.15.0. The web interface is being rebuilt as a React application that no longer renders from the `templates/` directory. Template overrides under `custom/templates/`, including the `inject/head.tmpl` and `inject/footer.tmpl` content injection points, will stop taking effect once the migration is complete. The documentation below applies only to releases still served by the legacy template engine.
+  Overriding full HTML page templates under `custom/templates/` is deprecated starting with 0.15.0. The web interface is being rebuilt as a React application that renders pages on the client, so it no longer reads page templates from the `templates/` directory and your copies of them will stop taking effect once the migration is complete. Injecting custom content through `inject/head.tmpl` and `inject/footer.tmpl` and overriding static files under `custom/public/` remain supported.
 </Danger>
 
 Gogs allows you to customize the appearance and behavior of your instance by overriding HTML templates, replacing static files, and injecting custom content. All customizations are placed under the `custom/` directory and survive code updates.
@@ -17,6 +17,10 @@ Gogs allows you to customize the appearance and behavior of your instance by ove
 ## Override HTML templates
 
 You can replace any HTML template (including email templates) by placing a customized version under the `custom/templates/` directory.
+
+<Warning>
+  Overriding page templates such as `home.tmpl` is deprecated and stops working once the React web interface migration is complete (see the notice at the top of this page). Email template overrides are not affected, because emails are still rendered on the server.
+</Warning>
 
 <Steps>
   <Step title="Find the original template">

--- a/docs/advancing/custom-templates.mdx
+++ b/docs/advancing/custom-templates.mdx
@@ -5,7 +5,7 @@ icon: "paintbrush"
 ---
 
 <Danger>
-  Custom HTML templates are deprecated starting with 0.15.0. The web interface is being rebuilt as a React application, which no longer renders from the `templates/` directory, so template overrides under `custom/templates/` will stop taking effect. Injecting custom content through `head.tmpl` and `footer.tmpl` and overriding static files under `custom/public/` remain supported.
+  Custom HTML templates are deprecated starting with 0.15.0. The web interface is being rebuilt as a React application that no longer renders from the `templates/` directory. Template overrides under `custom/templates/`, including the `inject/head.tmpl` and `inject/footer.tmpl` content injection points, will stop taking effect once the migration is complete. The documentation below applies only to releases still served by the legacy template engine.
 </Danger>
 
 Gogs allows you to customize the appearance and behavior of your instance by overriding HTML templates, replacing static files, and injecting custom content. All customizations are placed under the `custom/` directory and survive code updates.

--- a/docs/advancing/custom-templates.mdx
+++ b/docs/advancing/custom-templates.mdx
@@ -7,6 +7,10 @@ icon: "paintbrush"
 Gogs allows you to customize the appearance and behavior of your instance by overriding HTML templates, replacing static files, and injecting custom content. All customizations are placed under the `custom/` directory and survive code updates.
 
 <Warning>
+  Custom HTML templates are deprecated starting with 0.15.0. The web interface is being rebuilt as a React application, which no longer renders from the `templates/` directory, so template overrides under `custom/templates/` will stop taking effect. Injecting custom content through `head.tmpl` and `footer.tmpl` and overriding static files under `custom/public/` remain supported.
+</Warning>
+
+<Warning>
   Be careful when overriding templates and static files, as changes to the upstream Gogs codebase may break your customizations in future releases. Keep track of what you have overridden.
 </Warning>
 

--- a/docs/asking/release-strategy.mdx
+++ b/docs/asking/release-strategy.mdx
@@ -44,6 +44,8 @@ Gogs maintains backwards compatibility across **one minor version** at a time. P
 
 ## Source build update frequency
 
-<Tip>
-  If you run Gogs from a source build rather than an official binary, update **at least once per week**. This prevents you from falling behind and potentially missing incremental database migrations that cannot be applied out of order.
-</Tip>
+<Warning>
+  Running Gogs from a source build is no longer recommended. If you want to stay current with the latest commit, use the per-commit binary release instead: every push to `main` publishes updated binaries to the [`latest-commit-build`](https://github.com/gogs/gogs/releases/tag/latest-commit-build) release on GitHub.
+</Warning>
+
+If you still run Gogs from a source build, update **at least once per week**. This prevents you from falling behind and potentially missing incremental database migrations that cannot be applied out of order.

--- a/templates/embed.go
+++ b/templates/embed.go
@@ -71,6 +71,19 @@ func ReadMailFile(name string) ([]byte, error) {
 	return files.ReadFile(path.Join("mail", name))
 }
 
+// ReadInjectFile returns the content of an injection template (e.g.,
+// "head.tmpl" or "footer.tmpl") from the "inject" directory. A file placed
+// under customDir on disk takes precedence over the embedded default, which is
+// empty. Both the embedded default and a missing custom file yield empty
+// content with no error, so an instance that injects nothing renders normally.
+func ReadInjectFile(customDir, name string) ([]byte, error) {
+	fpath := path.Join(customDir, "inject", name)
+	if osx.IsFile(fpath) {
+		return os.ReadFile(fpath)
+	}
+	return files.ReadFile(path.Join("inject", name))
+}
+
 // NewTemplateFileSystem returns a macaron.TemplateFileSystem instance for embedded assets.
 // The argument "dir" can be used to serve subset of embedded assets. Template file
 // found under the "customDir" on disk has higher precedence over embedded assets.

--- a/templates/embed_test.go
+++ b/templates/embed_test.go
@@ -1,0 +1,34 @@
+package templates
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadInjectFile(t *testing.T) {
+	t.Run("embedded default is empty", func(t *testing.T) {
+		got, err := ReadInjectFile(filepath.Join(t.TempDir(), "templates"), "head.tmpl")
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("custom file takes precedence", func(t *testing.T) {
+		customDir := filepath.Join(t.TempDir(), "templates")
+		require.NoError(t, os.MkdirAll(filepath.Join(customDir, "inject"), 0700))
+		want := `<meta name="custom" content="1">`
+		require.NoError(t, os.WriteFile(filepath.Join(customDir, "inject", "head.tmpl"), []byte(want), 0600))
+
+		got, err := ReadInjectFile(customDir, "head.tmpl")
+		require.NoError(t, err)
+		assert.Equal(t, want, string(got))
+	})
+
+	t.Run("missing embedded file errors", func(t *testing.T) {
+		_, err := ReadInjectFile(filepath.Join(t.TempDir(), "templates"), "does-not-exist.tmpl")
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
## Describe the pull request

Keep custom head/footer injection working with the React web interface. Clarify that full page overrides are deprecated, injection files now use plain HTML, and static and email overrides remain supported. Recommend per-commit binaries over source builds.

Link to the issue: n/a

## Checklist

- [ ] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [ ] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [x] I have added test cases to cover the new code or have provided the test plan. (if applicable)
- [x] I have added an entry to [CHANGELOG](https://github.com/gogs/gogs/blob/main/CHANGELOG.md). (if applicable)

## Test plan

- Unit tests cover injection file fallback, custom overrides, and placement in the HTML shell.
- `moon run gogs:lint` passes.
