### PR TITLE
fix: avoid database deadlock in GetParticipantsByIssueID()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to Gogs are documented in this file.
 
 ### Fixed
 
+- Fix database deadlock in mail notifications for comments. [#8375](https://github.com/gogs/gogs/issues/8375)
 - _Security:_ Open redirect on the `/redirect` endpoint and post-action flows via a backslash in the redirect target. [#8391](https://github.com/gogs/gogs/pull/8391) - [GHSA-3g28-2vwg-gxq6](https://github.com/gogs/gogs/security/advisories/GHSA-3g28-2vwg-gxq6)
 - _Security:_ Argument injection through a crafted commit or branch reference on several repository API endpoints allowed an authenticated user with read access to leak internal server details to the error logs. [#8393](https://github.com/gogs/gogs/pull/8393) - [GHSA-mxrh-2rxr-6mqc](https://github.com/gogs/gogs/security/advisories/GHSA-mxrh-2rxr-6mqc)
 - _Security:_ Argument injection through a crafted branch name when creating a pull request allowed an authenticated user with write access to write files to arbitrary paths on the server. [#8390](https://github.com/gogs/gogs/pull/8390) - [GHSA-2grc-qr7q-6m36](https://github.com/gogs/gogs/security/advisories/GHSA-2grc-qr7q-6m36)

--- a/internal/database/comment.go
+++ b/internal/database/comment.go
@@ -176,7 +176,7 @@ func (c *Comment) mailParticipants(e Engine, opType ActionType, issue *Issue) (e
 	case ActionReopenIssue:
 		issue.Content = fmt.Sprintf("Reopened #%d", issue.Index)
 	}
-	if err = mailIssueCommentToParticipants(issue, c.Poster, mentions); err != nil {
+	if err = mailIssueCommentToParticipants(e, issue, c.Poster, mentions); err != nil {
 		log.Error("mailIssueCommentToParticipants: %v", err)
 	}
 

--- a/internal/database/issue.go
+++ b/internal/database/issue.go
@@ -1010,9 +1010,9 @@ func Issues(opts *IssuesOptions) ([]*Issue, error) {
 }
 
 // GetParticipantsByIssueID returns all users who are participated in comments of an issue.
-func GetParticipantsByIssueID(issueID int64) ([]*User, error) {
+func GetParticipantsByIssueID(e Engine, issueID int64) ([]*User, error) {
 	userIDs := make([]int64, 0, 5)
-	if err := x.Table("comment").Cols("poster_id").
+	if err := e.Table("comment").Cols("poster_id").
 		Where("issue_id = ?", issueID).
 		Distinct("poster_id").
 		Find(&userIDs); err != nil {
@@ -1023,7 +1023,7 @@ func GetParticipantsByIssueID(issueID int64) ([]*User, error) {
 	}
 
 	users := make([]*User, 0, len(userIDs))
-	return users, x.In("id", userIDs).Find(&users)
+	return users, e.In("id", userIDs).Find(&users)
 }
 
 // .___                             ____ ___

--- a/internal/database/issue_mail.go
+++ b/internal/database/issue_mail.go
@@ -105,7 +105,7 @@ func NewMailerIssue(issue *Issue) email.Issue {
 // This functions sends two list of emails:
 // 1. Repository watchers, users who participated in comments and the assignee.
 // 2. Users who are not in 1. but get mentioned in current issue/comment.
-func mailIssueCommentToParticipants(issue *Issue, doer *User, mentions []string) error {
+func mailIssueCommentToParticipants(e Engine, issue *Issue, doer *User, mentions []string) error {
 	ctx := context.TODO()
 
 	if !conf.User.EnableEmailNotification {
@@ -116,7 +116,7 @@ func mailIssueCommentToParticipants(issue *Issue, doer *User, mentions []string)
 	if err != nil {
 		return errors.Newf("GetWatchers [repo_id: %d]: %v", issue.RepoID, err)
 	}
-	participants, err := GetParticipantsByIssueID(issue.ID)
+	participants, err := GetParticipantsByIssueID(e, issue.ID)
 	if err != nil {
 		return errors.Newf("GetParticipantsByIssueID [issue_id: %d]: %v", issue.ID, err)
 	}
@@ -194,7 +194,7 @@ func (issue *Issue) MailParticipants() (err error) {
 		return errors.Newf("UpdateIssueMentions [%d]: %v", issue.ID, err)
 	}
 
-	if err = mailIssueCommentToParticipants(issue, issue.Poster, mentions); err != nil {
+	if err = mailIssueCommentToParticipants(x, issue, issue.Poster, mentions); err != nil {
 		log.Error("mailIssueCommentToParticipants: %v", err)
 	}
 


### PR DESCRIPTION
## Describe the pull request

Fix a database deadlock in `GetParticipantsByIssueID()`.
Change `mailParticipants()` to pass Engine `e`
into `mailIssueCommentToParticipants()` and subsequently `GetParticipantsByIssueID()`.  This allows `GetParticipantsByIssueID()` to use the session created in `CreateComment()` to issue the database query, avoiding a deadlock.

This is a patch for #8375, and was authored by @chuckcranor

## Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [x] I have added test cases to cover the new code or have provided the test plan. (if applicable)
- [x] I have added an entry to [CHANGELOG](https://github.com/gogs/gogs/blob/main/CHANGELOG.md). (if applicable)

## Test plan
1. Create a new gogs instance using the SQLite 3 database.
2. Enable `ENABLE_EMAIL_NOTIFICATION` by setting:
```
[user]
ENABLE_EMAIL_NOTIFICATION = true
```
3. Attempt to comment on an issue in a repository.
4. Confirm that the server does not hang, the comment is successfully recorded and displayed, and that email notification is received by watchers and participants.